### PR TITLE
Add `source_locale_id` to download.yml

### DIFF
--- a/openapi-generator/ruby_lang.yaml
+++ b/openapi-generator/ruby_lang.yaml
@@ -3,7 +3,7 @@ generatorName: ruby
 outputDir: clients/ruby
 moduleName: Phrase
 gemName: phrase
-gemVersion: 2.2.0
+gemVersion: 2.3.0
 gemDescription: 'Phrase is a translation management platform for software projects.'
 gemSummary: 'You can collaborate on language file translation with your team or order translations through our platform. The API allows you to import locale files, download locale files, tag keys or interact in other ways with the localization data stored in Phrase for your account.'
 gemLicense: 'MIT'

--- a/paths/locales/download.yaml
+++ b/paths/locales/download.yaml
@@ -102,6 +102,12 @@ parameters:
   in: query
   schema:
     type: string
+- description: Provides the source language of a corresponding job as the source language of the generated locale file. This parameter will be ignored unless used in combination with a <code>tag</code> parameter indicating a specific job.
+  example:
+  name: source_locale_id
+  in: query
+  schema:
+    type: string
 responses:
   '200':
     description: OK


### PR DESCRIPTION
Add the `source_locale_id` to the download.yml so that it can be used by the XTM sync in the phrase-ruby library as well as documented in our OpenAPI.