### PR TITLE
Add support for branching in Screenshots API

### DIFF
--- a/paths/screenshot_markers/create.yaml
+++ b/paths/screenshot_markers/create.yaml
@@ -34,14 +34,14 @@ x-code-samples:
     curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:screenshot_id/markers" \
       -u USERNAME_OR_ACCESS_TOKEN \
       -X POST \
-      -d '{"key_id":"abcd1234abcd1234abcd1234abcd1234","presentation":"{ \"x\": 100, \"y\": 100, \"w\": 100, \"h\": 100 }"}' \
+      -d '{"branch":"my-feature-branch", "key_id":"abcd1234abcd1234abcd1234abcd1234","presentation":"{ \"x\": 100, \"y\": 100, \"w\": 100, \"h\": 100 }"}' \
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
     phrase screenshot_markers create \
     --project_id <project_id> \
     --screenshot_id <screenshot_id> \
-    --data '{"key_id":"abcd1234abcd1234abcd1234abcd1234", "presentation":""{ "x": 100, "y": 100, "w": 100, "h": 100 }""}' \
+    --data '{"branch":"my-feature-branch", "key_id":"abcd1234abcd1234abcd1234abcd1234", "presentation":""{ "x": 100, "y": 100, "w": 100, "h": 100 }""}' \
     --access_token <token>
 - lang: CLI v1
   source: |-
@@ -56,6 +56,10 @@ requestBody:
         type: object
         title: screenshot_marker/create/parameters
         properties:
+          branch:
+            description: specify the branch to use
+            type: string
+            example: my-feature-branch
           key_id:
             description: Specify the Key ID which should be highlighted on the specified screenshot. The Key must belong to the project.
             type: string

--- a/paths/screenshot_markers/destroy.yaml
+++ b/paths/screenshot_markers/destroy.yaml
@@ -8,6 +8,12 @@ parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/project_id"
 - "$ref": "../../parameters.yaml#/screenshot_id"
+- description: specify the branch to use
+  example: my-feature-branch
+  name: branch
+  in: query
+  schema:
+    type: string
 responses:
   '204':
     "$ref": "../../responses.yaml#/204"
@@ -23,11 +29,14 @@ x-code-samples:
     curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:screenshot_id/markers" \
       -u USERNAME_OR_ACCESS_TOKEN \
       -X DELETE
+      -d '{"branch":"my-feature-branch"}' \
+      -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
     phrase screenshot_markers delete \
     --project_id <project_id> \
     --screenshot_id <screenshot_id> \
+    --branch my-feature-branch \
     --access_token <token>
 - lang: CLI v1
   source: phraseapp screenshot_marker delete <project_id> <screenshot_id>

--- a/paths/screenshot_markers/index.yaml
+++ b/paths/screenshot_markers/index.yaml
@@ -10,6 +10,12 @@ parameters:
 - "$ref": "../../parameters.yaml#/id"
 - "$ref": "../../parameters.yaml#/page"
 - "$ref": "../../parameters.yaml#/per_page"
+- description: specify the branch to use
+  example: my-feature-branch
+  name: branch
+  in: query
+  schema:
+    type: string
 responses:
   '200':
     description: OK
@@ -37,12 +43,13 @@ responses:
 x-code-samples:
 - lang: Curl
   source: |-
-    curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:id/markers" \
+    curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:id/markers?branch=my-feature-branch" \
       -u USERNAME_OR_ACCESS_TOKEN
 - lang: CLI v2
   source: |-
     phrase screenshot_markers list \
     --project_id <project_id> \
+    --branch my-feature-branch \
     --id <id> \
     --access_token <token>
 - lang: CLI v1

--- a/paths/screenshot_markers/show.yaml
+++ b/paths/screenshot_markers/show.yaml
@@ -9,6 +9,12 @@ parameters:
 - "$ref": "../../parameters.yaml#/project_id"
 - "$ref": "../../parameters.yaml#/screenshot_id"
 - "$ref": "../../parameters.yaml#/id"
