### PR TITLE
Ruby-Client: Support nested objects/hashes in form data

### DIFF
--- a/openapi-generator/templates/ruby-client/api_client_faraday_partial.mustache
+++ b/openapi-generator/templates/ruby-client/api_client_faraday_partial.mustache
@@ -116,6 +116,8 @@
           when ::Array, nil
             # let Faraday handle Array and nil parameters
             data[key] = value
+          when ::Hash
+            data[key] = build_request_body(header_params, value, body)
           else
             data[key] = value.to_s
           end

--- a/openapi-generator/templates/ruby-client/api_client_typhoeus_partial.mustache
+++ b/openapi-generator/templates/ruby-client/api_client_typhoeus_partial.mustache
@@ -102,6 +102,8 @@
           when ::File, ::Tempfile, ::Array, nil
             # let typhoeus handle File, Tempfile, Array and nil parameters
             data[key] = value
+          when ::Hash
+            data[key] = build_request_body(header_params, value, body)
           else
             data[key] = value.to_s
           end


### PR DESCRIPTION
Nested objects in POST requests seem broken since objects are not properly serialized when generating the request body. This causes wrong requests, e.g. when submitting `format_options` since the hash is only sent as a string.

Before:

    --------------------------b8e580af624e881d
    Content-Disposition: form-data; name="format_options"
    
    {:ignore_source_translations=>true}
    --------------------------b8e580af624e881d--

After:

    --------------------------7f6d8be7b2cfe386
    Content-Disposition: form-data; name="format_options[ignore_source_translations]"
    
    true
    --------------------------7f6d8be7b2cfe386--


It's not an ideal solution but fixes the issue. For the future we can think about moving all format options to first-class form params of the upload endpoint in the OpenAPI specification.