### PR TITLE
auto-tag go releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           npm install
           npm run generate.go
-          git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/phrase/phrase-go.git clones/go &> /dev/null
+          git clone https://$API_TOKEN_GITHUB@github.com/phrase/phrase-go.git clones/go &> /dev/null
           rsync -avI --delete --exclude='.git/' clients/go/ clones/go
           cd clones/go
           git status --verbose
@@ -32,7 +32,9 @@ jobs:
           git config --global user.name "Phrase"
           git add .
           git commit --message "Deploying from  phrase/openapi@${GITHUB_SHA::8}"
-          git push origin master
+          PACKAGE_VERSION=$(awk '/- Package version:/{print $NF}' README.md)
+          git tag -s -a v$PACKAGE_VERSION -m v$PACKAGE_VERSION || true
+          git push --tags origin master
           else
           echo "  No changes, skipping."
           fi


### PR DESCRIPTION
The idea is to read the phrase-go version from `README.md` and try to create a tag with this version.

If the tag already exists, it will not be created twice. Then we push to `phrase/phrase-go` with tags and for new tag the pipeline will start automatically.