### PR TITLE
Add 'include_branches' option for webhooks

### DIFF
--- a/paths/webhooks/create.yaml
+++ b/paths/webhooks/create.yaml
@@ -75,3 +75,7 @@ requestBody:
             description: Whether webhook is active or inactive
             type: boolean
             example:
+          include_branches:
+            description: If enabled, webhook will also be triggered for events from branches of the project specified.
+            type: boolean
+            example:

--- a/paths/webhooks/update.yaml
+++ b/paths/webhooks/update.yaml
@@ -77,3 +77,7 @@ requestBody:
             description: Whether webhook is active or inactive
             type: boolean
             example:
+          include_branches:
+            description: If enabled, webhook will also be triggered for events from branches of the project specified.
+            type: boolean
+            example:

--- a/schemas/webhook.yaml
+++ b/schemas/webhook.yaml
@@ -15,6 +15,8 @@ webhook:
         type: string
     active:
       type: boolean
+    include_branches:
+      type: boolean
     created_at:
       type: string
       format: date-time
@@ -27,5 +29,6 @@ webhook:
     description: My webhook for chat notifications
     events: locales:create,translations:update
     active: true
+    include_branches: false
     created_at: '2015-01-28T09:52:53Z'
     updated_at: '2015-01-28T09:52:53Z'


### PR DESCRIPTION
Webhooks now feature the new "include_branches" option that lets you define if webhooks should also be triggered for events that happen inside a branch of the project. 