### PR TITLE
Fix query parameter name in CLI examples

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -17507,7 +17507,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase keys search \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"sort\":\"updated_at\", \"order\":\"desc\", \"query\":\"'mykey* translated:true'\", \"locale_id\":\"abcd1234abcd1234abcd1234abcd1234\"}' \\\n--access_token <token>"
+            "source": "phrase keys search \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"sort\":\"updated_at\", \"order\":\"desc\", \"q\":\"'mykey* translated:true'\", \"locale_id\":\"abcd1234abcd1234abcd1234abcd1234\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -17885,7 +17885,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase keys tag \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"query\":\"'mykey* translated:true'\", \"locale_id\":\"abcd1234abcd1234abcd1234abcd1234\", \"tags\":\"landing-page,release-1.2\"}' \\\n--access_token <token>"
+            "source": "phrase keys tag \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"q\":\"'mykey* translated:true'\", \"locale_id\":\"abcd1234abcd1234abcd1234abcd1234\", \"tags\":\"landing-page,release-1.2\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -17979,7 +17979,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase keys untag \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"query\":\"'mykey* translated:true'\", \"locale_id\":\"abcd1234abcd1234abcd1234abcd1234\", \"tags\":\"landing-page,release-1.2\"}' \\\n--access_token <token>"
+            "source": "phrase keys untag \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"q\":\"'mykey* translated:true'\", \"locale_id\":\"abcd1234abcd1234abcd1234abcd1234\", \"tags\":\"landing-page,release-1.2\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -18073,7 +18073,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase keys exclude \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"query\":\"'mykey* translated:true'\", \"target_locale_id\":\"abcd1234abcd1234abcd1234abcd1234\", \"tags\":\"landing-page,release-1.2\"}' \\\n--access_token <token>"
+            "source": "phrase keys exclude \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"q\":\"'mykey* translated:true'\", \"target_locale_id\":\"abcd1234abcd1234abcd1234abcd1234\", \"tags\":\"landing-page,release-1.2\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -18167,7 +18167,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase keys include \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"query\":\"'mykey* translated:true'\", \"target_locale_id\":\"abcd1234abcd1234abcd1234abcd1234\", \"tags\":\"landing-page,release-1.2\"}' \\\n--access_token <token>"
+            "source": "phrase keys include \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"q\":\"'mykey* translated:true'\", \"target_locale_id\":\"abcd1234abcd1234abcd1234abcd1234\", \"tags\":\"landing-page,release-1.2\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -20410,7 +20410,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase translations search \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"sort\":\"updated_at\", \"order\":\"desc\", \"query\":\"'PhraseApp*%20unverified:true%20excluded:true%20tags:feature,center'\"}' \\\n--access_token <token>"
+            "source": "phrase translations search \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"sort\":\"updated_at\", \"order\":\"desc\", \"q\":\"'PhraseApp*%20unverified:true%20excluded:true%20tags:feature,center'\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -21092,7 +21092,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase translations verify-collection \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"query\":\"'PhraseApp*%20unverified:true%20tags:feature,center'\"}' \\\n--access_token <token>"
+            "source": "phrase translations verify-collection \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"q\":\"'PhraseApp*%20unverified:true%20tags:feature,center'\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -21181,7 +21181,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase translations unverify-collection \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"query\":\"'PhraseApp*%20verified:true%20tags:feature,center'\", \"sort\":\"updated_at\", \"order\":\"desc\"}' \\\n--access_token <token>"
+            "source": "phrase translations unverify-collection \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"q\":\"'PhraseApp*%20verified:true%20tags:feature,center'\", \"sort\":\"updated_at\", \"order\":\"desc\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -21275,7 +21275,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase translations review-collection \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"query\":\"'PhraseApp*%reviewed:false%20tags:feature,center'\"}' \\\n--access_token <token>"
+            "source": "phrase translations review-collection \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"q\":\"'PhraseApp*%reviewed:false%20tags:feature,center'\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -21359,7 +21359,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase translations exclude-collection \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"query\":\"'PhraseApp*%20verified:true%20tags:feature,center'\", \"sort\":\"updated_at\", \"order\":\"desc\"}' \\\n--access_token <token>"
+            "source": "phrase translations exclude-collection \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"q\":\"'PhraseApp*%20verified:true%20tags:feature,center'\", \"sort\":\"updated_at\", \"order\":\"desc\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -21453,7 +21453,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase translations include-collection \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"query\":\"'PhraseApp*%20verified:true%20tags:feature,center'\", \"sort\":\"updated_at\", \"order\":\"desc\"}' \\\n--access_token <token>"
+            "source": "phrase translations include-collection \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"q\":\"'PhraseApp*%20verified:true%20tags:feature,center'\", \"sort\":\"updated_at\", \"order\":\"desc\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -22072,7 +22072,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase search in_account \\\n--account_id <account_id> \\\n--data '{\"query\":\"keyword\",\"locale_code\": \"de\",\"page\": 1,\"per_page\": 25}' \\\n--access_token <token>"
+            "source": "phrase search in_account \\\n--account_id <account_id> \\\n--data '{\"q\":\"keyword\",\"locale_code\": \"de\",\"page\": 1,\"per_page\": 25}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {

