### PR TITLE
Use correct id in path for teams

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -18814,7 +18814,7 @@
         }
       }
     },
-    "/accounts/{account_id}/teams/{team_id}": {
+    "/accounts/{account_id}/teams/{id}": {
       "get": {
         "summary": "Get Team",
         "description": "Show the specified Team.",

--- a/openapi-generator/go_lang.yaml
+++ b/openapi-generator/go_lang.yaml
@@ -2,7 +2,7 @@
 generatorName: go
 outputDir: clients/go
 packageName: phrase
-packageVersion: 2.6.0
+packageVersion: 2.6.1
 gitUserId: phrase
 gitRepoId: phrase-go
 httpUserAgent: Phrase Strings go

--- a/paths.yaml
+++ b/paths.yaml
@@ -472,7 +472,7 @@
     "$ref": "./paths/teams/index.yaml"
   post:
     "$ref": "./paths/teams/create.yaml"
-"/accounts/{account_id}/teams/{team_id}":
+"/accounts/{account_id}/teams/{id}":
   get:
     "$ref": "./paths/teams/show.yaml"
   patch:


### PR DESCRIPTION
Fix invalid paths, which contained `team_id`, but should just be `id` as this is the resource we're accessing

Reported in https://github.com/phrase/phrase-go/issues/10