### PR TITLE
Jobs: Add project to job results

### DIFF
--- a/schemas/job.yaml
+++ b/schemas/job.yaml
@@ -22,6 +22,8 @@ job:
     updated_at:
       type: string
       format: date-time
+    project:
+      "$ref": "./project_short.yaml#/project_short"
   example:
     id: 626ea67628690c73ac86ac81eec2d185
     name: Translations for new Feature
@@ -31,3 +33,9 @@ job:
     ticket_url: 'https://example.atlassian.net/browse/FOO'
     created_at: '2017-01-28T09:52:53Z'
     updated_at: '2017-01-28T09:52:53Z'
+    project:
+      id: abcd1234cdef1234abcd1234cdef1234
+      name: My Android Project
+      main_format: xml
+      created_at: '2015-01-28T09:52:53Z'
+      updated_at: '2015-01-28T09:52:53Z'


### PR DESCRIPTION
Required for an account-wide jobs endpoint.