+- description: specify the branch to use
+  example: my-feature-branch
+  name: branch
+  in: query
+  schema:
+    type: string
 responses:
   '200':
     description: OK
@@ -32,7 +38,7 @@ responses:
 x-code-samples:
 - lang: Curl
   source: |-
-    curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:screenshot_id/markers/:id" \
+    curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:screenshot_id/markers/:id?branch=my-feature-branch" \
       -u USERNAME_OR_ACCESS_TOKEN
 - lang: CLI v2
   source: |-
@@ -40,6 +46,7 @@ x-code-samples:
     --project_id <project_id> \
     --screenshot_id <screenshot_id> \
     --id <id> \
+    --branch my-feature-branch \
     --access_token <token>
 - lang: CLI v1
   source: phraseapp screenshot_marker show <project_id> <screenshot_id> <id>

--- a/paths/screenshot_markers/update.yaml
+++ b/paths/screenshot_markers/update.yaml
@@ -34,14 +34,14 @@ x-code-samples:
     curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:screenshot_id/markers" \
       -u USERNAME_OR_ACCESS_TOKEN \
       -X PATCH \
-      -d '{"key_id":"abcd1234abcd1234abcd1234abcd1234","presentation":"{ \"x\": 100, \"y\": 100, \"w\": 100, \"h\": 100 }"}' \
+      -d '{"branch":"my-feature-branch", "key_id":"abcd1234abcd1234abcd1234abcd1234","presentation":"{ \"x\": 100, \"y\": 100, \"w\": 100, \"h\": 100 }"}' \
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
     phrase screenshot_markers update \
     --project_id <project_id> \
     --screenshot_id <screenshot_id> \
-    --data '{"key_id":"abcd1234abcd1234abcd1234abcd1234", "presentation":""{ "x": 100, "y": 100, "w": 100, "h": 100 }""}' \
+    --data '{"branch":"my-feature-branch", "key_id":"abcd1234abcd1234abcd1234abcd1234", "presentation":""{ "x": 100, "y": 100, "w": 100, "h": 100 }""}' \
     --access_token <token>
 - lang: CLI v1
   source: |-
@@ -56,6 +56,10 @@ requestBody:
         type: object
         title: screenshot_marker/update/parameters
         properties:
+          branch:
+            description: specify the branch to use
+            type: string
+            example: my-feature-branch
           key_id:
             description: Specify the Key ID which should be highlighted on the specified screenshot. The Key must belong to the project.
             type: string

--- a/paths/screenshots/create.yaml
+++ b/paths/screenshots/create.yaml
@@ -33,6 +33,7 @@ x-code-samples:
     curl "https://api.phrase.com/v2/projects/:project_id/screenshots" \
       -u USERNAME_OR_ACCESS_TOKEN \
       -X POST \
+      -F branch=my-feature-branch \
       -F name=A%20screenshot%20name \
       -F description=A%20screenshot%20description \
       -F filename=@/path/to/my/screenshot.png
@@ -40,7 +41,7 @@ x-code-samples:
   source: |-
     phrase screenshots create \
     --project_id <project_id> \
-    --data '{"name":""A screenshot name"", "description":""A screenshot description"", "filename":"/path/to/my/screenshot.png"}' \
+    --data '{"branch":"my-feature-branch", "name":""A screenshot name"", "description":""A screenshot description"", "filename":"/path/to/my/screenshot.png"}' \
     --access_token <token>
 - lang: CLI v1
   source: |-
@@ -56,6 +57,10 @@ requestBody:
         type: object
         title: screenshot/create/parameters
         properties:
+          branch:
+            description: specify the branch to use
+            type: string
+            example: my-feature-branch
           name:
             description: Name of the screenshot
             type: string

--- a/paths/screenshots/destroy.yaml
+++ b/paths/screenshots/destroy.yaml
@@ -8,6 +8,12 @@ parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/project_id"
 - "$ref": "../../parameters.yaml#/id"
