### PR TITLE
Ruby: Support sending Tempfile objects

### DIFF
--- a/openapi-generator/templates/ruby-client/api_client_typhoeus_partial.mustache
+++ b/openapi-generator/templates/ruby-client/api_client_typhoeus_partial.mustache
@@ -99,8 +99,8 @@
         data = {}
         form_params.each do |key, value|
           case value
-          when ::File, ::Array, nil
-            # let typhoeus handle File, Array and nil parameters
+          when ::File, ::Tempfile, ::Array, nil
+            # let typhoeus handle File, Tempfile, Array and nil parameters
             data[key] = value
           else
             data[key] = value.to_s


### PR DESCRIPTION
Currently only File objects are supported but when scripting uploads, we often use Tempfiles instead.