### PR TITLE
Add x-cli-version attribute to all operations

### DIFF
--- a/paths/accounts/index.yaml
+++ b/paths/accounts/index.yaml
@@ -41,4 +41,4 @@ x-code-samples:
   source: |-
     phrase accounts list \
     --access_token <token>
-
+x-cli-version: '2.5'

--- a/paths/accounts/locales.yaml
+++ b/paths/accounts/locales.yaml
@@ -43,3 +43,4 @@ x-code-samples:
     phrase accounts locales \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/accounts/show.yaml
+++ b/paths/accounts/show.yaml
@@ -37,3 +37,4 @@ x-code-samples:
     phrase accounts show \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/authorizations/create.yaml
+++ b/paths/authorizations/create.yaml
@@ -63,3 +63,4 @@ requestBody:
             type: string
             format: date-time
             example: '2015-03-30T09:52:53Z'
+x-cli-version: '2.5'

--- a/paths/authorizations/destroy.yaml
+++ b/paths/authorizations/destroy.yaml
@@ -26,3 +26,4 @@ x-code-samples:
   source: |-
     phrase authorizations delete \
     --id <id>
+x-cli-version: '2.5'

--- a/paths/authorizations/index.yaml
+++ b/paths/authorizations/index.yaml
@@ -39,3 +39,4 @@ x-code-samples:
       -u USERNAME
 - lang: CLI v2
   source: phrase authorizations list
+x-cli-version: '2.5'

--- a/paths/authorizations/show.yaml
+++ b/paths/authorizations/show.yaml
@@ -36,3 +36,4 @@ x-code-samples:
   source: |-
     phrase authorizations show \
     --id <id>
+x-cli-version: '2.5'

--- a/paths/authorizations/update.yaml
+++ b/paths/authorizations/update.yaml
@@ -65,3 +65,4 @@ requestBody:
             type: string
             format: date-time
             example: '2015-03-30T09:52:53Z'
+x-cli-version: '2.5'

--- a/paths/bitbucket_syncs/export.yaml
+++ b/paths/bitbucket_syncs/export.yaml
@@ -53,3 +53,4 @@ requestBody:
             description: Account ID to specify the actual account the project should be created in. Required if the requesting user is a member of multiple accounts.
             type: string
             example: abcd1234
+x-cli-version: '2.5'

--- a/paths/bitbucket_syncs/import.yaml
+++ b/paths/bitbucket_syncs/import.yaml
@@ -49,3 +49,4 @@ requestBody:
             description: Account ID to specify the actual account the project should be created in. Required if the requesting user is a member of multiple accounts.
             type: string
             example: abcd1234
+x-cli-version: '2.5'

--- a/paths/bitbucket_syncs/index.yaml
+++ b/paths/bitbucket_syncs/index.yaml
@@ -46,3 +46,4 @@ x-code-samples:
     phrase bitbucket_sync list \
     --account_id abcd1234 \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/blacklisted_keys/create.yaml
+++ b/paths/blacklisted_keys/create.yaml
@@ -53,3 +53,4 @@ requestBody:
             description: Blocked key name
             type: string
             example: date.formats.*
+x-cli-version: '2.5'

--- a/paths/blacklisted_keys/destroy.yaml
+++ b/paths/blacklisted_keys/destroy.yaml
@@ -29,3 +29,4 @@ x-code-samples:
     --project_id <project_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/blacklisted_keys/index.yaml
+++ b/paths/blacklisted_keys/index.yaml
@@ -49,3 +49,4 @@ x-code-samples:
     phrase blacklisted_keys list \
     --project_id <project_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/blacklisted_keys/show.yaml
+++ b/paths/blacklisted_keys/show.yaml
@@ -39,3 +39,4 @@ x-code-samples:
     --project_id <project_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/blacklisted_keys/update.yaml
+++ b/paths/blacklisted_keys/update.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: Blocked key name
             type: string
             example: date.formats.*
+x-cli-version: '2.5'

--- a/paths/branches/compare.yaml
+++ b/paths/branches/compare.yaml
@@ -42,3 +42,4 @@ x-code-samples:
     --name <name> \
     --name my-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/branches/create.yaml
+++ b/paths/branches/create.yaml
@@ -53,3 +53,4 @@ requestBody:
             description: Name of the branch
             type: string
             example: my-branch
+x-cli-version: '2.5'

--- a/paths/branches/destroy.yaml
+++ b/paths/branches/destroy.yaml
@@ -29,3 +29,4 @@ x-code-samples:
     --project_id <project_id> \
     --name <name> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/branches/index.yaml
+++ b/paths/branches/index.yaml
@@ -43,3 +43,4 @@ x-code-samples:
     phrase branches list \
     --project_id <project_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/branches/merge.yaml
+++ b/paths/branches/merge.yaml
@@ -51,3 +51,4 @@ requestBody:
             description: strategy used for merge blocking, use_main or use_branch
             type: string
             example: use_main
+x-cli-version: '2.5'

--- a/paths/branches/show.yaml
+++ b/paths/branches/show.yaml
@@ -39,3 +39,4 @@ x-code-samples:
     --project_id <project_id> \
     --name <name> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/branches/update.yaml
+++ b/paths/branches/update.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: Name of the branch
             type: string
             example: my-branch
+x-cli-version: '2.5'

--- a/paths/comments/check_if_read.yaml
+++ b/paths/comments/check_if_read.yaml
@@ -37,3 +37,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/comments/create.yaml
+++ b/paths/comments/create.yaml
@@ -59,3 +59,4 @@ requestBody:
             description: Comment message
             type: string
             example: Some message...
+x-cli-version: '2.5'

--- a/paths/comments/destroy.yaml
+++ b/paths/comments/destroy.yaml
@@ -40,3 +40,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/comments/index.yaml
+++ b/paths/comments/index.yaml
@@ -52,3 +52,4 @@ x-code-samples:
     --key_id <key_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/comments/mark_as_read.yaml
+++ b/paths/comments/mark_as_read.yaml
@@ -46,3 +46,4 @@ requestBody:
             description: specify the branch to use
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/comments/show.yaml
+++ b/paths/comments/show.yaml
@@ -48,3 +48,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/comments/unmark_as_read.yaml
+++ b/paths/comments/unmark_as_read.yaml
@@ -40,3 +40,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/comments/update.yaml
+++ b/paths/comments/update.yaml
@@ -61,3 +61,4 @@ requestBody:
             description: Comment message
             type: string
             example: Some message...
+x-cli-version: '2.5'

--- a/paths/distributions/create.yaml
+++ b/paths/distributions/create.yaml
@@ -95,3 +95,4 @@ requestBody:
             description: Use last reviewed instead of latest translation in a project
             type: boolean
             example: true
+x-cli-version: '2.5'

--- a/paths/distributions/destroy.yaml
+++ b/paths/distributions/destroy.yaml
@@ -29,3 +29,4 @@ x-code-samples:
     --account_id <account_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/distributions/index.yaml
+++ b/paths/distributions/index.yaml
@@ -43,3 +43,4 @@ x-code-samples:
     phrase distributions list \
     --account_id <account_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/distributions/show.yaml
+++ b/paths/distributions/show.yaml
@@ -39,3 +39,4 @@ x-code-samples:
     --account_id <account_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/distributions/update.yaml
+++ b/paths/distributions/update.yaml
@@ -97,3 +97,4 @@ requestBody:
             description: Use last reviewed instead of latest translation in a project
             type: boolean
             example: true
+x-cli-version: '2.5'

--- a/paths/documents/destroy.yaml
+++ b/paths/documents/destroy.yaml
@@ -30,3 +30,4 @@ x-code-samples:
     --project_id <project_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/documents/index.yaml
+++ b/paths/documents/index.yaml
@@ -43,3 +43,4 @@ x-code-samples:
     phrase documents list \
     --project_id <project_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/formats/index.yaml
+++ b/paths/formats/index.yaml
@@ -37,3 +37,4 @@ x-code-samples:
   source: |-
     phrase formats list \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/github_syncs/export.yaml
