### PR TITLE
Fix error handling in callAPI

### DIFF
--- a/openapi-generator/go_lang.yaml
+++ b/openapi-generator/go_lang.yaml
@@ -2,7 +2,7 @@
 generatorName: go
 outputDir: clients/go
 packageName: phrase
-packageVersion: 1.0.19
+packageVersion: 1.0.20
 gitUserId: phrase
 gitRepoId: phrase-go
 httpUserAgent: Phrase go

--- a/openapi-generator/templates/go/client.mustache
+++ b/openapi-generator/templates/go/client.mustache
@@ -175,10 +175,10 @@ func (c *APIClient) callAPI(request *http.Request) (*APIResponse, error) {
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)
-	response := NewAPIResponse(resp)
 	if err != nil {
-		return response, err
+		return nil, err
 	}
+	response := NewAPIResponse(resp)
 
 	if c.cfg.Debug {
 		dump, err := httputil.DumpResponse(resp, true)


### PR DESCRIPTION
Response should not be used in case of an error. Reported in https://github.com/phrase/phrase-go/pull/5