### PR TITLE
Fix linux/arm64 Docker build

### DIFF
--- a/clients/cli/.github/workflows/release.yml
+++ b/clients/cli/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Version
         id: version
         run: |
-          echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+          echo "{VERSION}=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # pin@v2.1
         with:

--- a/clients/cli/.github/workflows/release.yml
+++ b/clients/cli/.github/workflows/release.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.16
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # pin@2.1.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # pin@2.2.1
       - name: Version
         id: version
         run: |
           echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: Login to DockerHub
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c # pin@v1
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # pin@v2.1
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/clients/cli/Dockerfile
+++ b/clients/cli/Dockerfile
@@ -1,6 +1,8 @@
-FROM --platform=$BUILDPLATFORM alpine:latest AS phrase-cli
+FROM alpine:latest AS phrase-cli
 
-ARG CLI_PATH
-COPY ${CLI_PATH} /usr/bin/phrase
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY dist/${TARGETOS}/${TARGETARCH} /usr/bin/phrase
 
 ENTRYPOINT ["/usr/bin/phrase"]

--- a/clients/cli/build/release.sh
+++ b/clients/cli/build/release.sh
@@ -18,8 +18,12 @@ IMAGE=${IMAGE_PREFIX}:${VERSION}
 IMAGE_LATEST=${IMAGE_PREFIX}:latest
 
 echo build docker image "${IMAGE}" and ${IMAGE_LATEST}
-docker buildx build --tag "${IMAGE}" --tag ${IMAGE_LATEST} --build-arg CLI_PATH="dist/phrase_linux_amd64" --platform linux/amd64 -f ./Dockerfile --push .
-docker buildx build --tag "${IMAGE}" --tag ${IMAGE_LATEST} --build-arg CLI_PATH="dist/phrase_linux_arm64" --platform linux/arm64 -f ./Dockerfile --push .
+
+mkdir -p dist/linux
+cp dist/phrase_linux_amd64 dist/linux/amd64
+cp dist/phrase_linux_amd64 dist/linux/arm64
+
+docker buildx build --tag "${IMAGE}" --tag ${IMAGE_LATEST} --platform linux/amd64,linux/arm64 -f ./Dockerfile --push .
 
 # Create release
 function create_release_data()

--- a/clients/cli/build/release.sh
+++ b/clients/cli/build/release.sh
@@ -21,7 +21,7 @@ echo build docker image "${IMAGE}" and ${IMAGE_LATEST}
 
 mkdir -p dist/linux
 cp dist/phrase_linux_amd64 dist/linux/amd64
-cp dist/phrase_linux_amd64 dist/linux/arm64
+cp dist/phrase_linux_arm64 dist/linux/arm64
 
 docker buildx build --tag "${IMAGE}" --tag ${IMAGE_LATEST} --platform linux/amd64,linux/arm64 -f ./Dockerfile --push .
 


### PR DESCRIPTION
Pushing the image twice is overwriting the previous image. Instead both platforms needs to used in a single build/push command