### PR TITLE
CLI: Fix batch printing for ratelimit message

### DIFF
--- a/clients/cli/cmd/internal/print/print.go
+++ b/clients/cli/cmd/internal/print/print.go
@@ -52,11 +52,21 @@ func NonBatchPrintf(msg string, args ...interface{}) {
 
 func Success(msg string, args ...interface{}) {
 	if shared.BatchMode {
-		jsonStuct := &InfoMessage{Message: fmt.Sprintf(msg, args...)}
-		encodedJson, _ := json.Marshal(jsonStuct)
+		jsonStruct := &InfoMessage{Message: fmt.Sprintf(msg, args...)}
+		encodedJson, _ := json.Marshal(jsonStruct)
 		fmt.Println(string(encodedJson))
 	} else {
 		WithColor(ct.Green, msg, args...)
+	}
+}
+
+func Warn(msg string, args ...interface{}) {
+	if shared.BatchMode {
+		jsonStruct := &InfoMessage{Message: fmt.Sprintf(msg, args...)}
+		encodedJson, _ := json.Marshal(jsonStruct)
+		fmt.Println(string(encodedJson))
+	} else {
+		WithColor(ct.Yellow, msg, args...)
 	}
 }
 

--- a/clients/cli/cmd/internal/pull.go
+++ b/clients/cli/cmd/internal/pull.go
@@ -253,18 +253,17 @@ func (target *Target) createLocaleFiles(remoteLocale *phrase.Locale) (LocaleFile
 func waitForRateLimit(rate phrase.Rate) {
 	endTime := rate.Reset.Time.Add(5 * time.Second)
 	duration := time.Until(endTime)
-	message := "\rRate limit exceeded. Download will resume in %d seconds"
+	message := "Rate limit exceeded. Download will resume in %d seconds"
 	seconds := int64(time.Until(endTime).Seconds())
-	fmt.Printf(message, seconds)
+	print.Warn(message, seconds)
 	counter := int64(1)
 	ticker := time.NewTicker(1 * time.Second)
 	for range ticker.C {
 		counter++
 		seconds = int64(time.Until(endTime).Seconds())
-		fmt.Printf(message, seconds)
+		print.Warn(message, seconds)
 		if counter > int64(duration/time.Second) {
 			ticker.Stop()
-			fmt.Println()
 			break
 		}
 	}

--- a/openapi-generator/cli_lang.yaml
+++ b/openapi-generator/cli_lang.yaml
@@ -2,4 +2,4 @@
 generatorName: go
 outputDir: clients/cli
 packageName: phrase
-packageVersion: 2.8.1
+packageVersion: 2.8.2


### PR DESCRIPTION
Print rate limit warning as JSON when `batch` mode is enabled. Timer is also no updated inline anymore as the color printing was interfering with that