+++ b/paths/github_syncs/export.yaml
@@ -33,8 +33,7 @@ x-code-samples:
       -d '{"project_id":"abcd1234"}' \
       -H 'Content-Type: application/json'
 - lang: CLI v2
-  source: |-
-    UNAVAILABLE
+  source: UNAVAILABLE
 requestBody:
   required: true
   content:
@@ -47,3 +46,4 @@ requestBody:
             description: Project ID to specify the actual project the GitHub export should be triggered in.
             type: string
             example: abcd1234
+x-cli-version: '2.5'

--- a/paths/github_syncs/import.yaml
+++ b/paths/github_syncs/import.yaml
@@ -33,8 +33,7 @@ x-code-samples:
       -d '{"project_id":"abcd1234"}' \
       -H 'Content-Type: application/json'
 - lang: CLI v2
-  source: |-
-    UNAVAILABLE
+  source: UNAVAILABLE
 requestBody:
   required: true
   content:
@@ -47,3 +46,4 @@ requestBody:
             description: Project ID to specify the actual project the GitHub import should be triggered in.
             type: string
             example: abcd1234
+x-cli-version: '2.5'

--- a/paths/gitlab_syncs/destroy.yaml
+++ b/paths/gitlab_syncs/destroy.yaml
@@ -36,3 +36,4 @@ x-code-samples:
     --id <id> \
     --account_id abcd1234 \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/gitlab_syncs/export.yaml
+++ b/paths/gitlab_syncs/export.yaml
@@ -53,3 +53,4 @@ requestBody:
             description: Account ID to specify the actual account the GitLab Sync should be created in. Required if the requesting user is a member of multiple accounts.
             type: string
             example: abcd1234
+x-cli-version: '2.5'

--- a/paths/gitlab_syncs/history.yaml
+++ b/paths/gitlab_syncs/history.yaml
@@ -50,3 +50,4 @@ x-code-samples:
     --gitlab_sync_id <gitlab_sync_id> \
     --account_id abcd1234 \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/gitlab_syncs/import.yaml
+++ b/paths/gitlab_syncs/import.yaml
@@ -57,3 +57,4 @@ requestBody:
             description: Account ID to specify the actual account the GitLab Sync should be created in. Required if the requesting user is a member of multiple accounts.
             type: string
             example: abcd1234
+x-cli-version: '2.5'

--- a/paths/gitlab_syncs/index.yaml
+++ b/paths/gitlab_syncs/index.yaml
@@ -46,3 +46,4 @@ x-code-samples:
     phrase gitlab_syncs list \
     --account_id abcd1234 \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/gitlab_syncs/show.yaml
+++ b/paths/gitlab_syncs/show.yaml
@@ -44,3 +44,4 @@ x-code-samples:
     --id <id> \
     --account_id abcd1234 \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/gitlab_syncs/update.yaml
+++ b/paths/gitlab_syncs/update.yaml
@@ -65,3 +65,4 @@ x-code-samples:
     --id <id> \
     --data '{"account_id":"abcd1234", "phrase_project_code":"3456abcd", "gitlab_project_id":"12345", "gitlab_branch_name":"feature-development"}' \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/glossaries/create.yaml
+++ b/paths/glossaries/create.yaml
@@ -1,6 +1,6 @@
 ---
 summary: Create a term base
-description: "Create a new term base (previously: glossary)."
+description: 'Create a new term base (previously: glossary).'
 operationId: glossary/create
 tags:
 - Glossaries
@@ -65,3 +65,4 @@ requestBody:
             example:
             - abcd1234abcd1234abcd1234
             - abcd1234abcd1234abcd1235
+x-cli-version: '2.5'

--- a/paths/glossaries/destroy.yaml
+++ b/paths/glossaries/destroy.yaml
@@ -1,6 +1,6 @@
 ---
 summary: Delete a term base
-description: "Delete an existing term base (previously: glossary)."
+description: 'Delete an existing term base (previously: glossary).'
 operationId: glossary/delete
 tags:
 - Glossaries
@@ -29,3 +29,4 @@ x-code-samples:
     --account_id <account_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/glossaries/index.yaml
+++ b/paths/glossaries/index.yaml
@@ -1,6 +1,6 @@
 ---
 summary: List term bases
-description: "List all term bases (previously: glossaries) the current user has access to."
+description: 'List all term bases (previously: glossaries) the current user has access to.'
 operationId: glossaries/list
 tags:
 - Glossaries
@@ -43,3 +43,4 @@ x-code-samples:
     phrase glossaries list \
     --account_id <account_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/glossaries/show.yaml
+++ b/paths/glossaries/show.yaml
@@ -1,6 +1,6 @@
 ---
 summary: Get a single term base
-description: "Get details on a single term base (previously: glossary)."
+description: 'Get details on a single term base (previously: glossary).'
 operationId: glossary/show
 tags:
 - Glossaries
@@ -39,3 +39,4 @@ x-code-samples:
     --account_id <account_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/glossaries/update.yaml
+++ b/paths/glossaries/update.yaml
@@ -1,6 +1,6 @@
 ---
 summary: Update a term base
-description: "Update an existing term base (previously: glossary)."
+description: 'Update an existing term base (previously: glossary).'
 operationId: glossary/update
 tags:
 - Glossaries
@@ -67,3 +67,4 @@ requestBody:
             example:
             - abcd1234abcd1234abcd1234
             - abcd1234abcd1234abcd1235
+x-cli-version: '2.5'

--- a/paths/glossary_term_translations/create.yaml
+++ b/paths/glossary_term_translations/create.yaml
@@ -1,6 +1,6 @@
 ---
 summary: Create a translation for a term
-description: "Create a new translation for a term in a term base (previously: glossary)."
+description: 'Create a new translation for a term in a term base (previously: glossary).'
 operationId: glossary_term_translation/create
 tags:
 - Glossary Term Translations
@@ -61,3 +61,4 @@ requestBody:
             description: The content of the translation
             type: string
             example: My translated term
+x-cli-version: '2.5'

--- a/paths/glossary_term_translations/destroy.yaml
+++ b/paths/glossary_term_translations/destroy.yaml
@@ -1,6 +1,6 @@
 ---
 summary: Delete a translation for a term
-description: "Delete an existing translation of a term in a term base (previously: glossary)."
+description: 'Delete an existing translation of a term in a term base (previously: glossary).'
 operationId: glossary_term_translation/delete
 tags:
 - Glossary Term Translations
@@ -33,3 +33,4 @@ x-code-samples:
     --term_id <term_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/glossary_term_translations/update.yaml
+++ b/paths/glossary_term_translations/update.yaml
@@ -1,6 +1,6 @@
 ---
 summary: Update a translation for a term
-description: "Update an existing translation for a term in a term base (previously: glossary)."
+description: 'Update an existing translation for a term in a term base (previously: glossary).'
 operationId: glossary_term_translation/update
 tags:
 - Glossary Term Translations
@@ -63,3 +63,4 @@ requestBody:
             description: The content of the translation
             type: string
             example: My translated term
+x-cli-version: '2.5'

--- a/paths/glossary_terms/create.yaml
+++ b/paths/glossary_terms/create.yaml
@@ -1,6 +1,6 @@
 ---
 summary: Create a term
-description: "Create a new term in a term base (previously: glossary)."
+description: 'Create a new term in a term base (previously: glossary).'
 operationId: glossary_term/create
 tags:
 - Glossary Terms
@@ -67,3 +67,4 @@ requestBody:
             description: Indicates whether the term is case sensitive
             type: boolean
             example: true
+x-cli-version: '2.5'

--- a/paths/glossary_terms/destroy.yaml
+++ b/paths/glossary_terms/destroy.yaml
@@ -1,6 +1,6 @@
 ---
 summary: Delete a term
-description: "Delete an existing term in a term base (previously: glossary)."
+description: 'Delete an existing term in a term base (previously: glossary).'
 operationId: glossary_term/delete
 tags:
 - Glossary Terms
@@ -31,3 +31,4 @@ x-code-samples:
     --glossary_id <glossary_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/glossary_terms/index.yaml
