### PR TITLE
CLI: Add project_id to uploads cleanup command

### DIFF
--- a/clients/cli/cmd/internal/upload_cleanup.go
+++ b/clients/cli/cmd/internal/upload_cleanup.go
@@ -12,9 +12,10 @@ import (
 
 type UploadCleanupCommand struct {
 	phrase.Config
-	ID      string
-	Confirm bool
-	Branch  string
+	ID        string
+	ProjectID string
+	Confirm   bool
+	Branch    string
 }
 
 func (cmd *UploadCleanupCommand) Run() error {
@@ -32,7 +33,7 @@ func UploadCleanup(client *phrase.APIClient, cmd *UploadCleanupCommand) error {
 		Q:       optional.NewString(q),
 		Branch:  optional.NewString(cmd.Branch),
 	}
-	keys, _, err := client.KeysApi.KeysList(Auth, cmd.Config.DefaultProjectID, &keysListLocalVarOptionals)
+	keys, _, err := client.KeysApi.KeysList(Auth, cmd.ProjectID, &keysListLocalVarOptionals)
 	if err != nil {
 		return err
 	}

--- a/clients/cli/cmd/upload_cleanup.go
+++ b/clients/cli/cmd/upload_cleanup.go
@@ -17,11 +17,21 @@ func initUpoadCleanup() {
 		Short: "Delete unmentioned keys for given upload",
 		Long:  "",
 		Run: func(cmd *cobra.Command, args []string) {
+			projectId := params.GetString("project_id")
+			if projectId == "" {
+				projectId = Config.DefaultProjectID
+			}
+			if projectId == "" {
+				HandleError("required flag \"project_id\" not set")
+				return
+			}
+
 			cmduploadCleanup := uploadCleanup.UploadCleanupCommand{
-				Config:  *Config,
-				ID:      params.GetString("id"),
-				Confirm: params.GetBool("confirm"),
-				Branch:  params.GetString("branch"),
+				Config:    *Config,
+				ID:        params.GetString("id"),
+				ProjectID: projectId,
+				Confirm:   params.GetBool("confirm"),
+				Branch:    params.GetString("branch"),
 			}
 			err := cmduploadCleanup.Run()
 			if err != nil {
@@ -31,7 +41,8 @@ func initUpoadCleanup() {
 	}
 	UploadsApiCmd.AddCommand(uploadCleanupCmd)
 	AddFlag(uploadCleanupCmd, "bool", "confirm", "y", "Don’t ask for confirmation", false)
-	AddFlag(uploadCleanupCmd, "string", "id", "", "Upload id", true)
+	AddFlag(uploadCleanupCmd, "string", "id", "", "Upload ID", true)
+	AddFlag(uploadCleanupCmd, "string", "project_id", "", "Project ID - required if the current directory does not contain a config with a project_id", false)
 	AddFlag(uploadCleanupCmd, "string", "branch", "", "Branch", false)
 	params.BindPFlags(uploadCleanupCmd.Flags())
 }

--- a/openapi-generator/cli_lang.yaml
+++ b/openapi-generator/cli_lang.yaml
@@ -2,4 +2,4 @@
 generatorName: go
 outputDir: clients/cli
 packageName: phrase
-packageVersion: 2.4.2
+packageVersion: 2.4.3


### PR DESCRIPTION
Add project_id flag for `uploads cleanup` command in cases in which there is no `.phrase.yml` config or the config does not contain a default project id