### PR TITLE
CLI: Fix passing in host as CLI argument

### DIFF
--- a/clients/cli/cmd/init.go
+++ b/clients/cli/cmd/init.go
@@ -15,7 +15,9 @@ func initInit() {
 		Short: "Configure your Phrase client",
 		Long:  "",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdInit := commands.InitCommand{}
+			cmdInit := commands.InitCommand{
+				Config: *Config,
+			}
 			err := cmdInit.Run()
 			if err != nil {
 				HandleError(err)

--- a/clients/cli/cmd/internal/init.go
+++ b/clients/cli/cmd/internal/init.go
@@ -87,11 +87,16 @@ type InitCommand struct {
 
 func (cmd *InitCommand) Run() error {
 	// keep host if specified in config file or as command line parameter
-	if cmd.Config.Credentials.Host != "" {
-		cmd.YAML.Host = cmd.Config.Credentials.Host
+	if cmd.Config.Host != "" {
+		cmd.YAML.Host = cmd.Config.Host
 	}
 
-	step := StepAskForToken
+	step := StepSelectProject
+	if cmd.Config.Token == "" {
+		step = StepAskForToken
+	} else {
+		cmd.setToken(cmd.Config.Token)
+	}
 
 	for step != StepFinished {
 		err := stepFuncs[step](cmd)
@@ -133,14 +138,16 @@ func (cmd *InitCommand) askForToken() error {
 		break
 	}
 
-	cmd.YAML.AccessToken = token
+	cmd.setToken(token)
+	return nil
+}
 
+func (cmd *InitCommand) setToken(token string) {
+	cmd.YAML.AccessToken = token
 	cmd.Credentials.Token = token
 	Config = &cmd.Config
 	client := newClient()
-
 	cmd.client = client
-	return nil
 }
 
 func (cmd *InitCommand) selectProject() error {

--- a/openapi-generator/cli_lang.yaml
+++ b/openapi-generator/cli_lang.yaml
@@ -2,4 +2,4 @@
 generatorName: go
 outputDir: clients/cli
 packageName: phrase
-packageVersion: 2.5.0
+packageVersion: 2.5.1


### PR DESCRIPTION
Use `host` and `access_token` args when calling `phrase init --host <host> --access_token <token>`