### PR TITLE
Fix uploading screenshots via CLI

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -738,30 +738,7 @@
           "teams": {
             "type": "array",
             "items": {
-              "type": "object",
-              "title": "team",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "updated_at": {
-                  "type": "string",
-                  "format": "date-time"
-                }
-              },
-              "example": {
-                "id": "2e7574e8f2372906a03110c2a7cfe671",
-                "name": "My first Team",
-                "created_at": "2020-02-25T12:17:25Z",
-                "updated_at": "2020-03-13T14:46:57Z"
-              }
+              "$ref": "#/components/schemas/team_short"
             }
           },
           "spaces": {
@@ -999,6 +976,12 @@
               "$ref": "#/components/schemas/locale_preview"
             }
           },
+          "teams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/team_short"
+            }
+          },
           "default_locale_codes": {
             "type": "array",
             "items": {
@@ -1029,32 +1012,7 @@
           "spaces": {
             "type": "array",
             "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "updated_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "projects_count": {
-                  "type": "integer"
-                }
-              }
-            }
-          },
-          "teams": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/member/properties/teams/items"
+              "$ref": "#/components/schemas/project/properties/space"
             }
           },
           "project_role": {
@@ -2642,6 +2600,32 @@
               "updated_at": "2015-01-28T09:52:53Z"
             }
           ]
