### PR TITLE
Fix project create by passing pointer to prompt

### DIFF
--- a/clients/cli/cmd/internal/init.go
+++ b/clients/cli/cmd/internal/init.go
@@ -216,7 +216,7 @@ func (cmd *InitCommand) newProject() error {
 	}
 
 	for {
-		err := prompt.P("Enter the name of the new project:", params.Name)
+		err := prompt.P("Enter the name of the new project:", &params.Name)
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
We need to pass a pointer to allow setting a project name