### PR TITLE
Release CLI 2.7.0

### DIFF
--- a/clients/cli/go.mod
+++ b/clients/cli/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/daviddengcn/go-colortext v1.0.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/mitchellh/mapstructure v1.4.0
-	github.com/phrase/phrase-go/v2 v2.6.8
+	github.com/phrase/phrase-go/v2 v2.7.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/clients/cli/go.sum
+++ b/clients/cli/go.sum
@@ -220,6 +220,8 @@ github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNC
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/phrase/phrase-go/v2 v2.6.8 h1:PsEUUFE+6gaGPOXxl9L10iwMT/sR94YDGDrQTm41MVo=
 github.com/phrase/phrase-go/v2 v2.6.8/go.mod h1:N1ou4nnB9ak8aAWOH7x25Xhzw8FmFeBRhSGq5A0CY2o=
+github.com/phrase/phrase-go/v2 v2.7.0 h1:T3SgMkl+rciEVh29SvY5PCnubw1PTRf7Lhx3f8bzShs=
+github.com/phrase/phrase-go/v2 v2.7.0/go.mod h1:N1ou4nnB9ak8aAWOH7x25Xhzw8FmFeBRhSGq5A0CY2o=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=

--- a/clients/cli/go.sum
+++ b/clients/cli/go.sum
@@ -218,8 +218,6 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
-github.com/phrase/phrase-go/v2 v2.6.8 h1:PsEUUFE+6gaGPOXxl9L10iwMT/sR94YDGDrQTm41MVo=
-github.com/phrase/phrase-go/v2 v2.6.8/go.mod h1:N1ou4nnB9ak8aAWOH7x25Xhzw8FmFeBRhSGq5A0CY2o=
 github.com/phrase/phrase-go/v2 v2.7.0 h1:T3SgMkl+rciEVh29SvY5PCnubw1PTRf7Lhx3f8bzShs=
 github.com/phrase/phrase-go/v2 v2.7.0/go.mod h1:N1ou4nnB9ak8aAWOH7x25Xhzw8FmFeBRhSGq5A0CY2o=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/openapi-generator/cli_lang.yaml
+++ b/openapi-generator/cli_lang.yaml
@@ -2,4 +2,4 @@
 generatorName: go
 outputDir: clients/cli
 packageName: phrase
-packageVersion: 2.6.9
+packageVersion: 2.7.0


### PR DESCRIPTION
Release CLI version 2.7.0 with GJT endpoints, following #281 