### PR TITLE
CLI: Update phrase-go to 1.0.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ go:
 	openapi-generator generate -i tmp/compiled.yaml -g go -o clients/go -t ./openapi-generator/templates/go -c ./openapi-generator/go_lang.yaml
 	go get golang.org/x/tools/cmd/goimports
 	goimports -w clients/go
+	cd clients/go && go mod tidy
 typescript:
 	openapi-generator generate -i tmp/compiled.yaml -g typescript-fetch -o clients/typescript -t ./openapi-generator/templates/typescript-fetch -c ./openapi-generator/typescript_lang.yaml
 python:
@@ -57,3 +58,4 @@ cli:
 	cp tmp/cli/README.md clients/cli/
 	go get golang.org/x/tools/cmd/goimports
 	goimports -w clients/cli
+	cd clients/cli && go mod tidy

--- a/clients/cli/cmd/internal/pull.go
+++ b/clients/cli/cmd/internal/pull.go
@@ -84,7 +84,8 @@ func newClient() *phrase.APIClient {
 		Prefix: "token",
 	})
 
-	cfg := phrase.NewConfiguration(Config)
+	cfg := phrase.NewConfiguration()
+	cfg.SetUserAgent(Config.UserAgent)
 	return phrase.NewAPIClient(cfg)
 }
 

--- a/clients/cli/go.mod
+++ b/clients/cli/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/mitchellh/mapstructure v1.3.2
 	github.com/pelletier/go-toml v1.8.0 // indirect
-	github.com/phrase/phrase-go v1.0.7
+	github.com/phrase/phrase-go v1.0.8
 	github.com/spf13/afero v1.3.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/clients/cli/go.sum
+++ b/clients/cli/go.sum
@@ -96,6 +96,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -180,14 +181,8 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.0 h1:Keo9qb7iRJs2voHvunFtuuYFsbWeOBh8/P9v/kVMFtw=
 github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bAOTRnLElKs=
-github.com/phrase/phrase-go v1.0.4 h1:GBtr9WLkcIUJkA4dJh8rXrhoNoZiCIuJIqDSdDDuU7A=
-github.com/phrase/phrase-go v1.0.4/go.mod h1:BXgF/mv+yrmhBzVxpd099YsF77G3g6g5OL5NSdvx8wI=
-github.com/phrase/phrase-go v1.0.5 h1:NyHowQnxotn78wINM//sftaPYBa2rexV7f30eIzmTRc=
-github.com/phrase/phrase-go v1.0.5/go.mod h1:BXgF/mv+yrmhBzVxpd099YsF77G3g6g5OL5NSdvx8wI=
-github.com/phrase/phrase-go v1.0.6 h1:y3Qpzs3PYRQFvxU92XzsjsnCEp2IOnmosYt//78FECE=
-github.com/phrase/phrase-go v1.0.6/go.mod h1:BXgF/mv+yrmhBzVxpd099YsF77G3g6g5OL5NSdvx8wI=
-github.com/phrase/phrase-go v1.0.7 h1:cVzMTnx3Gm/dHsW51uFQm9Zhj6oRwuiJyB0cRjLntdo=
-github.com/phrase/phrase-go v1.0.7/go.mod h1:BXgF/mv+yrmhBzVxpd099YsF77G3g6g5OL5NSdvx8wI=
+github.com/phrase/phrase-go v1.0.8 h1:+CXojupDdDFfGNU90vpF8+YNM6vR1KIRt6e54OPrPII=
+github.com/phrase/phrase-go v1.0.8/go.mod h1:BXgF/mv+yrmhBzVxpd099YsF77G3g6g5OL5NSdvx8wI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
@@ -219,10 +214,6 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
-github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
-github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
-github.com/spf13/afero v1.3.0 h1:Ysnmjh1Di8EaWaBv40CYR4IdaIsBc5996Gh1oZzCBKk=
-github.com/spf13/afero v1.3.0/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.3.1 h1:GPTpEAuNr98px18yNQ66JllNil98wfRZ/5Ukny8FeQA=
 github.com/spf13/afero v1.3.1/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
@@ -249,6 +240,7 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -335,10 +327,6 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200610111108-226ff32320da h1:bGb80FudwxpeucJUjPYJXuJ8Hk91vNtfvrymzwiei38=
-golang.org/x/sys v0.0.0-20200610111108-226ff32320da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4 h1:5/PjkGUjvEU5Gl6BxmvKRPpqo2uNMv4rcHBMwzk/st8=
-golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/openapi-generator/templates/cli/api.handlebars
+++ b/openapi-generator/templates/cli/api.handlebars
@@ -37,7 +37,8 @@ func init{{{nickname}}}() {
 		Run: func(cmd *cobra.Command, args []string) {
 			auth := Auth()
 
-			cfg := api.NewConfiguration(Config)
+			cfg := api.NewConfiguration()
+			cfg.SetUserAgent(Config.UserAgent)
 			client := api.NewAPIClient(cfg)
 			{{#hasOptionalParams}}localVarOptionals := api.{{#structPrefix}}{{&classname}}{{/structPrefix}}{{{nickname}}}Opts{}
 

--- a/openapi-generator/templates/cli/go.mod.mustache
+++ b/openapi-generator/templates/cli/go.mod.mustache
@@ -9,7 +9,7 @@ require (
 	github.com/golangplus/testing v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2
-	github.com/phrase/phrase-go v1.0.1
+	github.com/phrase/phrase-go v1.0.8
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.6.3
 	gopkg.in/yaml.v2 v2.2.8


### PR DESCRIPTION
Use the latest version of the phrase-go lib