--- a/paths/keys/exclude.yaml
+++ b/paths/keys/exclude.yaml
@@ -39,7 +39,7 @@ x-code-samples:
   source: |-
     phrase keys exclude \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "query":"'mykey* translated:true'", "target_locale_id":"abcd1234abcd1234abcd1234abcd1234", "tags":"landing-page,release-1.2"}' \
+    --data '{"branch":"my-feature-branch", "q":"'mykey* translated:true'", "target_locale_id":"abcd1234abcd1234abcd1234abcd1234", "tags":"landing-page,release-1.2"}' \
     --access_token <token>
 requestBody:
   required: true

--- a/paths/keys/include.yaml
+++ b/paths/keys/include.yaml
@@ -39,7 +39,7 @@ x-code-samples:
   source: |-
     phrase keys include \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "query":"'mykey* translated:true'", "target_locale_id":"abcd1234abcd1234abcd1234abcd1234", "tags":"landing-page,release-1.2"}' \
+    --data '{"branch":"my-feature-branch", "q":"'mykey* translated:true'", "target_locale_id":"abcd1234abcd1234abcd1234abcd1234", "tags":"landing-page,release-1.2"}' \
     --access_token <token>
 requestBody:
   required: true

--- a/paths/keys/search.yaml
+++ b/paths/keys/search.yaml
@@ -43,7 +43,7 @@ x-code-samples:
   source: |-
     phrase keys search \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "sort":"updated_at", "order":"desc", "query":"'mykey* translated:true'", "locale_id":"abcd1234abcd1234abcd1234abcd1234"}' \
+    --data '{"branch":"my-feature-branch", "sort":"updated_at", "order":"desc", "q":"'mykey* translated:true'", "locale_id":"abcd1234abcd1234abcd1234abcd1234"}' \
     --access_token <token>
 requestBody:
   required: true

--- a/paths/keys/tag.yaml
+++ b/paths/keys/tag.yaml
@@ -39,7 +39,7 @@ x-code-samples:
   source: |-
     phrase keys tag \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "query":"'mykey* translated:true'", "locale_id":"abcd1234abcd1234abcd1234abcd1234", "tags":"landing-page,release-1.2"}' \
+    --data '{"branch":"my-feature-branch", "q":"'mykey* translated:true'", "locale_id":"abcd1234abcd1234abcd1234abcd1234", "tags":"landing-page,release-1.2"}' \
     --access_token <token>
 requestBody:
   required: true

--- a/paths/keys/untag.yaml
+++ b/paths/keys/untag.yaml
@@ -39,7 +39,7 @@ x-code-samples:
   source: |-
     phrase keys untag \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "query":"'mykey* translated:true'", "locale_id":"abcd1234abcd1234abcd1234abcd1234", "tags":"landing-page,release-1.2"}' \
+    --data '{"branch":"my-feature-branch", "q":"'mykey* translated:true'", "locale_id":"abcd1234abcd1234abcd1234abcd1234", "tags":"landing-page,release-1.2"}' \
     --access_token <token>
 requestBody:
   required: true

