### PR TITLE
Show operations headers in Safari

### DIFF
--- a/doc/rapidoc.scss
+++ b/doc/rapidoc.scss
@@ -61,7 +61,7 @@
 .nav-bar-tag {
   margin-left: $spacing5;
   color: $colorPrimaryForeground;
-  display: none;
+  display: flex;
 
   & + & {
     /* hides empty search results */


### PR DESCRIPTION
https://trello.com/c/QhCNIuu4/778-docs-no-operations-headers-in-safari

CSS load order in Safari is different that's why it was invisible only there.