### PR TITLE
make sure to only cleanup file if it is actually initialized

### DIFF
--- a/clients/cli/cmd/internal/pull.go
+++ b/clients/cli/cmd/internal/pull.go
@@ -174,9 +174,16 @@ func (target *Target) DownloadAndWriteToFile(client *phrase.APIClient, localeFil
 		}
 	}
 
-	data, _ := ioutil.ReadAll(file)
-	file.Close()
-	os.Remove(file.Name())
+	var data []byte
+	if file != nil {
+		data, err = ioutil.ReadAll(file)
+		if err != nil {
+			return err
+		}
+		file.Close()
+		os.Remove(file.Name())
+	}
+
 	err = ioutil.WriteFile(localeFile.Path, data, 0700)
 	return err
 }

--- a/openapi-generator/cli_lang.yaml
+++ b/openapi-generator/cli_lang.yaml
@@ -2,4 +2,4 @@
 generatorName: go
 outputDir: clients/cli
 packageName: phrase
-packageVersion: 2.1.5
+packageVersion: 2.1.6


### PR DESCRIPTION
The function `client.LocalesApi.LocaleDownload` does not create files if there is nothing to write (see https://github.com/phrase/phrase-go/blob/660264e0c1a322325cc83bf42da67b851514c762/client.go#L456). This also means that they cannot be cleaned up.

As we did not check the `err` part of `ioutil.ReadAll(file)` we also did not notice that file was still an uninitialized pointer.

Even though this now works (in case of an uninitialized os.File we now just write the empty byte slice) we should think of changing `client.LocalesApi.LocaleDownload` (as this would probably break the API we might need to add a new function) so that we can e.g. provide an `io.Reader` and so the caller can decide if to actually create a file or maybe if a buffer is also good enough.