+++ b/paths/glossary_terms/index.yaml
@@ -1,6 +1,6 @@
 ---
 summary: List terms
-description: "List all terms in term bases (previously: glossary) that the current user has access to."
+description: 'List all terms in term bases (previously: glossary) that the current user has access to.'
 operationId: glossary_terms/list
 tags:
 - Glossary Terms
@@ -45,3 +45,4 @@ x-code-samples:
     --account_id <account_id> \
     --glossary_id <glossary_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/glossary_terms/show.yaml
+++ b/paths/glossary_terms/show.yaml
@@ -1,6 +1,6 @@
 ---
 summary: Get a single term
-description: "Get details for a single term in the term base (previously: glossary)."
+description: 'Get details for a single term in the term base (previously: glossary).'
 operationId: glossary_term/show
 tags:
 - Glossary Terms
@@ -41,3 +41,4 @@ x-code-samples:
     --glossary_id <glossary_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/glossary_terms/update.yaml
+++ b/paths/glossary_terms/update.yaml
@@ -1,6 +1,6 @@
 ---
 summary: Update a term
-description: "Update an existing term in a term base (previously: glossary)."
+description: 'Update an existing term in a term base (previously: glossary).'
 operationId: glossary_term/update
 tags:
 - Glossary Terms
@@ -69,3 +69,4 @@ requestBody:
             description: Indicates whether the term is case sensitive
             type: boolean
             example: true
+x-cli-version: '2.5'

--- a/paths/icu/skeleton.yaml
+++ b/paths/icu/skeleton.yaml
@@ -60,7 +60,7 @@ requestBody:
               type: string
               example: en
             example:
-              - en
+            - en
           keep_content:
             description: Keep the content and add missing plural forms for each locale
             type: boolean
@@ -69,4 +69,4 @@ requestBody:
             description: Indicates whether the zero form should be included or excluded in the returned skeletons
             type: boolean
             example:
-
+x-cli-version: '2.5'

--- a/paths/invitations/create.yaml
+++ b/paths/invitations/create.yaml
@@ -103,3 +103,4 @@ requestBody:
             example:
               create_upload: true
               review_translations: true
+x-cli-version: '2.5'

--- a/paths/invitations/destroy.yaml
+++ b/paths/invitations/destroy.yaml
@@ -33,3 +33,4 @@ x-code-samples:
     --account_id <account_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/invitations/index.yaml
+++ b/paths/invitations/index.yaml
@@ -47,3 +47,4 @@ x-code-samples:
     phrase invitations list \
     --account_id <account_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/invitations/resend.yaml
+++ b/paths/invitations/resend.yaml
@@ -44,3 +44,4 @@ x-code-samples:
     --account_id <account_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/invitations/show.yaml
+++ b/paths/invitations/show.yaml
@@ -43,3 +43,4 @@ x-code-samples:
     --account_id <account_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/invitations/update.yaml
+++ b/paths/invitations/update.yaml
@@ -98,3 +98,4 @@ requestBody:
               type: string
             example:
               create_upload: true
+x-cli-version: '2.5'

--- a/paths/invitations/update_settings.yaml
+++ b/paths/invitations/update_settings.yaml
@@ -60,10 +60,11 @@ requestBody:
             type: string
             example: Developer
           locale_ids:
-            description: 'List of locale ids the user has access to.'
+            description: List of locale ids the user has access to.
             type: array
             items:
               type: string
             example:
             - abcd1234abcd1234abcd1234
             - abcd1234abcd1234abcd1235
+x-cli-version: '2.5'

--- a/paths/job_comments/create.yaml
+++ b/paths/job_comments/create.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: Job comment message
             type: string
             example: Some message...
+x-cli-version: '2.5'

--- a/paths/job_comments/destroy.yaml
+++ b/paths/job_comments/destroy.yaml
@@ -40,3 +40,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/job_comments/index.yaml
+++ b/paths/job_comments/index.yaml
@@ -50,3 +50,4 @@ x-code-samples:
     --job_id <key_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/job_comments/show.yaml
+++ b/paths/job_comments/show.yaml
@@ -48,3 +48,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/job_comments/update.yaml
+++ b/paths/job_comments/update.yaml
@@ -57,3 +57,4 @@ requestBody:
             description: Comment message
             type: string
             example: Some message...
+x-cli-version: '2.5'

--- a/paths/job_locales/complete.yaml
+++ b/paths/job_locales/complete.yaml
@@ -57,3 +57,4 @@ requestBody:
             description: specify the branch to use
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/job_locales/complete_review.yaml
+++ b/paths/job_locales/complete_review.yaml
@@ -57,3 +57,4 @@ requestBody:
             description: specify the branch to use
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/job_locales/create.yaml
+++ b/paths/job_locales/create.yaml
@@ -73,3 +73,4 @@ requestBody:
               type: string
             example:
             - abcd1234cdef1234abcd1234cdef1234
+x-cli-version: '2.5'

--- a/paths/job_locales/destroy.yaml
+++ b/paths/job_locales/destroy.yaml
@@ -40,3 +40,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/job_locales/index.yaml
+++ b/paths/job_locales/index.yaml
@@ -52,3 +52,4 @@ x-code-samples:
     --job_id <job_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/job_locales/reopen.yaml
+++ b/paths/job_locales/reopen.yaml
@@ -57,3 +57,4 @@ requestBody:
             description: specify the branch to use
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/job_locales/show.yaml
+++ b/paths/job_locales/show.yaml
@@ -48,3 +48,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/job_locales/update.yaml
+++ b/paths/job_locales/update.yaml
@@ -75,3 +75,4 @@ requestBody:
               type: string
             example:
             - abcd1234cdef1234abcd1234cdef1234
+x-cli-version: '2.5'

--- a/paths/job_template_locales/create.yaml
+++ b/paths/job_template_locales/create.yaml
@@ -74,4 +74,5 @@ requestBody:
             example:
             - abcd1234cdef1234abcd1234cdef1234
         required:
-          - locale_id
+        - locale_id
+x-cli-version: '2.5'

--- a/paths/job_template_locales/destroy.yaml
+++ b/paths/job_template_locales/destroy.yaml
@@ -40,3 +40,4 @@ x-code-samples:
     --job_template_locale_id <job_template_locale_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/job_template_locales/index.yaml
+++ b/paths/job_template_locales/index.yaml
@@ -52,3 +52,4 @@ x-code-samples:
     --job_template_id <job_template_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/job_template_locales/show.yaml
+++ b/paths/job_template_locales/show.yaml
@@ -48,3 +48,4 @@ x-code-samples:
     --job_template_locale_id <job_template_locale_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/job_template_locales/update.yaml
+++ b/paths/job_template_locales/update.yaml
@@ -76,4 +76,5 @@ requestBody:
             example:
             - abcd1234cdef1234abcd1234cdef1234
         required:
-          - locale_id
+        - locale_id
+x-cli-version: '2.5'

--- a/paths/job_templates/create.yaml
+++ b/paths/job_templates/create.yaml
@@ -62,4 +62,5 @@ requestBody:
             type: string
             example: text
         required:
-          - name
+        - name
+x-cli-version: '2.5'

--- a/paths/job_templates/destroy.yaml
+++ b/paths/job_templates/destroy.yaml
@@ -38,3 +38,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/job_templates/index.yaml
+++ b/paths/job_templates/index.yaml
@@ -50,3 +50,4 @@ x-code-samples:
     --project_id <project_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/job_templates/show.yaml
+++ b/paths/job_templates/show.yaml
@@ -46,3 +46,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/job_templates/update.yaml
+++ b/paths/job_templates/update.yaml
@@ -64,4 +64,5 @@ requestBody:
             type: string
             example: text
         required:
-          - name
+        - name
+x-cli-version: '2.5'

--- a/paths/jobs/add_keys.yaml
+++ b/paths/jobs/add_keys.yaml
@@ -62,3 +62,4 @@ requestBody:
               type: string
             example:
             - abcd1234cdef1234abcd1234cdef1234
+x-cli-version: '2.5'