+- description: specify the branch to use
+  example: my-feature-branch
+  name: branch
+  in: query
+  schema:
+    type: string
 responses:
   '204':
     "$ref": "../../responses.yaml#/204"
@@ -23,11 +29,14 @@ x-code-samples:
     curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:id" \
       -u USERNAME_OR_ACCESS_TOKEN \
       -X DELETE
+      -d '{"branch":"my-feature-branch"}' \
+      -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
     phrase screenshots delete \
     --project_id <project_id> \
     --id <id> \
+    --branch my-feature-branch \
     --access_token <token>
 - lang: CLI v1
   source: phraseapp screenshot delete <project_id> <id>

--- a/paths/screenshots/index.yaml
+++ b/paths/screenshots/index.yaml
@@ -9,6 +9,12 @@ parameters:
 - "$ref": "../../parameters.yaml#/project_id"
 - "$ref": "../../parameters.yaml#/page"
 - "$ref": "../../parameters.yaml#/per_page"
+- description: specify the branch to use
+  example: my-feature-branch
+  name: branch
+  in: query
+  schema:
+    type: string
 - description: filter by key
   example: abcd1234cdef1234abcd1234cdef1234
   name: key_id
@@ -42,12 +48,13 @@ responses:
 x-code-samples:
 - lang: Curl
   source: |-
-    curl "https://api.phrase.com/v2/projects/:project_id/screenshots" \
+    curl "https://api.phrase.com/v2/projects/:project_id/screenshots?branch=my-feature-branch" \
       -u USERNAME_OR_ACCESS_TOKEN
 - lang: CLI v2
   source: |-
     phrase screenshots list \
     --project_id <project_id> \
+    --branch my-feature-branch \
     --access_token <token>
 - lang: CLI v1
   source: phraseapp screenshots list <project_id>

--- a/paths/screenshots/show.yaml
+++ b/paths/screenshots/show.yaml
@@ -8,6 +8,12 @@ parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/project_id"
 - "$ref": "../../parameters.yaml#/id"
+- description: specify the branch to use
+  example: my-feature-branch
+  name: branch
+  in: query
+  schema:
+    type: string
 responses:
   '200':
     description: OK
@@ -31,13 +37,14 @@ responses:
 x-code-samples:
 - lang: Curl
   source: |-
-    curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:id" \
+    curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:id?branch=my-feature-branch" \
       -u USERNAME_OR_ACCESS_TOKEN
 - lang: CLI v2
   source: |-
     phrase screenshots show \
     --project_id <project_id> \
     --id <id> \
+    --branch my-feature-branch \
     --access_token <token>
 - lang: CLI v1
   source: phraseapp screenshot show <project_id> <id>

--- a/paths/screenshots/update.yaml
+++ b/paths/screenshots/update.yaml
@@ -34,6 +34,7 @@ x-code-samples:
     curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:id" \
       -u USERNAME_OR_ACCESS_TOKEN \
       -X PATCH \
+      -F branch=my-feature-branch \
       -F name=A%20screenshot%20name \
       -F description=A%20screenshot%20description \
       -F filename=@/path/to/my/screenshot.png
@@ -42,7 +43,7 @@ x-code-samples:
     phrase screenshots update \
     --project_id <project_id> \
     --id <id> \
-    --data '{"name":""A screenshot name"", "description":""A screenshot description"", "filename":"/path/to/my/screenshot.png"}' \
+    --data '{"branch":"my-feature-branch", "name":""A screenshot name"", "description":""A screenshot description"", "filename":"/path/to/my/screenshot.png"}' \
     --access_token <token>
 - lang: CLI v1
   source: |-
@@ -58,6 +59,10 @@ requestBody:
         type: object
         title: screenshot/update/parameters
         properties:
+          branch:
+            description: specify the branch to use
+            type: string
+            example: my-feature-branch
           name:
             description: Name of the screenshot
             type: string


### PR DESCRIPTION
Allow passing "branch" name since we now support branches in the Screenshots API.