### PR TITLE
Expose previously undocumented cldr_version parameter #TSI-1717

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -4398,13 +4398,18 @@
                     "description": "Indicates whether the zero form should be included or excluded in the returned skeletons",
                     "type": "boolean",
                     "example": null
+                  },
+                  "cldr_version": {
+                    "description": "Strings supports two CLDR variants, when it comes to pluralization rules. \\\nYou can choose which one you want to use when constructing the skeletons. Possible values \\\nare `legacy` and `cldr_41`. Default value is `legacy`.",
+                    "type": "string",
+                    "example": "cldr_41"
                   }
                 }
               }
             }
           }
         },
-        "x-cli-version": "2.5"
+        "x-cli-version": "2.9"
       }
     },
     "/formats": {

--- a/openapi-generator/go_lang.yaml
+++ b/openapi-generator/go_lang.yaml
@@ -2,7 +2,7 @@
 generatorName: go
 outputDir: clients/go
 packageName: phrase
-packageVersion: 2.8.0
+packageVersion: 2.9.0
 gitUserId: phrase
 gitRepoId: phrase-go
 httpUserAgent: Phrase Strings go

--- a/openapi-generator/java_lang.yaml
+++ b/openapi-generator/java_lang.yaml
@@ -4,7 +4,7 @@ outputDir: clients/java
 apiPackage: com.phrase.client.api
 artifactId: phrase-java
 artifactUrl: https://developers.phrase.com
-artifactVersion: 1.7.0
+artifactVersion: 1.8.0
 developerEmail: support@phrase.com
 developerName: Phrase
 developerOrganization: Phrase.com

--- a/openapi-generator/php_lang.yaml
+++ b/openapi-generator/php_lang.yaml
@@ -2,7 +2,7 @@
 generatorName: php
 outputDir: clients/php
 invokerPackage: Phrase
-artifactVersion: 1.7.0
+artifactVersion: 1.8.0
 gitUserId: phrase
 gitRepoId: phrase-php
 packageName: phrase-php

--- a/openapi-generator/python_lang.yaml
+++ b/openapi-generator/python_lang.yaml
@@ -3,7 +3,7 @@ generatorName: python
 outputDir: clients/python
 packageName: phrase_api
 projectName: phrase-api
-packageVersion: 1.7.0
+packageVersion: 1.8.0
 packageUrl: "https://github.com/phrase/phrase-python"
 gitUserId: phrase
 gitRepoId: phrase-python

--- a/openapi-generator/ruby_lang.yaml
+++ b/openapi-generator/ruby_lang.yaml
@@ -3,7 +3,7 @@ generatorName: ruby
 outputDir: clients/ruby
 moduleName: Phrase
 gemName: phrase
-gemVersion: 2.10.0
+gemVersion: 2.11.0
 gemDescription: 'Phrase Strings is a translation management platform for software projects.'
 gemSummary: 'You can collaborate on language file translation with your team or order translations through our platform. The API allows you to import locale files, download locale files, tag keys or interact in other ways with the localization data stored in Phrase Strings for your account.'
 gemRequiredRubyVersion: '>= 2.6.0'

--- a/openapi-generator/typescript_lang.yaml
+++ b/openapi-generator/typescript_lang.yaml
@@ -2,5 +2,5 @@
 generatorName: typescript-fetch
 outputDir: clients/typescript
 npmName: "phrase-js"
-npmVersion: 1.7.0
+npmVersion: 1.8.0
 typescriptThreePlus: true

--- a/paths/icu/skeleton.yaml
+++ b/paths/icu/skeleton.yaml
@@ -69,4 +69,12 @@ requestBody:
             description: Indicates whether the zero form should be included or excluded in the returned skeletons
             type: boolean
             example:
-x-cli-version: '2.5'
+          cldr_version:
+            description: |-
+              Strings supports two CLDR variants, when it comes to pluralization rules. \
+              You can choose which one you want to use when constructing the skeletons. Possible values \
+              are `legacy` and `cldr_41`. Default value is `legacy`.
+            type: string
+            example: cldr_41
+
+x-cli-version: '2.9'


### PR DESCRIPTION
The endpoint for building ICU skeletons has a previously undocumented parameter `cldr_version` which determines the pluralization version used.