+        }
+      },
+      "team_short": {
+        "type": "object",
+        "title": "team_short",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "id": "2e7574e8f2372906a03110c2a7cfe671",
+          "name": "My first Team",
+          "created_at": "2020-02-25T12:17:25Z",
+          "updated_at": "2020-03-13T14:46:57Z"
         }
       },
       "job": {
@@ -15262,13 +15246,13 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase screenshots create \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"name\":\"\"A screenshot name\"\", \"description\":\"\"A screenshot description\"\", \"filename\":\"/path/to/my/screenshot.png\"}' \\\n--access_token <token>"
+            "source": "phrase screenshots create \\\n--project_id <project_id> \\\n--branch \"my-feature-branch\" --name \"A screenshot name\" --description \"A screenshot description\" --filename \"/path/to/my/screenshot.png\" \\\n--access_token <token>"
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
-            "application/json": {
+            "multipart/form-data": {
               "schema": {
                 "type": "object",
                 "title": "screenshot/create/parameters",

--- a/openapi-generator/go_lang.yaml
+++ b/openapi-generator/go_lang.yaml
@@ -2,7 +2,7 @@
 generatorName: go
 outputDir: clients/go
 packageName: phrase
-packageVersion: 2.5.1
+packageVersion: 2.5.2
 gitUserId: phrase
 gitRepoId: phrase-go
 httpUserAgent: Phrase go

--- a/openapi-generator/templates/cli/api.handlebars
+++ b/openapi-generator/templates/cli/api.handlebars
@@ -49,29 +49,59 @@ func init{{{nickname}}}() {
 			if Config.Credentials.TFA && Config.Credentials.TFAToken != "" {
 				localVarOptionals.XPhraseAppOTP = optional.NewString(Config.Credentials.TFAToken)
 			}{{/hasOptionalParams}}
-			{{#allParams}}{{^required}}{{#isPrimitiveType}}if params.IsSet(helpers.ToSnakeCase("{{{paramName}}}")) {
-			{{#startsWith paramName "fileFormat"}}	localVarOptionals.{{{vendorExtensions.x-export-param-name}}} = {{#required}}params.Get{{{vendorExtensions.x-optional-data-type}}}(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}")){{/required}}{{^required}}optional.New{{{vendorExtensions.x-optional-data-type}}}(params.Get{{{vendorExtensions.x-optional-data-type}}}(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}"))){{/required}}{{else}}{{#startsWith paramName "file"}}	file, err := os.Open(params.GetString(helpers.ToSnakeCase("file")))
-				localVarOptionals.File = optional.NewInterface(file)
 
-				if err != nil {
-					HandleError(err)
-				}{{else}}	localVarOptionals.{{{vendorExtensions.x-export-param-name}}} = {{#required}}params.Get{{{vendorExtensions.x-optional-data-type}}}(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}")){{/required}}{{^required}}optional.New{{{vendorExtensions.x-optional-data-type}}}(params.Get{{{vendorExtensions.x-optional-data-type}}}(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}"))){{/required}}{{/startsWith}}{{/startsWith}}
-			}{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isModel}}if params.IsSet(helpers.ToSnakeCase("{{paramName}}")) {
-				var {{paramName}} map[string]interface{}
-				if err := json.Unmarshal([]byte(params.GetString(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}"))), &{{paramName}}); err != nil {
-					HandleError(err)
-				}
-				localVarOptionals.{{{vendorExtensions.x-export-param-name}}} = optional.NewInterface({{paramName}})
-			}{{/isModel}}{{/isPrimitiveType}}{{/required}}
-			{{/allParams}}
-			{{#allParams}}{{#required}}{{#isPrimitiveType}}{{paramName}} := params.Get{{{capitalizeFirst dataType}}}(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}")){{/isPrimitiveType}}
-			{{^isPrimitiveType}}{{#isModel}}{{paramName}} := api.{{{dataType}}}{}
-			if err := json.Unmarshal([]byte(params.GetString("data")), &{{paramName}}); err != nil {
-				HandleError(err)
-			}
-			if Config.Debug {
-				fmt.Printf("%+v\n", {{paramName}})
-			}{{/isModel}}{{/isPrimitiveType}}{{/required}}{{/allParams}}
+
+			{{#allParams~}}
+				{{#required~}}
+					{{#isPrimitiveType~}}
+						{{paramName}} := params.Get{{{capitalizeFirst dataType}}}(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}"))
+					{{else~}}
+						{{#isModel~}}
+							{{paramName}} := api.{{{dataType}}}{}
+							if err := json.Unmarshal([]byte(params.GetString("data")), &{{paramName}}); err != nil {
+								HandleError(err)
+							}
+							if Config.Debug {
+								fmt.Printf("%+v\n", {{paramName}})
+							}
+						{{else~}}
+							if params.IsSet(helpers.ToSnakeCase("{{paramName}}")) {
+								var {{paramName}} map[string]interface{}
+								if err := json.Unmarshal([]byte(params.GetString(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}"))),
+								&{{paramName}}); err != nil {
+									HandleError(err)
+							}
+							localVarOptionals.{{{vendorExtensions.x-export-param-name}}} = optional.NewInterface({{paramName}})
+						{{/isModel~}}
+					{{/isPrimitiveType~}}
+				{{else~}}
+					{{#if (or (eq paramName "file") (eq paramName "filename"))~}}
+						if params.IsSet(helpers.ToSnakeCase("{{paramName}}")) {
+							file, err := os.Open(params.GetString(helpers.ToSnakeCase("{{paramName}}")))
+							localVarOptionals.{{{vendorExtensions.x-export-param-name}}} = optional.NewInterface(file)
+							if err != nil {
+								HandleError(err)
+							}
+						}
+					{{else~}}
+						{{#isPrimitiveType~}}
+							if params.IsSet(helpers.ToSnakeCase("{{paramName}}")) {
+								localVarOptionals.{{{vendorExtensions.x-export-param-name}}} = optional.New{{{vendorExtensions.x-optional-data-type}}}(params.Get{{{vendorExtensions.x-optional-data-type}}}(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}")))
+							}
+						{{else~}}
+							var {{paramName}} map[string]interface{}
+							if err := json.Unmarshal([]byte(params.GetString("data")), &{{paramName}}); err != nil {
+								HandleError(err)
+							}
+
+							if Config.Debug {
+								fmt.Printf("%+v\n", {{paramName}})
+							}
+						{{/isPrimitiveType~}}
+					{{/if}}
+				{{/required~}}
+			{{/allParams~}}
+
 			data, api_response, err := client.{{classname}}.{{{nickname}}}(auth{{#hasParams}}, {{/hasParams}}{{#allParams}}{{#required}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}&localVarOptionals{{/hasOptionalParams}})
 
 			if err != nil {

--- a/paths/screenshots/create.yaml
+++ b/paths/screenshots/create.yaml
@@ -41,12 +41,12 @@ x-code-samples:
   source: |-
     phrase screenshots create \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "name":""A screenshot name"", "description":""A screenshot description"", "filename":"/path/to/my/screenshot.png"}' \
+    --branch "my-feature-branch" --name "A screenshot name" --description "A screenshot description" --filename "/path/to/my/screenshot.png" \
     --access_token <token>
 requestBody:
   required: true
   content:
-    application/json:
+    multipart/form-data:
       schema:
         type: object
         title: screenshot/create/parameters


### PR DESCRIPTION
The templates for the CLI did not handle cases correctly in which a parameter starts with `file` like `filename` or `fileencoding`. Now files should be opened and non-file types treated correctly as well. In addition, changing the screenshots content-type to `multipart/form-data` 