### PR TITLE
Correct "Add keys to job" and "Remove keys from job" CLI example

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -8817,7 +8817,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase jobs keys \\\n--project_id <project_id> \\\n--id <id> \\\n--data '{\"branch\":\"my-feature-branch\", \"translation_key_ids\": \"abcd1234cdef1234abcd1234cdef1234\"}' \\\n--access_token <token>"
+            "source": "phrase jobs keys_create \\\n--project_id <project_id> \\\n--id <id> \\\n--data '{\"branch\":\"my-feature-branch\", \"translation_key_ids\": \"abcd1234cdef1234abcd1234cdef1234\"}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -8912,7 +8912,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase jobs keys \\\n--project_id <project_id> \\\n--id <id> \\\n--branch my-feature-branch \\\n--translation_key_ids \"abcd1234cdef1234abcd1234cdef1234\" \\\n--access_token <token>"
+            "source": "phrase jobs keys_delete \\\n--project_id <project_id> \\\n--id <id> \\\n--branch my-feature-branch \\\n--translation_key_ids \"abcd1234cdef1234abcd1234cdef1234\" \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.5"

--- a/paths/jobs/add_keys.yaml
+++ b/paths/jobs/add_keys.yaml
@@ -38,7 +38,7 @@ x-code-samples:
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
-    phrase jobs keys \
+    phrase jobs keys_create \
     --project_id <project_id> \
     --id <id> \
     --data '{"branch":"my-feature-branch", "translation_key_ids": "abcd1234cdef1234abcd1234cdef1234"}' \

--- a/paths/jobs/remove_keys.yaml
+++ b/paths/jobs/remove_keys.yaml
@@ -42,7 +42,7 @@ x-code-samples:
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
-    phrase jobs keys \
+    phrase jobs keys_delete \
     --project_id <project_id> \
     --id <id> \
     --branch my-feature-branch \


### PR DESCRIPTION
We are using the CLI examples to generate Orchestrator actions. This PR fixes the above-mentioned ones.

co-authored by @cschmatzler