--- a/paths/jobs/complete.yaml
+++ b/paths/jobs/complete.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: specify the branch to use
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/jobs/create.yaml
+++ b/paths/jobs/create.yaml
@@ -73,7 +73,7 @@ requestBody:
           ticket_url:
             description: URL to a ticket for this job (e.g. Jira, Trello)
             type: string
-            example: 'https://example.atlassian.net/browse/FOO'
+            example: https://example.atlassian.net/browse/FOO
           tags:
             description: tags of keys that should be included within the job
             type: array
@@ -92,3 +92,4 @@ requestBody:
             description: id of a job template you would like to model the created job after. Any manually added parameters will take preference over template attributes.
             type: string
             example: abcd1234cdef1234abcd1234cdef1234
+x-cli-version: '2.5'

--- a/paths/jobs/destroy.yaml
+++ b/paths/jobs/destroy.yaml
@@ -38,3 +38,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/jobs/index.yaml
+++ b/paths/jobs/index.yaml
@@ -71,3 +71,4 @@ x-code-samples:
     --assigned_to abcd1234cdef1234abcd1234cdef1234 \
     --state completed \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/jobs/index_account.yaml
+++ b/paths/jobs/index_account.yaml
@@ -64,3 +64,4 @@ x-code-samples:
     --assigned_to abcd1234cdef1234abcd1234cdef1234 \
     --state completed \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/jobs/lock.yaml
+++ b/paths/jobs/lock.yaml
@@ -38,3 +38,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/jobs/remove_keys.yaml
+++ b/paths/jobs/remove_keys.yaml
@@ -48,3 +48,4 @@ x-code-samples:
     --branch my-feature-branch \
     --translation_key_ids "abcd1234cdef1234abcd1234cdef1234" \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/jobs/reopen.yaml
+++ b/paths/jobs/reopen.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: specify the branch to use
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/jobs/show.yaml
+++ b/paths/jobs/show.yaml
@@ -46,3 +46,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/jobs/start.yaml
+++ b/paths/jobs/start.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: specify the branch to use
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/jobs/unlock.yaml
+++ b/paths/jobs/unlock.yaml
@@ -38,3 +38,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/jobs/update.yaml
+++ b/paths/jobs/update.yaml
@@ -71,4 +71,5 @@ requestBody:
           ticket_url:
             description: URL to a ticket for this job (e.g. Jira, Trello)
             type: string
-            example: 'https://example.atlassian.net/browse/FOO'
+            example: https://example.atlassian.net/browse/FOO
+x-cli-version: '2.5'

--- a/paths/keys/create.yaml
+++ b/paths/keys/create.yaml
@@ -122,3 +122,4 @@ requestBody:
             description: NSStringLocalizedFormatKey attribute. Used in .stringsdict format.
             type: string
             example:
+x-cli-version: '2.5'

--- a/paths/keys/destroy-collection.yaml
+++ b/paths/keys/destroy-collection.yaml
@@ -72,3 +72,4 @@ x-code-samples:
     --query 'mykey* translated:true' \
     --locale_id abcd1234abcd1234abcd1234abcd1234 \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/keys/destroy.yaml
+++ b/paths/keys/destroy.yaml
@@ -38,3 +38,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/keys/exclude.yaml
+++ b/paths/keys/exclude.yaml
@@ -76,3 +76,4 @@ requestBody:
             description: Tag or comma-separated list of tags to add to the matching collection of keys
             type: string
             example: landing-page,release-1.2
+x-cli-version: '2.5'

--- a/paths/keys/include.yaml
+++ b/paths/keys/include.yaml
@@ -76,3 +76,4 @@ requestBody:
             description: Tag or comma-separated list of tags to add to the matching collection of keys
             type: string
             example: landing-page,release-1.2
+x-cli-version: '2.5'

--- a/paths/keys/index.yaml
+++ b/paths/keys/index.yaml
@@ -89,3 +89,4 @@ x-code-samples:
     --query 'mykey* translated:true' \
     --locale_id abcd1234abcd1234abcd1234abcd1234 \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/keys/search.yaml
+++ b/paths/keys/search.yaml
@@ -84,3 +84,4 @@ requestBody:
             description: Locale used to determine the translation state of a key when filtering for untranslated or translated keys.
             type: string
             example: abcd1234abcd1234abcd1234abcd1234
+x-cli-version: '2.5'

--- a/paths/keys/show.yaml
+++ b/paths/keys/show.yaml
@@ -46,3 +46,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/keys/tag.yaml
+++ b/paths/keys/tag.yaml
@@ -76,3 +76,4 @@ requestBody:
             description: Tag or comma-separated list of tags to add to the matching collection of keys
             type: string
             example: landing-page,release-1.2
+x-cli-version: '2.5'

--- a/paths/keys/untag.yaml
+++ b/paths/keys/untag.yaml
@@ -76,3 +76,4 @@ requestBody:
             description: Tag or comma-separated list of tags to remove from the matching collection of keys
             type: string
             example: landing-page,release-1.2
+x-cli-version: '2.5'

--- a/paths/keys/update.yaml
+++ b/paths/keys/update.yaml
@@ -120,3 +120,4 @@ requestBody:
             description: NSStringLocalizedFormatKey attribute. Used in .stringsdict format.
             type: string
             example:
+x-cli-version: '2.5'

--- a/paths/locales/create.yaml
+++ b/paths/locales/create.yaml
@@ -93,3 +93,4 @@ requestBody:
             description: If set, translations for this locale will be fetched automatically, right after creation.
             type: boolean
             example:
+x-cli-version: '2.5'

--- a/paths/locales/destroy.yaml
+++ b/paths/locales/destroy.yaml
@@ -38,3 +38,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/locales/download.yaml
+++ b/paths/locales/download.yaml
@@ -144,3 +144,4 @@ x-code-samples:
     --tags feature1,feature2 \
     --tag feature \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/locales/index.yaml
+++ b/paths/locales/index.yaml
@@ -56,3 +56,4 @@ x-code-samples:
     --project_id <project_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/locales/show.yaml
+++ b/paths/locales/show.yaml
@@ -46,3 +46,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/locales/update.yaml
+++ b/paths/locales/update.yaml
@@ -95,3 +95,4 @@ requestBody:
             description: If set, translations for this locale will be fetched automatically, right after creation.
             type: boolean
             example:
+x-cli-version: '2.5'

--- a/paths/members/destroy.yaml
+++ b/paths/members/destroy.yaml
@@ -33,3 +33,4 @@ x-code-samples:
     --account_id <account_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/members/index.yaml
+++ b/paths/members/index.yaml
@@ -47,3 +47,4 @@ x-code-samples:
     phrase members list \
     --account_id <account_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/members/show.yaml
+++ b/paths/members/show.yaml
@@ -43,3 +43,4 @@ x-code-samples:
     --account_id <account_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/members/update.yaml
+++ b/paths/members/update.yaml
@@ -3,13 +3,13 @@ summary: Update a member
 description: Update user permissions in the account. Developers and translators need <code>project_ids</code> and <code>locale_ids</code> assigned to access them. Access token scope must include <code>team.manage</code>.
 operationId: member/update
 tags:
-  - Members
+- Members
 parameters:
-  - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
-  - "$ref": "../../parameters.yaml#/account_id"
-  - "$ref": "../../parameters.yaml#/id"
+- "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
+- "$ref": "../../parameters.yaml#/account_id"
+- "$ref": "../../parameters.yaml#/id"
 responses:
-  "200":
+  '200':
     description: OK
     content:
       application/json:
@@ -22,31 +22,31 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Remaining"
       X-Rate-Limit-Reset:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
-  "400":
+  '400':
     "$ref": "../../responses.yaml#/400"
-  "401":
+  '401':
     "$ref": "../../responses.yaml#/401"
-  "403":
+  '403':
     "$ref": "../../responses.yaml#/403"
-  "404":
+  '404':
     "$ref": "../../responses.yaml#/404"
-  "429":
+  '429':
     "$ref": "../../responses.yaml#/429"
 x-code-samples:
