### PR TITLE
Ruby: Use String as default return type

### DIFF
--- a/openapi-generator/ruby_lang.yaml
+++ b/openapi-generator/ruby_lang.yaml
@@ -3,7 +3,7 @@ generatorName: ruby
 outputDir: clients/ruby
 moduleName: Phrase
 gemName: phrase
-gemVersion: 1.0.14
+gemVersion: 1.0.15
 gemDescription: 'Phrase is a translation management platform for software projects.'
 gemSummary: 'You can collaborate on language file translation with your team or order translations through our platform. The API allows you to import locale files, download locale files, tag keys or interact in other ways with the localization data stored in Phrase for your account.'
 gemLicense: 'MIT'

--- a/openapi-generator/templates/ruby-client/api.mustache
+++ b/openapi-generator/templates/ruby-client/api.mustache
@@ -172,7 +172,8 @@ module {{moduleName}}
       post_body = opts[:body] {{#bodyParam}}|| @api_client.object_to_http_body({{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}) {{/bodyParam}}
 
       # return_type
-      return_type = opts[:return_type] {{#returnType}}|| '{{{returnType}}}' {{/returnType}}
+      return_type = opts[:return_type] || {{#returnType}}'{{{returnType}}}'{{/returnType}}{{^returnType}}'String'{{/returnType}}
+
 
       # auth_names
       auth_names = opts[:auth_names] || [{{#authMethods}}'{{name}}'{{#hasMore}}, {{/hasMore}}{{/authMethods}}]


### PR DESCRIPTION
Use `String` as fallback return_type, which makes the `return_type` parameter optional for the `locale_download` method.