### PR TITLE
Update to go 1.16 for M1 builds

### DIFF
--- a/clients/cli/.github/workflows/release.yml
+++ b/clients/cli/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       - name: Version
         id: version
         run: |

--- a/clients/cli/build/config.sh
+++ b/clients/cli/build/config.sh
@@ -4,7 +4,7 @@ set -e
 wd=$(realpath $(dirname $0)/..)
 export BUILD_DIR=$(realpath $(dirname $0)/..)
 pushd $BUILD_DIR > /dev/null
-export GOVERSION=${GOVERSION:-1.14}
+export GOVERSION=${GOVERSION:-1.16}
 export REVISION=${GIT_COMMIT:-$(git rev-parse HEAD)}
 export LIBRARY_REVISION=$(cat go.sum | grep github.com/phrase/phrase-go | tail -n 1 | cut -d " " -f 2 | cut -d "-" -f 3 | cut -d "+" -f 1)
 export SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)


### PR DESCRIPTION
Required to update the go version in the phrase-cli repo