### PR TITLE
Allow empty translation content to be send

### DIFF
--- a/openapi-generator/templates/go/model.mustache
+++ b/openapi-generator/templates/go/model.mustache
@@ -34,7 +34,7 @@ type {{classname}} struct {
 {{#description}}
 	// {{{description}}}
 {{/description}}
-	{{name}} {{#isNullable}}*{{/isNullable}}{{^isNullable}}{{#isBoolean}}*{{/isBoolean}}{{/isNullable}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{name}} {{#isNullable}}*{{/isNullable}}{{^isNullable}}{{#isBoolean}}*{{/isBoolean}}{{/isNullable}}{{{dataType}}} `{{#vendorExtensions.x-json-tag}}{{{.}}}{{/vendorExtensions.x-json-tag}}{{^vendorExtensions.x-json-tag}}json:"{{baseName}}{{^required}},omitempty{{/required}}"{{/vendorExtensions.x-json-tag}}{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/allVars}}
 }
 {{/isEnum}}

--- a/schemas/translation.yaml
+++ b/schemas/translation.yaml
@@ -7,6 +7,7 @@ translation:
       type: string
     content:
       type: string
+      x-json-tag: json:"content"
     unverified:
       type: boolean
     excluded:


### PR DESCRIPTION
Currently it's not possible to send an empty translation which might be important if we want to use a machine translation later.

This removes the `omitempty` option from the `content` field by providing a custom JSON options via `x-json-tag`.

I changed the template to the intent. So the tag now provides a replacement.

This is how a generated model looks like:

```
package phrase

import (
	"time"
)

// Translation struct for Translation
type Translation struct {
	Id           string        `json:"id,omitempty"`
	Content      string        `json:"content"`
	Unverified   *bool         `json:"unverified,omitempty"`
	Excluded     *bool         `json:"excluded,omitempty"`
	PluralSuffix string        `json:"plural_suffix,omitempty"`
	Key          KeyPreview    `json:"key,omitempty"`
	Locale       LocalePreview `json:"locale,omitempty"`
	Placeholders []string      `json:"placeholders,omitempty"`
	State        string        `json:"state,omitempty"`
	CreatedAt    time.Time     `json:"created_at,omitempty"`
	UpdatedAt    time.Time     `json:"updated_at,omitempty"`
}
```