### PR TITLE
phrase-php: Fix upload_create object params was not correctly sent

### DIFF
--- a/openapi-generator/templates/php/api.mustache
+++ b/openapi-generator/templates/php/api.mustache
@@ -536,7 +536,7 @@ use {{invokerPackage}}\ObjectSerializer;
             $formParams['{{baseName}}'] = \GuzzleHttp\Psr7\Utils::tryFopen(ObjectSerializer::toFormValue(${{paramName}}), 'rb');
             {{/isFile}}
             {{^isFile}}
-            $formParams['{{baseName}}'] = ObjectSerializer::toFormValue(${{paramName}});
+            $this->formParamsAppend($formParams, '{{baseName}}', ${{paramName}});
             {{/isFile}}
         }
         {{/formParams}}
@@ -664,6 +664,21 @@ use {{invokerPackage}}\ObjectSerializer;
         }
 
         return $options;
+    }
+    /**
+     * Append to form params, handle object params
+     */
+    protected function formParamsAppend(&$formParams, $name, $value)
+    {
+        if (is_object($value)) {
+            foreach ((array) $value as $k => $v) {
+                $formParams[$name.'['.$k.']'] = ObjectSerializer::toFormValue($v);
+            }
+
+            return;
+        }
+
+        $formParams[$name] = ObjectSerializer::toFormValue($value);
     }
 }
 {{/operations}}


### PR DESCRIPTION
On UploadApi and create method, params `format_options` and `locale_mapping` cannot be sent due to a fatal error.

So now, for example, we can pass ['my_option' => 'my-value'] as format_options argument and it will send as :
name `format_options[my_option]` and contents `my-value`.