### PR TITLE
CLI: Run brew release step only after a successful release

### DIFF
--- a/clients/cli/.github/workflows/release.yml
+++ b/clients/cli/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
   brew:
     runs-on: ubuntu-latest
+    needs: release
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
In case the release fails we should not try to create a brew PR