### PR TITLE
Fix account/locales operation definition

### DIFF
--- a/paths/accounts/locales.yaml
+++ b/paths/accounts/locales.yaml
@@ -6,6 +6,7 @@ tags:
 - Locales
 parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
+- "$ref": "../../parameters.yaml#/account_id"
 - "$ref": "../../parameters.yaml#/page"
 - "$ref": "../../parameters.yaml#/per_page"
 responses:


### PR DESCRIPTION
Parameter `account_id` was missing into definition. 
So clients `Locale::accountLocales` methods cannot works.