### PR TITLE
Change response type for locale downloads

### DIFF
--- a/clients/cli/cmd/internal/pull.go
+++ b/clients/cli/cmd/internal/pull.go
@@ -158,11 +158,11 @@ func (target *Target) DownloadAndWriteToFile(client *phrase.APIClient, localeFil
 		fmt.Fprintln(os.Stderr, "FormatOptions", localVarOptionals.FormatOptions)
 	}
 
-	data, response, err := client.LocalesApi.LocaleDownload(Auth, target.ProjectID, localeFile.ID, &localVarOptionals)
+	file, response, err := client.LocalesApi.LocaleDownload(Auth, target.ProjectID, localeFile.ID, &localVarOptionals)
 	if err != nil {
 		if response.Rate.Remaining == 0 {
 			waitForRateLimit(response.Rate)
-			data, _, err = client.LocalesApi.LocaleDownload(Auth, target.ProjectID, localeFile.ID, &localVarOptionals)
+			file, _, err = client.LocalesApi.LocaleDownload(Auth, target.ProjectID, localeFile.ID, &localVarOptionals)
 			if err != nil {
 				return err
 			}
@@ -171,6 +171,9 @@ func (target *Target) DownloadAndWriteToFile(client *phrase.APIClient, localeFil
 		}
 	}
 
+	data, _ := ioutil.ReadAll(file)
+	file.Close()
+	os.Remove(file.Name())
 	err = ioutil.WriteFile(localeFile.Path, data, 0700)
 	return err
 }

--- a/openapi-generator/go_lang.yaml
+++ b/openapi-generator/go_lang.yaml
@@ -2,7 +2,7 @@
 generatorName: go
 outputDir: clients/go
 packageName: phrase
-packageVersion: 1.0.20
+packageVersion: 2.0.0
 gitUserId: phrase
 gitRepoId: phrase-go
 httpUserAgent: Phrase go

--- a/openapi-generator/ruby_lang.yaml
+++ b/openapi-generator/ruby_lang.yaml
@@ -3,7 +3,7 @@ generatorName: ruby
 outputDir: clients/ruby
 moduleName: Phrase
 gemName: phrase
-gemVersion: 1.0.14
+gemVersion: 2.0.0
 gemDescription: 'Phrase is a translation management platform for software projects.'
 gemSummary: 'You can collaborate on language file translation with your team or order translations through our platform. The API allows you to import locale files, download locale files, tag keys or interact in other ways with the localization data stored in Phrase for your account.'
 gemLicense: 'MIT'

--- a/openapi-generator/templates/cli/api.handlebars
+++ b/openapi-generator/templates/cli/api.handlebars
@@ -71,13 +71,15 @@ func init{{{nickname}}}() {
 			data, api_response, err := client.{{classname}}.{{{nickname}}}(auth{{#hasParams}}, {{/hasParams}}{{#allParams}}{{#required}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}&localVarOptionals{{/hasOptionalParams}})
 
 			if api_response.StatusCode >= 200 && api_response.StatusCode < 300 {
-				{{#if returnType}}jsonBuf, jsonErr := json.MarshalIndent(data, "", " ")
+				{{#if returnType}}{{#if (eq returnType "*os.File")}}content, _ := ioutil.ReadAll(data)
+				fmt.Printf("%s", string(content))
+				data.Close()
+				os.Remove(data.Name()){{else}}jsonBuf, jsonErr := json.MarshalIndent(data, "", " ")
 				if jsonErr != nil {
 					fmt.Printf("%v\n", data)
 					HandleError(err)
 				}
-
-				fmt.Printf("%s\n", string(jsonBuf)){{/if}}{{#unless returnType}}os.Stdout.Write(data){{/unless}}
+				fmt.Printf("%s\n", string(jsonBuf)){{/if}}{{else}}os.Stdout.Write(data){{/if}}
 			}
 			if err != nil {
 				switch castedError := err.(type) {

--- a/openapi-generator/templates/go/client.mustache
+++ b/openapi-generator/templates/go/client.mustache
@@ -388,22 +388,37 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 	if len(b) == 0 {
 		return nil
 	}
+
 	if s, ok := v.(*string); ok {
 		*s = string(b)
 		return nil
 	}
+
+	if f, ok := v.(**os.File); ok {
+		file, err := ioutil.TempFile(os.TempDir(), "phrase-locale-download-*")
+		if err != nil {
+			return err
+		}
+		file.Write(b)
+		file.Seek(0, io.SeekStart)
+		*f = file
+		return nil
+	}
+
 	if xmlCheck.MatchString(contentType) {
 		if err = xml.Unmarshal(b, v); err != nil {
 			return err
 		}
 		return nil
 	}
+
 	if jsonCheck.MatchString(contentType) {
 		if err = json.Unmarshal(b, v); err != nil {
 			return err
 		}
 		return nil
 	}
+
 	return errors.New("undefined response type")
 }
 

--- a/paths/locales/download.yaml
+++ b/paths/locales/download.yaml
@@ -105,6 +105,11 @@ parameters:
 responses:
   '200':
     description: OK
+    content:
+      "*":
+        schema:
+          type: string
+          format: binary
     headers:
       X-Rate-Limit-Limit:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Limit"


### PR DESCRIPTION
Return file handlers for locale download to be consistent between formats and better handle binary formats