### PR TITLE
Remove `sort` and `order` from docs for `batch_verify` endpoint

### DIFF
--- a/paths/translations/batch_verify.yaml
+++ b/paths/translations/batch_verify.yaml
@@ -33,21 +33,19 @@ x-code-samples:
     curl "https://api.phrase.com/v2/projects/:project_id/translations/verify" \
       -u USERNAME_OR_ACCESS_TOKEN \
       -X PATCH \
-      -d '{"branch":"my-feature-branch","q":"PhraseApp*%20unverified:true%20tags:feature,center","sort":"updated_at","order":"desc"}' \
+      -d '{"branch":"my-feature-branch","q":"PhraseApp*%20unverified:true%20tags:feature,center"}' \
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
     phrase translations verify-collection \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "query":"'PhraseApp*%20unverified:true%20tags:feature,center'", "sort":"updated_at", "order":"desc"}' \
+    --data '{"branch":"my-feature-branch", "query":"'PhraseApp*%20unverified:true%20tags:feature,center'"}' \
     --access_token <token>
 - lang: CLI v1
   source: |-
     phraseapp translations verify <project_id> \
     --branch my-feature-branch \
     --query 'PhraseApp*%20unverified:true%20tags:feature,center' \
-    --sort updated_at \
-    --order desc
 requestBody:
   required: true
   content:


### PR DESCRIPTION
These two are not actual parameters.