### PR TITLE
python: support Python 3 for downloading locales

### DIFF
--- a/openapi-generator/python_lang.yaml
+++ b/openapi-generator/python_lang.yaml
@@ -3,7 +3,7 @@ generatorName: python
 outputDir: clients/python
 packageName: phrase_api
 projectName: phrase-api
-packageVersion: 1.4.0
+packageVersion: 1.4.1
 packageUrl: "https://github.com/phrase/phrase-python"
 gitUserId: phrase
 gitRepoId: phrase-python

--- a/openapi-generator/templates/python/api_client.mustache
+++ b/openapi-generator/templates/python/api_client.mustache
@@ -572,8 +572,13 @@ class ApiClient(object):
                                  content_disposition).group(1)
             path = os.path.join(os.path.dirname(path), filename)
 
-        with open(path, "wb") as f:
-            f.write(response.data)
+        # In Python 3 response.data is a string
+        if six.PY3:
+            with open(path, "w") as f:
+                f.write(response.data)
+        else:
+            with open(path, "wb") as f:
+                f.write(response.data)
 
         return path
 


### PR DESCRIPTION
Support Python 3 when writing locale files.

Fix from https://github.com/phrase/phrase-python/pull/4