### PR TITLE
phrase-ruby: Update Ruby version for release

### DIFF
--- a/clients/ruby/.github/workflows/release.yml
+++ b/clients/ruby/.github/workflows/release.yml
@@ -11,12 +11,12 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@d3c9825d67b0d8720afdfdde5af56c79fdb38d16 # pin@v1.138.0
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.2'
       -
         name: Version
         id: version


### PR DESCRIPTION
Ruby 2.6 cannot be found anymore: https://github.com/phrase/phrase-ruby/actions/runs/4229987197/jobs/7346857566