### PR TITLE
Fix build of phrase-js by adding missing type declarations to date-time field

### DIFF
--- a/schemas/invitation.yaml
+++ b/schemas/invitation.yaml
@@ -48,8 +48,10 @@ invitation:
           name:
             type: string
           created_at:
+            type: string
             format: date-time
           updated_at:
+            type: string
             format: date-time
           projects_count:
             type: integer

--- a/schemas/member.yaml
+++ b/schemas/member.yaml
@@ -31,8 +31,10 @@ member:
           name:
             type: string
           created_at:
+            type: string
             format: date-time
           updated_at:
+            type: string
             format: date-time
           projects_count:
             type: integer

--- a/schemas/member_project_detail.yaml
+++ b/schemas/member_project_detail.yaml
@@ -35,8 +35,10 @@ member_project_detail:
           name:
             type: string
           created_at:
+            type: string
             format: date-time
           updated_at:
+            type: string
             format: date-time
           projects_count:
             type: integer


### PR DESCRIPTION
This pull request adds missing type declarations to `date-time` fields. This created an `AnyType` issue in the generated `phrase-js` project (also reported here https://github.com/phrase/phrase-js/issues/9).