-  - lang: Curl
-    source: |-
-      curl "https://api.phrase.com/v2/accounts/:account_id/members/:id" \
-        -u USERNAME_OR_ACCESS_TOKEN \
-        -X PATCH \
-        -d '{"role":"Developer","strategy":"set","project_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235","locale_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235","default_locale_codes":["de","en"],"space_ids":["abcd1234abcd1234abcd1234","abcd1234abcd1234abcd1235"],"permissions":{"create_upload":true,"review_translations":true}}' \
-        -H 'Content-Type: application/json'
-  - lang: CLI v2
-    source: |-
-      phrase members update \
-      --account_id <account_id> \
-      --id <id> \
-      --data '{"role":"Developer", "strategy":"set", "project_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235", "locale_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235", "default_locale_codes":["de","en"], "space_ids":["abcd1234abcd1234abcd1234","abcd1234abcd1234abcd1235"], "permissions":"{"create_upload"=>true, "review_translations"=>true}"}' \
-      --access_token <token>
+- lang: Curl
+  source: |-
+    curl "https://api.phrase.com/v2/accounts/:account_id/members/:id" \
+      -u USERNAME_OR_ACCESS_TOKEN \
+      -X PATCH \
+      -d '{"role":"Developer","strategy":"set","project_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235","locale_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235","default_locale_codes":["de","en"],"space_ids":["abcd1234abcd1234abcd1234","abcd1234abcd1234abcd1235"],"permissions":{"create_upload":true,"review_translations":true}}' \
+      -H 'Content-Type: application/json'
+- lang: CLI v2
+  source: |-
+    phrase members update \
+    --account_id <account_id> \
+    --id <id> \
+    --data '{"role":"Developer", "strategy":"set", "project_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235", "locale_ids":"abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235", "default_locale_codes":["de","en"], "space_ids":["abcd1234abcd1234abcd1234","abcd1234abcd1234abcd1235"], "permissions":"{"create_upload"=>true, "review_translations"=>true}"}' \
+    --access_token <token>
 requestBody:
   required: true
   content:
@@ -64,7 +64,7 @@ requestBody:
             type: string
             example: Developer
           project_ids:
-            description: "List of project ids the user has access to. "
+            description: 'List of project ids the user has access to. '
             type: string
             example: abcd1234abcd1234abcd1234,abcd1234abcd1234abcd1235
           locale_ids:
@@ -77,16 +77,16 @@ requestBody:
             items:
               type: string
             example:
-              - en
-              - fi
+            - en
+            - fi
           space_ids:
             description: List of spaces the user is assigned to.
             type: array
             items:
               type: string
             example:
-              - abcd1234abcd1234abcd1234
-              - abcd1234abcd1234abcd1235
+            - abcd1234abcd1234abcd1234
+            - abcd1234abcd1234abcd1235
           permissions:
             description: Additional permissions depending on member role. Available permissions are <code>create_upload</code> and <code>review_translations</code>
             type: object
@@ -95,3 +95,4 @@ requestBody:
             example:
               create_upload: true
               review_translations: true
+x-cli-version: '2.5'

--- a/paths/members/update_settings.yaml
+++ b/paths/members/update_settings.yaml
@@ -67,3 +67,4 @@ requestBody:
             example:
             - abcd1234abcd1234abcd1234
             - abcd1234abcd1234abcd1235
+x-cli-version: '2.5'

--- a/paths/notification_groups/index.yaml
+++ b/paths/notification_groups/index.yaml
@@ -41,3 +41,4 @@ x-code-samples:
   source: |-
     phrase notification_groups list \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/notification_groups/mark_all_as_read.yaml
+++ b/paths/notification_groups/mark_all_as_read.yaml
@@ -39,3 +39,4 @@ x-code-samples:
   source: |-
     phrase notification_groups mark_all_as_read \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/notification_groups/mark_as_read.yaml
+++ b/paths/notification_groups/mark_as_read.yaml
@@ -39,3 +39,4 @@ x-code-samples:
     phrase notification_groups mark_as_read \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/notifications/index.yaml
+++ b/paths/notifications/index.yaml
@@ -47,3 +47,4 @@ x-code-samples:
   source: |-
     phrase notifications list \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/notifications/mark_all_as_read.yaml
+++ b/paths/notifications/mark_all_as_read.yaml
@@ -39,3 +39,4 @@ x-code-samples:
   source: |-
     phrase notifications mark_all_as_read \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/notifications/show.yaml
+++ b/paths/notifications/show.yaml
@@ -41,3 +41,4 @@ x-code-samples:
     phrase notifications show \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/orders/confirm.yaml
+++ b/paths/orders/confirm.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: specify the branch to use
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/orders/create.yaml
+++ b/paths/orders/create.yaml
@@ -54,9 +54,9 @@ requestBody:
             type: string
             example: my-feature-branch
           name:
-            description: "the name of the order, default name is: Translation order from 'current datetime'"
+            description: 'the name of the order, default name is: Translation order from ''current datetime'''
             type: string
-            example: "Welcome message translations"
+            example: Welcome message translations
           lsp:
             description: Name of the LSP that should process this order. Can be one of gengo, textmaster.
             type: string
@@ -113,3 +113,4 @@ requestBody:
             description: Indicates whether the priority option should be ordered which decreases turnaround time by 30%. Available only for orders processed by TextMaster.
             type: boolean
             example:
+x-cli-version: '2.5'

--- a/paths/orders/destroy.yaml
+++ b/paths/orders/destroy.yaml
@@ -38,3 +38,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/orders/index.yaml
+++ b/paths/orders/index.yaml
@@ -50,3 +50,4 @@ x-code-samples:
     --project_id <project_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/orders/show.yaml
+++ b/paths/orders/show.yaml
@@ -46,3 +46,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/projects/create.yaml
+++ b/paths/projects/create.yaml
@@ -82,19 +82,19 @@ requestBody:
             type: string
             example: review
           machine_translation_enabled:
-            description: (Optional) Enable machine translation support in the project. Required for Autopilot and Smart Suggest
+            description: "(Optional) Enable machine translation support in the project. Required for Autopilot and Smart Suggest"
             type: boolean
             example: true
           enable_branching:
-            description: (Optional) Enable branching in the project
+            description: "(Optional) Enable branching in the project"
             type: boolean
             example: true
           protect_master_branch:
-            description: (Optional) Protect the master branch in project where branching is enabled
+            description: "(Optional) Protect the master branch in project where branching is enabled"
             type: boolean
             example: true
           enable_all_data_type_translation_keys_for_translators:
-            description: (Optional) Otherwise, translators are not allowed to edit translations other than strings
+            description: "(Optional) Otherwise, translators are not allowed to edit translations other than strings"
             type: boolean
             example: true
           enable_icu_message_format:
@@ -102,7 +102,7 @@ requestBody:
             type: boolean
             example: true
           zero_plural_form_enabled:
-            description: (Optional) Displays the input fields for the 'ZERO' plural form for every key as well although only some languages require the 'ZERO' explicitly.
+            description: "(Optional) Displays the input fields for the 'ZERO' plural form for every key as well although only some languages require the 'ZERO' explicitly."
             type: boolean
             example: true
           autotranslate_enabled:
@@ -110,38 +110,39 @@ requestBody:
             type: boolean
             example: true
           autotranslate_check_new_translation_keys:
-            description: (Optional) Requires autotranslate_enabled to be true
+            description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
           autotranslate_check_new_uploads:
-            description: (Optional) Requires autotranslate_enabled to be true
+            description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
           autotranslate_check_new_locales:
-            description: (Optional) Requires autotranslate_enabled to be true
+            description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
           autotranslate_mark_as_unverified:
-            description: (Optional) Requires autotranslate_enabled to be true
+            description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
           autotranslate_use_machine_translation:
-            description: (Optional) Requires autotranslate_enabled to be true
+            description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
           autotranslate_use_translation_memory:
-            description: (Optional) Requires autotranslate_enabled to be true
+            description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
           smart_suggest_enabled:
