### PR TITLE
Typescript: Always return server response

### DIFF
--- a/openapi-generator/templates/typescript-fetch/apis.mustache
+++ b/openapi-generator/templates/typescript-fetch/apis.mustache
@@ -301,7 +301,7 @@ export class {{classname}} extends runtime.BaseAPI {
         {{/isResponseFile}}
         {{/returnType}}
         {{^returnType}}
-        return new runtime.VoidApiResponse(response);
+        return new runtime.TextApiResponse(response) as any;
         {{/returnType}}
     }
 
@@ -326,13 +326,8 @@ export class {{classname}} extends runtime.BaseAPI {
     {{/useSingleRequestParameter}}
     {{#useSingleRequestParameter}}
     async {{nickname}}({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
-        {{#returnType}}
         const response = await this.{{nickname}}Raw({{#allParams.0}}requestParameters{{/allParams.0}});
         return await response.value();
-        {{/returnType}}
-        {{^returnType}}
-        await this.{{nickname}}Raw({{#allParams.0}}requestParameters{{/allParams.0}});
-        {{/returnType}}
     }
     {{/useSingleRequestParameter}}
 

--- a/openapi-generator/typescript_lang.yaml
+++ b/openapi-generator/typescript_lang.yaml
@@ -2,5 +2,5 @@
 generatorName: typescript-fetch
 outputDir: clients/typescript
 npmName: "phrase-js"
-npmVersion: 1.0.4
+npmVersion: 1.0.5
 typescriptThreePlus: true


### PR DESCRIPTION
We need to return the API response even when there is no return type