### PR TITLE
Fix the CLI example for job comments

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -22418,7 +22418,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase comments show \\\n--project_id <project_id> \\\n--job_id <job_id> \\\n--id <id> \\\n--branch my-feature-branch \\\n--access_token <token>"
+            "source": "phrase job_comments show \\\n--project_id <project_id> \\\n--job_id <job_id> \\\n--id <id> \\\n--branch my-feature-branch \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.5"
@@ -22483,7 +22483,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase comments update \\\n--project_id <project_id> \\\n--job_id <job_id> \\\n--id <id> \\\n--data '{\"message\": \"Some message...\"}' \\\n--access_token <token>"
+            "source": "phrase job_comments update \\\n--project_id <project_id> \\\n--job_id <job_id> \\\n--id <id> \\\n--data '{\"message\": \"Some message...\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -22557,7 +22557,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase comments delete \\\n--project_id <project_id> \\\n--job_id <key_id> \\\n--id <id> \\\n--branch my-feature-branch \\\n--access_token <token>"
+            "source": "phrase job_comments delete \\\n--project_id <project_id> \\\n--job_id <key_id> \\\n--id <id> \\\n--branch my-feature-branch \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.5"
@@ -22636,7 +22636,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase comments list \\\n--project_id <project_id> \\\n--job_id <key_id> \\\n--branch my-feature-branch \\\n--access_token <token>"
+            "source": "phrase job_comments list \\\n--project_id <project_id> \\\n--job_id <key_id> \\\n--branch my-feature-branch \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.5"
@@ -22698,7 +22698,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase comments create \\\n--project_id <project_id> \\\n--job_id <job_id> \\\n--data '{\"message\": \"Some message...\"}' \\\n--access_token <token>"
+            "source": "phrase job_comments create \\\n--project_id <project_id> \\\n--job_id <job_id> \\\n--data '{\"message\": \"Some message...\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {

--- a/paths/job_comments/create.yaml
+++ b/paths/job_comments/create.yaml
@@ -38,7 +38,7 @@ x-code-samples:
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
-    phrase comments create \
+    phrase job_comments create \
     --project_id <project_id> \
     --job_id <job_id> \
     --data '{"message": "Some message..."}' \

--- a/paths/job_comments/destroy.yaml
+++ b/paths/job_comments/destroy.yaml
@@ -34,7 +34,7 @@ x-code-samples:
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
-    phrase comments delete \
+    phrase job_comments delete \
     --project_id <project_id> \
     --job_id <key_id> \
     --id <id> \

--- a/paths/job_comments/index.yaml
+++ b/paths/job_comments/index.yaml
@@ -45,7 +45,7 @@ x-code-samples:
       -u USERNAME_OR_ACCESS_TOKEN
 - lang: CLI v2
   source: |-
-    phrase comments list \
+    phrase job_comments list \
     --project_id <project_id> \
     --job_id <key_id> \
     --branch my-feature-branch \

--- a/paths/job_comments/show.yaml
+++ b/paths/job_comments/show.yaml
@@ -42,7 +42,7 @@ x-code-samples:
       -u USERNAME_OR_ACCESS_TOKEN
 - lang: CLI v2
   source: |-
-    phrase comments show \
+    phrase job_comments show \
     --project_id <project_id> \
     --job_id <job_id> \
     --id <id> \

--- a/paths/job_comments/update.yaml
+++ b/paths/job_comments/update.yaml
@@ -39,7 +39,7 @@ x-code-samples:
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
-    phrase comments update \
+    phrase job_comments update \
     --project_id <project_id> \
     --job_id <job_id> \
     --id <id> \


### PR DESCRIPTION
We use cli v2 examples to generate docker comments for phrase cli.

Fix to use correct one.