-            description: (Optional) Smart Suggest, requires machine_translation_enabled
+            description: "(Optional) Smart Suggest, requires machine_translation_enabled"
             type: boolean
             example: true
           smart_suggest_use_glossary:
-            description: (Optional) Requires smart_suggest_enabled to be true
+            description: "(Optional) Requires smart_suggest_enabled to be true"
             type: boolean
             example: true
           smart_suggest_use_machine_translation:
-            description: (Optional) Requires smart_suggest_enabled to be true
+            description: "(Optional) Requires smart_suggest_enabled to be true"
             type: boolean
             example: true
+x-cli-version: '2.5'

--- a/paths/projects/destroy.yaml
+++ b/paths/projects/destroy.yaml
@@ -27,3 +27,4 @@ x-code-samples:
     phrase projects delete \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/projects/index.yaml
+++ b/paths/projects/index.yaml
@@ -16,7 +16,7 @@ parameters:
   schema:
     type: string
 - description: Filter projects. Valid options are ["favorites"].
-  example: 'favorites'
+  example: favorites
   name: filters
   in: query
   schema:
@@ -56,3 +56,4 @@ x-code-samples:
   source: |-
     phrase projects list \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/projects/show.yaml
+++ b/paths/projects/show.yaml
@@ -37,3 +37,4 @@ x-code-samples:
     phrase projects show \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/projects/update.yaml
+++ b/paths/projects/update.yaml
@@ -55,7 +55,7 @@ requestBody:
             type: string
             example: abcd1234
           name:
-            description: (Optional) Name of the project
+            description: "(Optional) Name of the project"
             type: string
             example: My Android Project
           main_format:
@@ -63,16 +63,16 @@ requestBody:
             type: string
             example: yml
           shares_translation_memory:
-            description: (Optional) Indicates whether the project should share the account's translation memory
+            description: "(Optional) Indicates whether the project should share the account's translation memory"
             type: boolean
             example: true
           project_image:
-            description: (Optional) Image to identify the project
+            description: "(Optional) Image to identify the project"
             type: string
             format: binary
             example: "/path/to/my/project-screenshot.png"
           remove_project_image:
-            description: (Optional) Indicates whether the project image should be deleted.
+            description: "(Optional) Indicates whether the project image should be deleted."
             type: boolean
             example: false
           workflow:
@@ -80,19 +80,19 @@ requestBody:
             type: string
             example: review
           machine_translation_enabled:
-            description: (Optional) Enable machine translation support in the project. Required for Autopilot and Smart Suggest
+            description: "(Optional) Enable machine translation support in the project. Required for Autopilot and Smart Suggest"
             type: boolean
             example: true
           enable_branching:
-            description: (Optional) Enable branching in the project
+            description: "(Optional) Enable branching in the project"
             type: boolean
             example: true
           protect_master_branch:
-            description: (Optional) Protect the master branch in project where branching is enabled
+            description: "(Optional) Protect the master branch in project where branching is enabled"
             type: boolean
             example: true
           enable_all_data_type_translation_keys_for_translators:
-            description: (Optional) Otherwise, translators are not allowed to edit translations other than strings
+            description: "(Optional) Otherwise, translators are not allowed to edit translations other than strings"
             type: boolean
             example: true
           enable_icu_message_format:
@@ -100,7 +100,7 @@ requestBody:
             type: boolean
             example: true
           zero_plural_form_enabled:
-            description: (Optional) Displays the input fields for the 'ZERO' plural form for every key as well although only some languages require the 'ZERO' explicitly.
+            description: "(Optional) Displays the input fields for the 'ZERO' plural form for every key as well although only some languages require the 'ZERO' explicitly."
             type: boolean
             example: true
           autotranslate_enabled:
@@ -108,38 +108,39 @@ requestBody:
             type: boolean
             example: true
           autotranslate_check_new_translation_keys:
-            description: (Optional) Requires autotranslate_enabled to be true
+            description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
           autotranslate_check_new_uploads:
-            description: (Optional) Requires autotranslate_enabled to be true
+            description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
           autotranslate_check_new_locales:
-            description: (Optional) Requires autotranslate_enabled to be true
+            description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
           autotranslate_mark_as_unverified:
-            description: (Optional) Requires autotranslate_enabled to be true
+            description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
           autotranslate_use_machine_translation:
-            description: (Optional) Requires autotranslate_enabled to be true
+            description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
           autotranslate_use_translation_memory:
-            description: (Optional) Requires autotranslate_enabled to be true
+            description: "(Optional) Requires autotranslate_enabled to be true"
             type: boolean
             example: true
           smart_suggest_enabled:
-            description: (Optional) Smart Suggest, requires machine_translation_enabled
+            description: "(Optional) Smart Suggest, requires machine_translation_enabled"
             type: boolean
             example: true
           smart_suggest_use_glossary:
-            description: (Optional) Requires smart_suggest_enabled to be true
+            description: "(Optional) Requires smart_suggest_enabled to be true"
             type: boolean
             example: true
           smart_suggest_use_machine_translation:
-            description: (Optional) Requires smart_suggest_enabled to be true
+            description: "(Optional) Requires smart_suggest_enabled to be true"
             type: boolean
             example: true
+x-cli-version: '2.5'

--- a/paths/releases/create.yaml
+++ b/paths/releases/create.yaml
@@ -75,3 +75,4 @@ requestBody:
             description: Branch used for release
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/releases/destroy.yaml
+++ b/paths/releases/destroy.yaml
@@ -31,3 +31,4 @@ x-code-samples:
     --distribution_id <distribution_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/releases/index.yaml
+++ b/paths/releases/index.yaml
@@ -45,3 +45,4 @@ x-code-samples:
     --account_id <account_id> \
     --distribution_id <distribution_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/releases/publish.yaml
+++ b/paths/releases/publish.yaml
@@ -42,3 +42,4 @@ x-code-samples:
     --distribution_id <distribution_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/releases/show.yaml
+++ b/paths/releases/show.yaml
@@ -41,3 +41,4 @@ x-code-samples:
     --distribution_id <distribution_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/releases/update.yaml
+++ b/paths/releases/update.yaml
@@ -69,3 +69,4 @@ requestBody:
             description: Branch used for release
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/screenshot_markers/create.yaml
+++ b/paths/screenshot_markers/create.yaml
@@ -63,3 +63,4 @@ requestBody:
             description: Presentation details of the screenshot marker in JSON format.<br/><br/>Each Screenshot Marker is represented as a rectangular shaped highlight box with the name of the specified Key attached. You can specify the marker position on the screenshot (<code>x</code>-axis and <code>y</code>-axis in pixels) from the top left corner of the screenshot and the dimensions of the marker itself (<code>w</code> and <code>h</code> in pixels).
             type: string
             example: '{ "x": 100, "y": 100, "w": 100, "h": 100 }'
+x-cli-version: '2.5'

--- a/paths/screenshot_markers/destroy.yaml
+++ b/paths/screenshot_markers/destroy.yaml
@@ -38,3 +38,4 @@ x-code-samples:
     --screenshot_id <screenshot_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/screenshot_markers/index.yaml
+++ b/paths/screenshot_markers/index.yaml
@@ -52,3 +52,4 @@ x-code-samples:
     --branch my-feature-branch \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/screenshot_markers/show.yaml
+++ b/paths/screenshot_markers/show.yaml
@@ -48,3 +48,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/screenshot_markers/update.yaml
+++ b/paths/screenshot_markers/update.yaml
@@ -63,3 +63,4 @@ requestBody:
             description: Presentation details of the screenshot marker in JSON format.<br/><br/>Each Screenshot Marker is represented as a rectangular shaped highlight box with the name of the specified Key attached. You can specify the marker position on the screenshot (<code>x</code>-axis and <code>y</code>-axis in pixels) from the top left corner of the screenshot and the dimensions of the marker itself (<code>w</code> and <code>h</code> in pixels).
             type: string
             example: '{ "x": 100, "y": 100, "w": 100, "h": 100 }'
+x-cli-version: '2.5'

--- a/paths/screenshots/create.yaml
+++ b/paths/screenshots/create.yaml
@@ -68,3 +68,4 @@ requestBody:
             type: string
             format: binary
             example: "/path/to/my/screenshot.png"
