### PR TITLE
fix(typescript): Serialize deep FormData parameters [TSI-1895]

### DIFF
--- a/openapi-generator/templates/typescript-fetch/apis.mustache
+++ b/openapi-generator/templates/typescript-fetch/apis.mustache
@@ -238,11 +238,16 @@ export class {{classname}} extends runtime.BaseAPI {
         {{/isListContainer}}
         {{^isListContainer}}
         if (requestParameters.{{paramName}} !== undefined) {
+            {{#isFreeFormObject}}
             this.flattenDeepParams({
                 {{baseName}}: requestParameters.{{paramName}}
             }).forEach(([name, value]) => {
                 formParams.append(name, value as any);
             });
+            {{/isFreeFormObject}}
+            {{^isFreeFormObject}}
+            formParams.append('{{baseName}}', requestParameters.{{paramName}} as any);
+            {{/isFreeFormObject}}
         }
 
         {{/isListContainer}}

--- a/openapi-generator/templates/typescript-fetch/apis.mustache
+++ b/openapi-generator/templates/typescript-fetch/apis.mustache
@@ -239,7 +239,7 @@ export class {{classname}} extends runtime.BaseAPI {
         {{^isListContainer}}
         if (requestParameters.{{paramName}} !== undefined) {
             this.flattenDeepParams({
-                {{paramName}}: requestParameters.{{paramName}}
+                {{baseName}}: requestParameters.{{paramName}}
             }).forEach(([name, value]) => {
                 formParams.append(name, value as any);
             });

--- a/openapi-generator/templates/typescript-fetch/apis.mustache
+++ b/openapi-generator/templates/typescript-fetch/apis.mustache
@@ -238,7 +238,11 @@ export class {{classname}} extends runtime.BaseAPI {
         {{/isListContainer}}
         {{^isListContainer}}
         if (requestParameters.{{paramName}} !== undefined) {
-            formParams.append('{{baseName}}', requestParameters.{{paramName}} as any);
+            this.flattenDeepParams({
+                {{paramName}}: requestParameters.{{paramName}}
+            }).forEach(([name, value]) => {
+                formParams.append(name, value as any);
+            });
         }
 
         {{/isListContainer}}

--- a/openapi-generator/templates/typescript-fetch/runtime.mustache
+++ b/openapi-generator/templates/typescript-fetch/runtime.mustache
@@ -98,6 +98,22 @@ export class BaseAPI {
         next.middleware = this.middleware.slice();
         return next;
     }
+
+    protected flattenDeepParams(obj: any, prefix?: string): any[] {
+        var res: any[] = [];
+        if (obj?.constructor === Array) {
+          obj.forEach(value => {
+            res = res.concat(this.flattenDeepParams(value, `${prefix}[]`));
+          });
+        } else if (obj?.constructor === Object) {
+          for (const key in obj) {
+            res = res.concat(this.flattenDeepParams(obj[key], prefix ? `${prefix}[${key}]` : key));
+          }
+        } else {
+          res = [[prefix, obj]];
+        }
+        return res;
+    }
 };
 
 export class RequiredError extends Error {


### PR DESCRIPTION
Addresses https://github.com/phrase/phrase-js/issues/16

`flattenDeepParams` implementation heavily inspired by https://github.com/rails/rails/blob/7-0-stable/activesupport/lib/active_support/core_ext/object/to_query.rb