### PR TITLE
Fix CLI installation help links

### DIFF
--- a/openapi-generator/templates/cli/README.handlebars
+++ b/openapi-generator/templates/cli/README.handlebars
@@ -23,7 +23,7 @@ This quick start will guide you through the basic steps to get up and running wi
 
 #### 1. Install
 
-[Download and install](https://phrase.com/cli) the client for your platform. See our [detailed installation guide](https://help.phrase.com/phrase-for-developers/phrase-client/installation) for more information.
+[Download and install](https://phrase.com/cli) the client for your platform. See our [detailed installation guide](https://help.phrase.com/help/installation-1) for more information.
 
 ##### Homebrew
 

--- a/openapi-generator/templates/cli/README.mustache
+++ b/openapi-generator/templates/cli/README.mustache
@@ -17,7 +17,7 @@ This quick start will guide you through the basic steps to get up and running wi
 
 #### 1. Install
 
-[Download and install](https://phrase.com/cli) the client for your platform. See our [detailed installation guide](https://help.phrase.com/phrase-for-developers/phrase-client/installation) for more information.
+[Download and install](https://phrase.com/cli) the client for your platform. See our [detailed installation guide](https://help.phrase.com/help/installation-1) for more information.
 
 ##### Homebrew
 


### PR DESCRIPTION
Readme links were not working anymore: https://github.com/phrase/phrase-cli/issues/52