+x-cli-version: '2.5'

--- a/paths/screenshots/destroy.yaml
+++ b/paths/screenshots/destroy.yaml
@@ -38,3 +38,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/screenshots/index.yaml
+++ b/paths/screenshots/index.yaml
@@ -56,3 +56,4 @@ x-code-samples:
     --project_id <project_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/screenshots/show.yaml
+++ b/paths/screenshots/show.yaml
@@ -46,3 +46,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/screenshots/update.yaml
+++ b/paths/screenshots/update.yaml
@@ -70,3 +70,4 @@ requestBody:
             type: string
             format: binary
             example: "/path/to/my/screenshot.png"
+x-cli-version: '2.5'

--- a/paths/search/in_account.yaml
+++ b/paths/search/in_account.yaml
@@ -67,3 +67,4 @@ requestBody:
             description: Number of results per page
             type: integer
             example: 25
+x-cli-version: '2.5'

--- a/paths/spaces/add_project.yaml
+++ b/paths/spaces/add_project.yaml
@@ -51,3 +51,4 @@ requestBody:
             description: Project ID to add or to the Space
             type: string
             example: a4b3c2d1
+x-cli-version: '2.5'

--- a/paths/spaces/create.yaml
+++ b/paths/spaces/create.yaml
@@ -53,3 +53,4 @@ requestBody:
             description: Name of the space
             type: string
             example: My Android Projects
+x-cli-version: '2.5'

--- a/paths/spaces/delete.yaml
+++ b/paths/spaces/delete.yaml
@@ -29,3 +29,4 @@ x-code-samples:
     --account_id <account_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/spaces/index.yaml
+++ b/paths/spaces/index.yaml
@@ -43,3 +43,4 @@ x-code-samples:
     phrase spaces list \
     --account_id <account_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/spaces/remove_project.yaml
+++ b/paths/spaces/remove_project.yaml
@@ -31,3 +31,4 @@ x-code-samples:
     --space_id <space_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/spaces/show.yaml
+++ b/paths/spaces/show.yaml
@@ -39,3 +39,4 @@ x-code-samples:
     --account_id <account_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/spaces/spaces_projects.yaml
+++ b/paths/spaces/spaces_projects.yaml
@@ -45,3 +45,4 @@ x-code-samples:
     --account_id <account_id> \
     --space_id <space_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/spaces/update.yaml
+++ b/paths/spaces/update.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: New name of the space
             type: string
             example: My Android Projects
+x-cli-version: '2.5'

--- a/paths/styleguides/create.yaml
+++ b/paths/styleguides/create.yaml
@@ -101,3 +101,4 @@ requestBody:
             description: Provide links to sample product pages, FAQ pages, etc. to give the translator a point of reference. You can also provide past translations. Even snippets or short paragraphs are helpful for maintaining consistency.
             type: string
             example: http://www.myexample.com/my/document/path/to/samples.pdf
+x-cli-version: '2.5'

--- a/paths/styleguides/destroy.yaml
+++ b/paths/styleguides/destroy.yaml
@@ -29,3 +29,4 @@ x-code-samples:
     --project_id <project_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/styleguides/index.yaml
+++ b/paths/styleguides/index.yaml
@@ -43,3 +43,4 @@ x-code-samples:
     phrase styleguides list \
     --project_id <project_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/styleguides/show.yaml
+++ b/paths/styleguides/show.yaml
@@ -39,3 +39,4 @@ x-code-samples:
     --project_id <project_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/styleguides/update.yaml
+++ b/paths/styleguides/update.yaml
@@ -103,3 +103,4 @@ requestBody:
             description: Provide links to sample product pages, FAQ pages, etc. to give the translator a point of reference. You can also provide past translations. Even snippets or short paragraphs are helpful for maintaining consistency.
             type: string
             example: http://www.myexample.com/my/document/path/to/samples.pdf
+x-cli-version: '2.5'

--- a/paths/tags/create.yaml
+++ b/paths/tags/create.yaml
@@ -57,3 +57,4 @@ requestBody:
             description: Name of the tag
             type: string
             example: my-feature
+x-cli-version: '2.5'

--- a/paths/tags/destroy.yaml
+++ b/paths/tags/destroy.yaml
@@ -38,3 +38,4 @@ x-code-samples:
     --name <name> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/tags/index.yaml
+++ b/paths/tags/index.yaml
@@ -50,3 +50,4 @@ x-code-samples:
     --project_id <project_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/tags/show.yaml
+++ b/paths/tags/show.yaml
@@ -46,3 +46,4 @@ x-code-samples:
     --name <name> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/teams/add_project.yaml
+++ b/paths/teams/add_project.yaml
@@ -51,3 +51,4 @@ requestBody:
             description: Project ID to add to the Team
             type: string
             example: a4b3c2d1
+x-cli-version: '2.5'

--- a/paths/teams/add_space.yaml
+++ b/paths/teams/add_space.yaml
@@ -51,3 +51,4 @@ requestBody:
             description: Space ID to add to the Team
             type: string
             example: a4b3c2d1
+x-cli-version: '2.5'

--- a/paths/teams/add_user.yaml
+++ b/paths/teams/add_user.yaml
@@ -51,3 +51,4 @@ requestBody:
             description: User ID to add to the Team
             type: string
             example: a4b3c2d1
+x-cli-version: '2.5'

--- a/paths/teams/create.yaml
+++ b/paths/teams/create.yaml
@@ -53,3 +53,4 @@ requestBody:
             description: Name of the team
             type: string
             example: German Translators
+x-cli-version: '2.5'

--- a/paths/teams/delete.yaml
+++ b/paths/teams/delete.yaml
@@ -29,3 +29,4 @@ x-code-samples:
     --account_id <account_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/teams/index.yaml
+++ b/paths/teams/index.yaml
@@ -43,3 +43,4 @@ x-code-samples:
     phrase teams list \
     --account_id <account_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/teams/remove_project.yaml
+++ b/paths/teams/remove_project.yaml
@@ -31,3 +31,4 @@ x-code-samples:
     --team_id <team_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/teams/remove_space.yaml
+++ b/paths/teams/remove_space.yaml
@@ -31,3 +31,4 @@ x-code-samples:
     --team_id <team_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/teams/remove_user.yaml
+++ b/paths/teams/remove_user.yaml
@@ -31,3 +31,4 @@ x-code-samples:
     --team_id <team_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/teams/show.yaml
+++ b/paths/teams/show.yaml
@@ -39,3 +39,4 @@ x-code-samples:
     --account_id <account_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/teams/update.yaml
+++ b/paths/teams/update.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: New name of the team
             type: string
             example: German Translators
+x-cli-version: '2.5'

--- a/paths/translations/batch_exclude.yaml
+++ b/paths/translations/batch_exclude.yaml
@@ -75,3 +75,4 @@ requestBody:
             description: 'Order direction. Can be one of: asc, desc.'
             type: string
             example: desc
+x-cli-version: '2.5'

--- a/paths/translations/batch_include.yaml
+++ b/paths/translations/batch_include.yaml
@@ -75,3 +75,4 @@ requestBody:
             description: 'Order direction. Can be one of: asc, desc.'
             type: string
             example: desc
+x-cli-version: '2.5'

--- a/paths/translations/batch_review.yaml
+++ b/paths/translations/batch_review.yaml
@@ -67,3 +67,4 @@ requestBody:
               Find more examples <a href="#overview--usage-examples">here</a>.
             type: string
             example: PhraseApp*%reviewed:false%20tags:feature,center
+x-cli-version: '2.5'

--- a/paths/translations/batch_unverify.yaml
+++ b/paths/translations/batch_unverify.yaml
@@ -75,3 +75,4 @@ requestBody:
             description: 'Order direction. Can be one of: asc, desc.'
             type: string
             example: desc
+x-cli-version: '2.5'

