### PR TITLE
CLI: Fix waiting for rate limit reset

### DIFF
--- a/clients/cli/cmd/internal/pull.go
+++ b/clients/cli/cmd/internal/pull.go
@@ -251,18 +251,20 @@ func (target *Target) createLocaleFiles(remoteLocale *phrase.Locale) (LocaleFile
 }
 
 func waitForRateLimit(rate phrase.Rate) {
-	var duration = time.Until(rate.Reset.Time)
+	endTime := rate.Reset.Time.Add(5 * time.Second)
+	duration := time.Until(endTime)
 	message := "\rRate limit exceeded. Download will resume in %d seconds"
-	seconds := int64(time.Until(rate.Reset.Time).Seconds())
+	seconds := int64(time.Until(endTime).Seconds())
 	fmt.Printf(message, seconds)
 	counter := int64(1)
 	ticker := time.NewTicker(1 * time.Second)
 	for range ticker.C {
 		counter++
-		seconds = int64(time.Until(rate.Reset.Time).Seconds())
+		seconds = int64(time.Until(endTime).Seconds())
 		fmt.Printf(message, seconds)
 		if counter > int64(duration/time.Second) {
 			ticker.Stop()
+			fmt.Println()
 			break
 		}
 	}

--- a/openapi-generator/cli_lang.yaml
+++ b/openapi-generator/cli_lang.yaml
@@ -2,4 +2,4 @@
 generatorName: go
 outputDir: clients/cli
 packageName: phrase
-packageVersion: 2.8.0
+packageVersion: 2.8.1


### PR DESCRIPTION
Fix waiting until rate limit timeout is reset and update waiting time dynamically

[Screencast from 2023-05-31 15-51-36.webm](https://github.com/phrase/openapi/assets/1757301/a327034c-ca79-4955-bbd9-7a8593de87d4)
