### PR TITLE
Bump phrase-cli to 2.4.8

### DIFF
--- a/clients/cli/go.mod
+++ b/clients/cli/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/magiconair/properties v1.8.4 // indirect
 	github.com/mitchellh/mapstructure v1.4.0
 	github.com/pelletier/go-toml v1.8.1 // indirect
-	github.com/phrase/phrase-go/v2 v2.5.1
+	github.com/phrase/phrase-go/v2 v2.5.2
 	github.com/spf13/afero v1.4.1 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v1.0.0

--- a/clients/cli/go.sum
+++ b/clients/cli/go.sum
@@ -218,8 +218,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
-github.com/phrase/phrase-go/v2 v2.5.1 h1:iavTLvYE47dYWaNpzeto2aPVn93l4vE8QvHNC9vC70U=
-github.com/phrase/phrase-go/v2 v2.5.1/go.mod h1:N1ou4nnB9ak8aAWOH7x25Xhzw8FmFeBRhSGq5A0CY2o=
+github.com/phrase/phrase-go/v2 v2.5.2 h1:LiNzsyS2BN6f8zBabMxadcVLbxyi+gX9EpUV5rGHOns=
+github.com/phrase/phrase-go/v2 v2.5.2/go.mod h1:N1ou4nnB9ak8aAWOH7x25Xhzw8FmFeBRhSGq5A0CY2o=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=

--- a/openapi-generator/cli_lang.yaml
+++ b/openapi-generator/cli_lang.yaml
@@ -2,4 +2,4 @@
 generatorName: go
 outputDir: clients/cli
 packageName: phrase
-packageVersion: 2.4.7
+packageVersion: 2.4.8


### PR DESCRIPTION
Release new CLI version with fixes from https://github.com/phrase/openapi/pull/199