--- a/paths/translations/batch_verify.yaml
+++ b/paths/translations/batch_verify.yaml
@@ -71,3 +71,4 @@ requestBody:
               Find more examples <a href="#overview--usage-examples">here</a>.
             type: string
             example: PhraseApp*%20unverified:true%20tags:feature,center
+x-cli-version: '2.5'

--- a/paths/translations/create.yaml
+++ b/paths/translations/create.yaml
@@ -81,3 +81,4 @@ requestBody:
             description: Indicates whether the translation should be auto-translated. Responses with status 422 if provided for translation within a non-default locale or the project does not have the Autopilot feature enabled.
             type: boolean
             example:
+x-cli-version: '2.5'

--- a/paths/translations/exclude.yaml
+++ b/paths/translations/exclude.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: specify the branch to use
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/translations/include.yaml
+++ b/paths/translations/include.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: specify the branch to use
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/translations/index.yaml
+++ b/paths/translations/index.yaml
@@ -81,3 +81,4 @@ x-code-samples:
     --order desc \
     --query 'PhraseApp*%20unverified:true%20excluded:true%20tags:feature,center' \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/translations/index_keys.yaml
+++ b/paths/translations/index_keys.yaml
@@ -83,3 +83,4 @@ x-code-samples:
     --order desc \
     --query 'PhraseApp*%20unverified:true%20excluded:true%20tags:feature,center' \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/translations/index_locale.yaml
+++ b/paths/translations/index_locale.yaml
@@ -83,3 +83,4 @@ x-code-samples:
     --order desc \
     --query 'PhraseApp*%20unverified:true%20excluded:true%20tags:feature,center' \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/translations/review.yaml
+++ b/paths/translations/review.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: specify the branch to use
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/translations/search.yaml
+++ b/paths/translations/search.yaml
@@ -79,3 +79,4 @@ requestBody:
               Find more examples <a href="#overview--usage-examples">here</a>.
             type: string
             example: PhraseApp*%20unverified:true%20excluded:true%20tags:feature,center
+x-cli-version: '2.5'

--- a/paths/translations/show.yaml
+++ b/paths/translations/show.yaml
@@ -46,3 +46,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/translations/unverify.yaml
+++ b/paths/translations/unverify.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: specify the branch to use
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/translations/update.yaml
+++ b/paths/translations/update.yaml
@@ -75,3 +75,4 @@ requestBody:
             description: Indicates whether the translation should be auto-translated. Responses with status 422 if provided for translation within a non-default locale or the project does not have the Autopilot feature enabled.
             type: boolean
             example:
+x-cli-version: '2.5'

--- a/paths/translations/verify.yaml
+++ b/paths/translations/verify.yaml
@@ -55,3 +55,4 @@ requestBody:
             description: specify the branch to use
             type: string
             example: my-feature-branch
+x-cli-version: '2.5'

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -124,3 +124,4 @@ requestBody:
             description: Indicated whether the imported translations should be marked as reviewed. This setting is available if the review workflow (currently beta) is enabled for the project.
             type: boolean
             example:
+x-cli-version: '2.5'

--- a/paths/uploads/index.yaml
+++ b/paths/uploads/index.yaml
@@ -50,3 +50,4 @@ x-code-samples:
     --project_id <project_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/uploads/show.yaml
+++ b/paths/uploads/show.yaml
@@ -46,3 +46,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/users/user.yaml
+++ b/paths/users/user.yaml
@@ -35,3 +35,4 @@ x-code-samples:
   source: |-
     phrase shows user \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/variables/create.yaml
+++ b/paths/variables/create.yaml
@@ -57,3 +57,4 @@ requestBody:
             description: Value of the variable
             type: string
             example: Hello World
+x-cli-version: '2.5'

--- a/paths/variables/destroy.yaml
+++ b/paths/variables/destroy.yaml
@@ -29,3 +29,4 @@ x-code-samples:
     --project_id <project_id> \
     --name <name> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/variables/index.yaml
+++ b/paths/variables/index.yaml
@@ -43,3 +43,4 @@ x-code-samples:
     phrase variables list \
     --project_id <project_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/variables/show.yaml
+++ b/paths/variables/show.yaml
@@ -39,3 +39,4 @@ x-code-samples:
     --project_id <project_id> \
     --name <name> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/variables/update.yaml
+++ b/paths/variables/update.yaml
@@ -59,3 +59,4 @@ requestBody:
             description: Value of the variable
             type: string
             example: Hello World
+x-cli-version: '2.5'

--- a/paths/versions/index.yaml
+++ b/paths/versions/index.yaml
@@ -52,3 +52,4 @@ x-code-samples:
     --translation_id <translation_id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/versions/show.yaml
+++ b/paths/versions/show.yaml
@@ -48,3 +48,4 @@ x-code-samples:
     --id <id> \
     --branch my-feature-branch \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/webhook_deliveries/index.yaml
+++ b/paths/webhook_deliveries/index.yaml
@@ -9,7 +9,6 @@ parameters:
 - "$ref": "../../parameters.yaml#/project_id"
 - "$ref": "../../parameters.yaml#/webhook_id"
 - "$ref": "../../parameters.yaml#/response_status_codes"
-
 responses:
   '200':
     description: OK
@@ -45,3 +44,4 @@ x-code-samples:
     --project_id <project_id> \
     --webhook_id <webhook_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/webhook_deliveries/redeliver.yaml
+++ b/paths/webhook_deliveries/redeliver.yaml
@@ -1,6 +1,6 @@
 ---
 summary: Redeliver a single webhook delivery
-description: Trigger an individual webhook delivery to be redelivered. 
+description: Trigger an individual webhook delivery to be redelivered.
 operationId: webhook_deliveries/redeliver
 tags:
 - Webhook Deliveries
@@ -9,7 +9,6 @@ parameters:
 - "$ref": "../../parameters.yaml#/project_id"
 - "$ref": "../../parameters.yaml#/webhook_id"
 - "$ref": "../../parameters.yaml#/id"
-
 responses:
   '200':
     description: OK
@@ -44,3 +43,4 @@ x-code-samples:
     --webhook_id <webhook_id> \
     --id <delivery_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/webhook_deliveries/show.yaml
+++ b/paths/webhook_deliveries/show.yaml
@@ -9,7 +9,6 @@ parameters:
 - "$ref": "../../parameters.yaml#/project_id"
 - "$ref": "../../parameters.yaml#/webhook_id"
 - "$ref": "../../parameters.yaml#/id"
-
 responses:
   '200':
     description: OK
@@ -44,3 +43,4 @@ x-code-samples:
     --webhook_id <webhook_id> \
     --id <delivery_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/webhooks/create.yaml
+++ b/paths/webhooks/create.yaml
@@ -73,3 +73,4 @@ requestBody:
             description: If enabled, webhook will also be triggered for events from branches of the project specified.
             type: boolean
             example:
+x-cli-version: '2.5'

--- a/paths/webhooks/destroy.yaml
+++ b/paths/webhooks/destroy.yaml
@@ -29,3 +29,4 @@ x-code-samples:
     --project_id <project_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/webhooks/index.yaml
+++ b/paths/webhooks/index.yaml
@@ -43,3 +43,4 @@ x-code-samples:
     phrase webhooks list \
     --project_id <project_id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/webhooks/show.yaml
+++ b/paths/webhooks/show.yaml
@@ -39,3 +39,4 @@ x-code-samples:
     --project_id <project_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/webhooks/test.yaml
+++ b/paths/webhooks/test.yaml
@@ -36,3 +36,4 @@ x-code-samples:
     --project_id <project_id> \
     --id <id> \
     --access_token <token>
+x-cli-version: '2.5'

--- a/paths/webhooks/update.yaml
+++ b/paths/webhooks/update.yaml
@@ -75,3 +75,4 @@ requestBody:
             description: If enabled, webhook will also be triggered for events from branches of the project specified.
             type: boolean
             example:
+x-cli-version: '2.5'


### PR DESCRIPTION
https://memsource.tpondemand.com/entity/80698-orch-support-openapi-spec-provides-cli_version

I opted for succinct value, without the patch number (as patch updates don't introduce API changes) and without the leading `>` (as any other symbol makes no sense).