--- a/paths/search/in_account.yaml
+++ b/paths/search/in_account.yaml
@@ -41,7 +41,7 @@ x-code-samples:
   source: |-
     phrase search in_account \
     --account_id <account_id> \
-    --data '{"query":"keyword","locale_code": "de","page": 1,"per_page": 25}' \
+    --data '{"q":"keyword","locale_code": "de","page": 1,"per_page": 25}' \
     --access_token <token>
 requestBody:
   required: true

--- a/paths/translations/batch_exclude.yaml
+++ b/paths/translations/batch_exclude.yaml
@@ -39,7 +39,7 @@ x-code-samples:
   source: |-
     phrase translations exclude-collection \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "query":"'PhraseApp*%20verified:true%20tags:feature,center'", "sort":"updated_at", "order":"desc"}' \
+    --data '{"branch":"my-feature-branch", "q":"'PhraseApp*%20verified:true%20tags:feature,center'", "sort":"updated_at", "order":"desc"}' \
     --access_token <token>
 requestBody:
   required: true

--- a/paths/translations/batch_include.yaml
+++ b/paths/translations/batch_include.yaml
@@ -39,7 +39,7 @@ x-code-samples:
   source: |-
     phrase translations include-collection \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "query":"'PhraseApp*%20verified:true%20tags:feature,center'", "sort":"updated_at", "order":"desc"}' \
+    --data '{"branch":"my-feature-branch", "q":"'PhraseApp*%20verified:true%20tags:feature,center'", "sort":"updated_at", "order":"desc"}' \
     --access_token <token>
 requestBody:
   required: true

--- a/paths/translations/batch_review.yaml
+++ b/paths/translations/batch_review.yaml
@@ -39,7 +39,7 @@ x-code-samples:
   source: |-
     phrase translations review-collection \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "query":"'PhraseApp*%reviewed:false%20tags:feature,center'"}' \
+    --data '{"branch":"my-feature-branch", "q":"'PhraseApp*%reviewed:false%20tags:feature,center'"}' \
     --access_token <token>
 requestBody:
   required: true

--- a/paths/translations/batch_unverify.yaml
+++ b/paths/translations/batch_unverify.yaml
@@ -39,7 +39,7 @@ x-code-samples:
   source: |-
     phrase translations unverify-collection \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "query":"'PhraseApp*%20verified:true%20tags:feature,center'", "sort":"updated_at", "order":"desc"}' \
+    --data '{"branch":"my-feature-branch", "q":"'PhraseApp*%20verified:true%20tags:feature,center'", "sort":"updated_at", "order":"desc"}' \
     --access_token <token>
 requestBody:
   required: true

--- a/paths/translations/batch_verify.yaml
+++ b/paths/translations/batch_verify.yaml
@@ -39,7 +39,7 @@ x-code-samples:
   source: |-
     phrase translations verify-collection \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "query":"'PhraseApp*%20unverified:true%20tags:feature,center'"}' \
+    --data '{"branch":"my-feature-branch", "q":"'PhraseApp*%20unverified:true%20tags:feature,center'"}' \
     --access_token <token>
 requestBody:
   required: true

--- a/paths/translations/search.yaml
+++ b/paths/translations/search.yaml
@@ -43,7 +43,7 @@ x-code-samples:
   source: |-
     phrase translations search \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "sort":"updated_at", "order":"desc", "query":"'PhraseApp*%20unverified:true%20excluded:true%20tags:feature,center'"}' \
+    --data '{"branch":"my-feature-branch", "sort":"updated_at", "order":"desc", "q":"'PhraseApp*%20unverified:true%20excluded:true%20tags:feature,center'"}' \
     --access_token <token>
 requestBody:
   required: true


### PR DESCRIPTION
In many CLI examples the query parameter was named `query` instead of `q`, which is invalid