### PR TITLE
Fix creating GitHub releases

### DIFF
--- a/clients/java/.github/workflows/release.sh
+++ b/clients/java/.github/workflows/release.sh
@@ -34,9 +34,9 @@ EOF
 }
 
 echo "Create release $VERSION"
-api_url="https://api.github.com/repos/phrase/phrase-java/releases?access_token=${GITHUB_TOKEN}"
-response="$(curl --data "$(create_release_data)" ${api_url})"
-release_id=$(echo $response | python -c "import sys, json; print(json.load(sys.stdin)['id'])")
+api_url="https://api.github.com/repos/phrase/phrase-java/releases"
+response="$(curl -H "Authorization: token ${GITHUB_TOKEN}" --data "$(create_release_data)" ${api_url})"
+release_id=$(echo $response | python -c "import sys, json; print(json.load(sys.stdin).get('id', ''))")
 
 if [ -z "$release_id" ]
 then
@@ -49,8 +49,8 @@ fi
 
 echo "Uploading ${file}"
 file=build/libs/phrase-java-${VERSION}.jar
-asset="https://uploads.github.com/repos/phrase/phrase-java/releases/${release_id}/assets?name=$(basename "$file")&access_token=${GITHUB_TOKEN}"
-curl --data-binary @"$file" -H "Content-Type: application/octet-stream" $asset > /dev/null
+asset="https://uploads.github.com/repos/phrase/phrase-java/releases/${release_id}/assets?name=$(basename "$file")"
+curl --data-binary @"$file" -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/octet-stream" $asset > /dev/null
 echo Hash: $(sha256sum $file)
 
 

--- a/clients/python/.github/workflows/release.sh
+++ b/clients/python/.github/workflows/release.sh
@@ -34,9 +34,9 @@ EOF
 }
 
 echo "Create release $VERSION"
-api_url="https://api.github.com/repos/phrase/phrase-python/releases?access_token=${GITHUB_TOKEN}"
-response="$(curl --data "$(create_release_data)" ${api_url})"
-release_id=$(echo $response | python -c "import sys, json; print(json.load(sys.stdin)['id'])")
+api_url="https://api.github.com/repos/phrase/phrase-python/releases"
+response="$(curl -H "Authorization: token ${GITHUB_TOKEN}" --data "$(create_release_data)" ${api_url})"
+release_id=$(echo $response | python -c "import sys, json; print(json.load(sys.stdin).get('id', ''))")
 
 if [ -z "$release_id" ]
 then
@@ -50,8 +50,8 @@ fi
 DIST_DIR="./dist"
 for file in "$DIST_DIR"/*; do
     echo "Uploading ${file}"
-    asset="https://uploads.github.com/repos/phrase/phrase-python/releases/${release_id}/assets?name=$(basename "$file")&access_token=${GITHUB_TOKEN}"
-    curl -sS --data-binary @"$file" -H "Content-Type: application/octet-stream" $asset > /dev/null
+    asset="https://uploads.github.com/repos/phrase/phrase-python/releases/${release_id}/assets?name=$(basename "$file")"
+    curl -sS --data-binary @"$file" -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/octet-stream" $asset > /dev/null
     echo Hash: $(sha256sum $file)
 done
 

--- a/clients/ruby/.github/workflows/release.sh
+++ b/clients/ruby/.github/workflows/release.sh
@@ -34,9 +34,9 @@ EOF
 }
 
 echo "Create release $VERSION"
-api_url="https://api.github.com/repos/phrase/phrase-ruby/releases?access_token=${GITHUB_TOKEN}"
-response="$(curl --data "$(create_release_data)" ${api_url})"
-release_id=$(echo $response | python -c "import sys, json; print(json.load(sys.stdin)['id'])")
+api_url="https://api.github.com/repos/phrase/phrase-ruby/releases"
+response="$(curl -H "Authorization: token ${GITHUB_TOKEN}" --data "$(create_release_data)" ${api_url})"
+release_id=$(echo $response | python -c "import sys, json; print(json.load(sys.stdin).get('id', ''))")
 
 if [ -z "$release_id" ]
 then
@@ -49,8 +49,8 @@ fi
 
 echo "Uploading ${file}"
 file=phrase-${VERSION}.gem
-asset="https://uploads.github.com/repos/phrase/phrase-ruby/releases/${release_id}/assets?name=$(basename "$file")&access_token=${GITHUB_TOKEN}"
-curl --data-binary @"$file" -H "Content-Type: application/octet-stream" $asset > /dev/null
+asset="https://uploads.github.com/repos/phrase/phrase-ruby/releases/${release_id}/assets?name=$(basename "$file")"
+curl --data-binary @"$file" -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/octet-stream" $asset > /dev/null
 echo Hash: $(sha256sum $file)
 
 # -----------


### PR DESCRIPTION
Specifying GitHub access tokens in query params is deprecated and no longer works https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param

Also improves the error logging of the response body

https://github.com/phrase/phrase-ruby/runs/4032267447?check_suite_focus=true