### PR TITLE
docs: rename endpoint summaries to be unique

### DIFF
--- a/paths/spaces/add_project.yaml
+++ b/paths/spaces/add_project.yaml
@@ -1,5 +1,5 @@
 ---
-summary: Add Project
+summary: Add Project to Space
 description: Adds an existing project to the space.
 operationId: spaces/projects/create
 tags:

--- a/paths/spaces/remove_project.yaml
+++ b/paths/spaces/remove_project.yaml
@@ -1,5 +1,5 @@
 ---
-summary: Remove Project
+summary: Remove Project from Space
 description: Removes a specified project from the specified space.
 operationId: spaces/projects/delete
 tags:

--- a/paths/spaces/spaces_projects.yaml
+++ b/paths/spaces/spaces_projects.yaml
@@ -1,5 +1,5 @@
 ---
-summary: List Projects
+summary: List Projects in Space
 description: List all projects for the specified Space.
 operationId: spaces/projects/list
 tags:

--- a/paths/teams/add_project.yaml
+++ b/paths/teams/add_project.yaml
@@ -1,5 +1,5 @@
 ---
-summary: Add Project
+summary: Add Project to Team
 description: Adds an existing project to the team.
 operationId: teams/projects/create
 tags:

--- a/paths/teams/remove_project.yaml
+++ b/paths/teams/remove_project.yaml
@@ -1,5 +1,5 @@
 ---
-summary: Remove Project
+summary: Remove Project from Team
 description: Removes a specified project from the specified team.
 operationId: teams/projects/delete
 tags:


### PR DESCRIPTION
Actions in Orchestrator are showing up under the same name. Since we do not show any related categories, it was confusing what the action actually does.

![image](https://github.com/phrase/openapi/assets/34650380/1cd0f73b-8566-4814-bf05-13c29ffc8828)

##### What has been done

* rename endpoint summaries