### PR TITLE
docs: Expand multiline descriptions by default [TSI-2024]

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -41,6 +41,7 @@
       nav-item-spacing="relaxed"
       schema-style="table"
       schema-expand-level="1"
+      schema-description-expanded="true"
       theme="light"
     >
 


### PR DESCRIPTION
Avoid confusing users with descriptions collapsed by default and not being obvious that they can be expanded

https://phrase.atlassian.net/browse/TSI-2024