### PR TITLE
CLI: Use correct project id for upload cleanup

### DIFF
--- a/clients/cli/cmd/internal/upload_cleanup.go
+++ b/clients/cli/cmd/internal/upload_cleanup.go
@@ -73,7 +73,7 @@ func UploadCleanup(client *phrase.APIClient, cmd *UploadCleanupCommand) error {
 			Q:      optional.NewString(q),
 			Branch: optional.NewString(cmd.Branch),
 		}
-		affected, _, err := client.KeysApi.KeysDeleteCollection(Auth, cmd.Config.DefaultProjectID, &keysDeletelocalVarOptionals)
+		affected, _, err := client.KeysApi.KeysDeleteCollection(Auth, cmd.ProjectID, &keysDeletelocalVarOptionals)
 
 		if err != nil {
 			return err
@@ -83,7 +83,7 @@ func UploadCleanup(client *phrase.APIClient, cmd *UploadCleanupCommand) error {
 
 		keysListLocalVarOptionals.Page = optional.NewInt32(keysListLocalVarOptionals.Page.Value() + 1)
 
-		keys, _, err = client.KeysApi.KeysList(Auth, cmd.Config.DefaultProjectID, &keysListLocalVarOptionals)
+		keys, _, err = client.KeysApi.KeysList(Auth, cmd.ProjectID, &keysListLocalVarOptionals)
 		if err != nil {
 			return err
 		}

--- a/openapi-generator/cli_lang.yaml
+++ b/openapi-generator/cli_lang.yaml
@@ -2,4 +2,4 @@
 generatorName: go
 outputDir: clients/cli
 packageName: phrase
-packageVersion: 2.4.3
+packageVersion: 2.4.4


### PR DESCRIPTION
It's using the wrong project id if a manual project id is provided. Missed adding it here: https://github.com/phrase/openapi/pull/173