### PR TITLE
Add secret to webhooks

### DIFF
--- a/paths/webhooks/create.yaml
+++ b/paths/webhooks/create.yaml
@@ -59,6 +59,10 @@ requestBody:
             description: Callback URL to send requests to
             type: string
             example: http://example.com/hooks/phraseapp-notifications
+          secret:
+            description: Webhook secret used to calculate signature. If empty, the default project secret will be used.
+            type: string
+            example: secr3t
           description:
             description: Webhook description
             type: string
@@ -70,4 +74,4 @@ requestBody:
           active:
             description: Whether webhook is active or inactive
             type: boolean
-            example: 
+            example:

--- a/paths/webhooks/update.yaml
+++ b/paths/webhooks/update.yaml
@@ -61,6 +61,10 @@ requestBody:
             description: Callback URL to send requests to
             type: string
             example: http://example.com/hooks/phraseapp-notifications
+          secret:
+            description: Webhook secret used to calculate signature. If empty, the default project secret will be used.
+            type: string
+            example: secr3t
           description:
             description: Webhook description
             type: string
@@ -72,4 +76,4 @@ requestBody:
           active:
             description: Whether webhook is active or inactive
             type: boolean
-            example: 
+            example:


### PR DESCRIPTION
Webhooks can now have a custom secret to override the project-wide secret.