### PR TITLE
build(CLI): Automatically update go-phrase version in CLI

### DIFF
--- a/clients/cli/go.mod
+++ b/clients/cli/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/daviddengcn/go-colortext v1.0.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/mitchellh/mapstructure v1.4.0
-	github.com/phrase/phrase-go/v2 v2.14.0
+	github.com/phrase/phrase-go/v2 v2.14.0 // x-release-please-version
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/release-please/config-go.json
+++ b/release-please/config-go.json
@@ -39,7 +39,8 @@
           "type": "yaml",
           "path": "openapi-generator/go_lang.yaml",
           "jsonpath": "$.packageVersion"
-        }
+        },
+        "clients/cli/go.mod"
       ]
     }
   },


### PR DESCRIPTION
Try automating phrase-go version bump for CLI using https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files