### PR TITLE
Update CLI go build version

### DIFF
--- a/clients/cli/build/config.sh
+++ b/clients/cli/build/config.sh
@@ -4,7 +4,7 @@ set -e
 wd=$(realpath $(dirname $0)/..)
 export BUILD_DIR=$(realpath $(dirname $0)/..)
 pushd $BUILD_DIR > /dev/null
-export GOVERSION=${GOVERSION:-1.16}
+export GOVERSION=${GOVERSION:-1.19}
 export REVISION=${GIT_COMMIT:-$(git rev-parse HEAD)}
 export LIBRARY_REVISION=$(cat go.sum | grep github.com/phrase/phrase-go | tail -n 1 | cut -d " " -f 2 | cut -d "-" -f 3 | cut -d "+" -f 1)
 export SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)


### PR DESCRIPTION
The release of the current version failed to  an outdated go version used in the build: https://github.com/phrase/phrase-cli/actions/runs/4084033929/jobs/7040257981