### PR TITLE
CLI: Set buildvcs to false to fix build

### DIFF
--- a/clients/cli/build/go_build.sh
+++ b/clients/cli/build/go_build.sh
@@ -15,7 +15,7 @@ function build {
 	name=$3
 	echo "build os=${goos} arch=${goarch}" > /dev/stderr
 
-	CGO_ENABLED=0 GOOS=$goos GOARCH=$goarch go build -o $bin_dir/${name} -ldflags "-X 'github.com/phrase/phrase-cli/cmd.LAST_CHANGE=${LAST_CHANGE}' -X=github.com/phrase/phrase-cli/cmd.REVISION=$REVISION -X=github.com/phrase/phrase-cli/cmd.PHRASE_CLIENT_VERSION=${VERSION} -X=github.com/phrase/phrase-cli/cmd.LIBRARY_REVISION=$LIBRARY_REVISION -extldflags '-static'" .
+	CGO_ENABLED=0 GOOS=$goos GOARCH=$goarch go build -o $bin_dir/${name} -buildvcs=false -ldflags "-X 'github.com/phrase/phrase-cli/cmd.LAST_CHANGE=${LAST_CHANGE}' -X=github.com/phrase/phrase-cli/cmd.REVISION=$REVISION -X=github.com/phrase/phrase-cli/cmd.PHRASE_CLIENT_VERSION=${VERSION} -X=github.com/phrase/phrase-cli/cmd.LIBRARY_REVISION=$LIBRARY_REVISION -extldflags '-static'" .
 }
 
 build linux   amd64   phrase_linux_amd64


### PR DESCRIPTION
Build was failing likely due to a git version mismatch of the GitHub runner and go Docker image. Disable `buildvcs` to attempt to fix it: https://github.com/phrase/phrase-cli/actions/runs/4263384954/jobs/7420054269