### PR TITLE
Remove Link headers from POST requests

### DIFF
--- a/paths/keys/search.yaml
+++ b/paths/keys/search.yaml
@@ -25,8 +25,6 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Remaining"
       X-Rate-Limit-Reset:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
-      Link:
-        "$ref": "../../headers.yaml#/Link"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/translations/search.yaml
+++ b/paths/translations/search.yaml
@@ -25,8 +25,6 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Remaining"
       X-Rate-Limit-Reset:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
-      Link:
-        "$ref": "../../headers.yaml#/Link"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':


### PR DESCRIPTION
We recently dropped support for Link-headers in POST requests so we should reflect that in the API documentation.