### PR TITLE
Bump Phrase CLI to 2.2.0

### DIFF
--- a/clients/cli/go.mod
+++ b/clients/cli/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/magiconair/properties v1.8.4 // indirect
 	github.com/mitchellh/mapstructure v1.4.0
 	github.com/pelletier/go-toml v1.8.1 // indirect
-	github.com/phrase/phrase-go/v2 v2.0.2
+	github.com/phrase/phrase-go/v2 v2.1.0
 	github.com/spf13/afero v1.4.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/openapi-generator/cli_lang.yaml
+++ b/openapi-generator/cli_lang.yaml
@@ -2,4 +2,4 @@
 generatorName: go
 outputDir: clients/cli
 packageName: phrase
-packageVersion: 2.1.7
+packageVersion: 2.2.0


### PR DESCRIPTION
Release a new version of Phrase CLI (includes job templates API)