### PR TITLE
Allow pushing files without extensions

### DIFF
--- a/clients/cli/cmd/internal/paths/paths.go
+++ b/clients/cli/cmd/internal/paths/paths.go
@@ -18,10 +18,6 @@ func Validate(file, formatName, formatExtension string) error {
 
 	fileExtension := strings.Trim(filepath.Ext(file), ".")
 
-	if fileExtension == "" {
-		return fmt.Errorf("%q has no file extension", file)
-	}
-
 	if fileExtension == "<locale_code>" {
 		return nil
 	}

--- a/openapi-generator/cli_lang.yaml
+++ b/openapi-generator/cli_lang.yaml
@@ -2,4 +2,4 @@
 generatorName: go
 outputDir: clients/cli
 packageName: phrase
-packageVersion: 2.6.4
+packageVersion: 2.6.5


### PR DESCRIPTION
https://memsource.tpondemand.com/entity/84434-phrase-cli-error-because-of-messages

Not sure why this check was here in the first place. Unfortunately, git blame is not very informative and there are no specs covering this validation.
Currently I see no drawbacks in removing this check.