### PR TITLE
fix(cli): Bump go library version

### DIFF
--- a/clients/cli/go.mod
+++ b/clients/cli/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/daviddengcn/go-colortext v1.0.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/mitchellh/mapstructure v1.4.0
-	github.com/phrase/phrase-go/v2 v2.10.3
+	github.com/phrase/phrase-go/v2 v2.11.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/clients/cli/go.sum
+++ b/clients/cli/go.sum
@@ -220,6 +220,8 @@ github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNC
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/phrase/phrase-go/v2 v2.10.3 h1:MZvJuVXw/ImtyWSsaWcP32R1zlL+7sN17e9UR1qlvPY=
 github.com/phrase/phrase-go/v2 v2.10.3/go.mod h1:N1ou4nnB9ak8aAWOH7x25Xhzw8FmFeBRhSGq5A0CY2o=
+github.com/phrase/phrase-go/v2 v2.11.0 h1:MQWSxH/UZgpOhH1hXg3smpQse61SSzkQNLixF9CQMrw=
+github.com/phrase/phrase-go/v2 v2.11.0/go.mod h1:N1ou4nnB9ak8aAWOH7x25Xhzw8FmFeBRhSGq5A0CY2o=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=


### PR DESCRIPTION
Addresses https://github.com/Homebrew/homebrew-core/pull/140271