### PR TITLE
Adjust branching merge strategy name

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -14476,11 +14476,11 @@
         "x-code-samples": [
           {
             "lang": "Curl",
-            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/branches/:name/merge\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X PATCH \\\n  -d '{\"strategy\":\"use_master\"}' \\\n  -H 'Content-Type: application/json'"
+            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/branches/:name/merge\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X PATCH \\\n  -d '{\"strategy\":\"use_main\"}' \\\n  -H 'Content-Type: application/json'"
           },
           {
             "lang": "CLI v2",
-            "source": "phrase branches merge \\\n--project_id <project_id> \\\n--name <name> \\\n--data '{\"strategy\":\"use_master\"}' \\\n--access_token <token>"
+            "source": "phrase branches merge \\\n--project_id <project_id> \\\n--name <name> \\\n--data '{\"strategy\":\"use_main\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -14492,9 +14492,9 @@
                 "title": "branch/merge/parameters",
                 "properties": {
                   "strategy": {
-                    "description": "strategy used for merge blocking, use_master or use_branch",
+                    "description": "strategy used for merge blocking, use_main or use_branch",
                     "type": "string",
-                    "example": "use_master"
+                    "example": "use_main"
                   }
                 }
               }

--- a/paths/branches/merge.yaml
+++ b/paths/branches/merge.yaml
@@ -30,14 +30,14 @@ x-code-samples:
     curl "https://api.phrase.com/v2/projects/:project_id/branches/:name/merge" \
       -u USERNAME_OR_ACCESS_TOKEN \
       -X PATCH \
-      -d '{"strategy":"use_master"}' \
+      -d '{"strategy":"use_main"}' \
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
     phrase branches merge \
     --project_id <project_id> \
     --name <name> \
-    --data '{"strategy":"use_master"}' \
+    --data '{"strategy":"use_main"}' \
     --access_token <token>
 requestBody:
   required: true
@@ -48,6 +48,6 @@ requestBody:
         title: branch/merge/parameters
         properties:
           strategy:
-            description: strategy used for merge blocking, use_master or use_branch
+            description: strategy used for merge blocking, use_main or use_branch
             type: string
-            example: use_master
+            example: use_main


### PR DESCRIPTION
Change strategy name from "use_master" to "use_main".

API still supports the deprecated name: https://github.com/phrase/phrase/pull/9750