### PR TITLE
CLI: Release binary for M1 Macs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       - name: Build and Deploy 🚀
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
@@ -50,7 +50,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       - name: Build and Deploy 🚀
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}

--- a/clients/cli/build/go_build.sh
+++ b/clients/cli/build/go_build.sh
@@ -21,5 +21,6 @@ function build {
 build linux   amd64   phrase_linux_amd64
 build linux   386     phrase_linux_386
 build darwin  amd64   phrase_macosx_amd64
+build darwin  arm64   phrase_macosx_arm64
 build windows amd64   phrase_windows_amd64.exe
 build windows 386     phrase_windows_386.exe

--- a/clients/cli/go.mod
+++ b/clients/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/phrase/phrase-cli
 
-go 1.14
+go 1.16
 
 require (
 	github.com/antihax/optional v1.0.0

--- a/openapi-generator/cli_lang.yaml
+++ b/openapi-generator/cli_lang.yaml
@@ -2,4 +2,4 @@
 generatorName: go
 outputDir: clients/cli
 packageName: phrase
-packageVersion: 2.0.28
+packageVersion: 2.1.0


### PR DESCRIPTION
With the release of go 1.16 we can now provide binaries for M1 Macs