### PR TITLE
Add support for Ruby 3

### DIFF
--- a/clients/ruby/lib/phrase/response.rb
+++ b/clients/ruby/lib/phrase/response.rb
@@ -10,7 +10,7 @@ module Phrase
       link_headers = headers["link"]
       if link_headers
         @paginated = true
-        parsed_links = LinkHeaderParser.parse(link_headers, base: 'https://api.phrase.com').by_relation_type
+        parsed_links = LinkHeaderParser.parse(link_headers, base: 'https://api.phrase.com').group_by_relation_type
         next_page_link = parsed_links[:next]&.first
         if next_page_link
           @next_page = CGI.parse(URI.parse(next_page_link.target_uri).query)["page"]&.first&.to_i

--- a/openapi-generator/ruby_lang.yaml
+++ b/openapi-generator/ruby_lang.yaml
@@ -3,9 +3,10 @@ generatorName: ruby
 outputDir: clients/ruby
 moduleName: Phrase
 gemName: phrase
-gemVersion: 2.4.0
+gemVersion: 2.5.0
 gemDescription: 'Phrase is a translation management platform for software projects.'
 gemSummary: 'You can collaborate on language file translation with your team or order translations through our platform. The API allows you to import locale files, download locale files, tag keys or interact in other ways with the localization data stored in Phrase for your account.'
+gemRequiredRubyVersion: '>= 2.6.0'
 gemLicense: 'MIT'
 gemHomepage: 'https://phrase.com'
 gemAuthor: Phrase

--- a/openapi-generator/templates/ruby-client/gemspec.mustache
+++ b/openapi-generator/templates/ruby-client/gemspec.mustache
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   {{/isFaraday}}
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
-  s.add_runtime_dependency 'link-header-parser', '~>1.0'
+  s.add_runtime_dependency 'link-header-parser', '~> 4.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 


### PR DESCRIPTION
Update link-header-parser dependency and restrict to use with Ruby 2.6+ which is required by link-header-parser.