### PR TITLE
Api default locale codes invitations WORKFLOWS-409

### DIFF
--- a/paths/invitations/create.yaml
+++ b/paths/invitations/create.yaml
@@ -33,13 +33,13 @@ x-code-samples:
     curl "https://api.phrase.com/v2/accounts/:account_id/invitations" \
       -u USERNAME_OR_ACCESS_TOKEN \
       -X POST \
-      -d '{"email":"example@mail.com","role":"Developer","project_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235","locale_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235","permissions":{"create_upload":true,"review_translations":true}}' \
+      -d '{"email":"example@mail.com","role":"Developer","project_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235","locale_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235","default_locale_codes":["de","en"],"permissions":{"create_upload":true,"review_translations":true}}' \
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
     phrase invitations create \
     --account_id <account_id> \
-    --data '{"email":"example@mail.com", "role":"Developer", "project_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235", "locale_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235", "permissions":"{"create_upload"=>true, "review_translations"=>true}"}' \
+    --data '{"email":"example@mail.com", "role":"Developer", "project_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235", "locale_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235", "default_locale_codes":["de","en"], "permissions":"{"create_upload"=>true, "review_translations"=>true}"}' \
     --access_token <token>
 - lang: CLI v1
   source: |-
@@ -73,6 +73,14 @@ requestBody:
             description: List of locale ids the invited user has access to.
             type: string
             example: abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235
+          default_locale_codes:
+            description: List of default locales for the user.
+            type: array
+            items:
+              type: string
+            example:
+            - en
+            - de
           permissions:
             description: Additional permissions depending on invitation role. Available permissions are <code>create_upload</code> and <code>review_translations</code>
             type: object

--- a/paths/invitations/update.yaml
+++ b/paths/invitations/update.yaml
@@ -34,14 +34,14 @@ x-code-samples:
     curl "https://api.phrase.com/v2/accounts/:account_id/invitations/:id" \
       -u USERNAME_OR_ACCESS_TOKEN \
       -X PATCH \
-      -d '{"role":"Invitiation role","project_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235","locale_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235","permissions":{"create_upload":true}}' \
+      -d '{"role":"Invitiation role","project_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235","locale_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235","default_locale_codes":["de","en"],"permissions":{"create_upload":true}}' \
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
     phrase invitations update \
     --account_id <account_id> \
     --id <id> \
-    --data '{"role":""Invitiation role"", "project_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235", "locale_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235", "permissions":"{"create_upload"=>true}"}' \
+    --data '{"role":""Invitiation role"", "project_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235", "locale_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235", "default_locale_codes":["de","en"], "permissions":"{"create_upload"=>true}"}' \
     --access_token <token>
 - lang: CLI v1
   source: |-
@@ -70,6 +70,14 @@ requestBody:
             description: List of locale ids the invited user has access to
             type: string
             example: abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235
+          default_locale_codes:
+            description: List of default locales for the user.
+            type: array
+            items:
+              type: string
+            example:
+            - en
+            - de
           permissions:
             description: Additional permissions depending on invitation role.
             type: object

--- a/schemas/invitation.yaml
+++ b/schemas/invitation.yaml
@@ -19,6 +19,10 @@ invitation:
       type: array
       items:
         "$ref": "./locale_preview.yaml#/locale_preview"
+    default_locale_codes:
+      type: array
+      items: 
+        type: string
     permissions:
       type: object
     created_at:
@@ -45,6 +49,9 @@ invitation:
     - id: abcd1234cdef1234abcd1234cdef1234
       name: English
       code: en-GB
+    default_locale_codes:
+      - en
+      - de
     permissions:
     - create_upload: true
       review_translations: true


### PR DESCRIPTION
Allow default_locale_codes parameter for invitations#create/update in API as we have it in our frontend already.

https://github.com/phrase/phrase/pull/7302