### PR TITLE
fix(go): Update goreleaser config

### DIFF
--- a/clients/go/.goreleaser.yaml
+++ b/clients/go/.goreleaser.yaml
@@ -6,12 +6,13 @@ before:
 builds:
 - skip: true
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+- name_template: >-
+    {{ .ProjectName }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else if eq .Arch "386" }}i386
+    {{- else }}{{ .Arch }}{{ end }}
+    {{- if .Arm }}v{{ .Arm }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
`replacements` parameter has been deprecated and removed by `goreleaser`, so our release process was broken for some time.

https://goreleaser.com/deprecations/#archivesreplacements

https://github.com/phrase/phrase-go/actions/runs/5962357481/job/16173405854

I am not sure though if the `name_template` is equivalent as given. Not even sure whether that section is used at all in case of libraries or not, as we are releasing source code only, no binaries.