### PR TITLE
feat: [TSI-2083] enable format_options argument for java-client  

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -18,7 +18,4 @@ jobs:
       with:
         gradle-version: 7.1.1
         build-root-directory: ./clients/java
-    - name: Run tests
-      run: |
-        cd clients/java
-        ./gradlew test --info
+        args: test --info

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -13,9 +13,12 @@ jobs:
       with:
         distribution: temurin
         java-version: 11
-    - name: Run Gradle Tests
+    - name: Set up Gradle
       uses: gradle/gradle-build-action@v2
       with:
         gradle-version: 7.1.1
         build-root-directory: ./clients/java
-        arguments: test
+    - name: Run tests
+      run: |
+        cd clients/java
+        ./gradlew test --info

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -13,9 +13,9 @@ jobs:
       with:
         distribution: temurin
         java-version: 11
-    - name: Set up Gradle
+    - name: Run gradle test
       uses: gradle/gradle-build-action@v2
       with:
         gradle-version: 7.1.1
         build-root-directory: ./clients/java
-        args: test --info
+        arguments: test --info

--- a/clients/java/src/test/java/com/phrase/client/api/LocalesApiTest.java
+++ b/clients/java/src/test/java/com/phrase/client/api/LocalesApiTest.java
@@ -137,9 +137,14 @@ public class LocalesApiTest {
 
         mockBackend.enqueue(mockResponse);
 
-        Map<String, String> formatOptionsMap = new HashMap<>();
+        
+        Map<String, String> nestedFormatOptionsMap = new HashMap<>();
+        nestedFormatOptionsMap.put("nested_option", "sub_option");
+        
+        Map<String, Object> formatOptionsMap = new HashMap<>();
         formatOptionsMap.put("omit_separator_space", "true");
         formatOptionsMap.put("fallback_language", "en");
+        formatOptionsMap.put("more_options", nestedFormatOptionsMap);
 
         String projectId = "MY_PROJECT_ID";
         String id = "MY_ID";
@@ -168,7 +173,8 @@ public class LocalesApiTest {
         Assert.assertEquals("Correct file contents", fileContents, body);
 
         RecordedRequest recordedRequest = mockBackend.takeRequest();
-        Assert.assertEquals("Request path", "//projects/MY_PROJECT_ID/locales/MY_ID/download?format_options%5Bomit_separator_space%5D=true&format_options%5Bfallback_language%5D=en", recordedRequest.getPath());
+        // for some reason with deep nested query params, ordering of query params change
+        Assert.assertEquals("Request path", "//projects/MY_PROJECT_ID/locales/MY_ID/download?format_options%5Bomit_separator_space%5D=true&format_options%5Bmore_options%5D%5Bnested_option%5D=sub_option&format_options%5Bfallback_language%5D=en", recordedRequest.getPath());
     }
 
     /**

--- a/clients/java/src/test/java/com/phrase/client/api/LocalesApiTest.java
+++ b/clients/java/src/test/java/com/phrase/client/api/LocalesApiTest.java
@@ -137,6 +137,10 @@ public class LocalesApiTest {
 
         mockBackend.enqueue(mockResponse);
 
+        Map<String, String> formatOptionsMap = new HashMap<>();
+        formatOptionsMap.put("omit_separator_space", "true");
+        formatOptionsMap.put("fallback_language", "en");
+
         String projectId = "MY_PROJECT_ID";
         String id = "MY_ID";
         String xPhraseAppOTP = null;
@@ -151,7 +155,7 @@ public class LocalesApiTest {
         Boolean includeTranslatedKeys = null;
         Boolean keepNotranslateTags = null;
         Boolean convertEmoji = null;
-        Object formatOptions = null;
+        Object formatOptions = formatOptionsMap;
         String encoding = null;
         Boolean skipUnverifiedTranslations = null;
         Boolean includeUnverifiedTranslations = null;
@@ -164,7 +168,7 @@ public class LocalesApiTest {
         Assert.assertEquals("Correct file contents", fileContents, body);
 
         RecordedRequest recordedRequest = mockBackend.takeRequest();
-        Assert.assertEquals("Request path", "//projects/MY_PROJECT_ID/locales/MY_ID/download", recordedRequest.getPath());
+        Assert.assertEquals("Request path", "//projects/MY_PROJECT_ID/locales/MY_ID/download?format_options[omit_separator_space]=true&format_options[fallback_language]=en", recordedRequest.getPath());
     }
 
     /**

--- a/clients/java/src/test/java/com/phrase/client/api/LocalesApiTest.java
+++ b/clients/java/src/test/java/com/phrase/client/api/LocalesApiTest.java
@@ -168,7 +168,7 @@ public class LocalesApiTest {
         Assert.assertEquals("Correct file contents", fileContents, body);
 
         RecordedRequest recordedRequest = mockBackend.takeRequest();
-        Assert.assertEquals("Request path", "//projects/MY_PROJECT_ID/locales/MY_ID/download?format_options[omit_separator_space]=true&format_options[fallback_language]=en", recordedRequest.getPath());
+        Assert.assertEquals("Request path", "//projects/MY_PROJECT_ID/locales/MY_ID/download?format_options%5Bomit_separator_space%5D=true&format_options%5Bfallback_language%5D=en", recordedRequest.getPath());
     }
 
     /**

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -7450,7 +7450,9 @@
             "schema": {
               "type": "object",
               "properties": {}
-            }
+            },
+            "style": "deepObject",
+            "explode": true
           },
           {
             "description": "Enforces a specific encoding on the file contents. Valid options are \"UTF-8\", \"UTF-16\" and \"ISO-8859-1\".",

--- a/openapi-generator/templates/java/build.gradle.mustache
+++ b/openapi-generator/templates/java/build.gradle.mustache
@@ -122,7 +122,7 @@ if(hasProperty('target') && target == 'android') {
        main = System.getProperty('mainClass')
        classpath = sourceSets.main.runtimeClasspath
     }
-    
+
     task sourcesJar(type: Jar, dependsOn: classes) {
         classifier = 'sources'
         from sourceSets.main.allSource
@@ -177,6 +177,12 @@ dependencies {
     testCompile "junit:junit:$junit_version"
 }
 
+test {
+    testLogging {
+        outputs.upToDateWhen {false}
+        showStandardStreams = true
+    }
+}
 
 publishing {
   publications {

--- a/openapi-generator/templates/java/libraries/okhttp-gson/ApiClient.mustache
+++ b/openapi-generator/templates/java/libraries/okhttp-gson/ApiClient.mustache
@@ -659,7 +659,8 @@ public class ApiClient {
         StringBuilder builder = new StringBuilder();
 
         for(Map.Entry<String, String> entry : parameter.entrySet()){
-            String key = builder.append(name).append("[").append(entry.getKey()).append("]");
+            {{! String key = builder.append(name).append("[").append(entry.getKey()).append("]"); }}
+            String key = name + "[" + entry.getKey() + "]";
             String value = entry.getValue();
 
             params.add(new Pair(key, parameterToString(value)));

--- a/openapi-generator/templates/java/libraries/okhttp-gson/ApiClient.mustache
+++ b/openapi-generator/templates/java/libraries/okhttp-gson/ApiClient.mustache
@@ -662,8 +662,6 @@ public class ApiClient {
             Map<String, String> mappedParameter = (Map<String, String>) parameter;
 
             for(Map.Entry<String, String> entry : mappedParameter.entrySet()){
-                System.out.println(entry);
-                {{! String key = builder.append(name).append("[").append(entry.getKey()).append("]"); }}
                 String key = name + "[" + entry.getKey() + "]";
                 String value = entry.getValue();
 

--- a/openapi-generator/templates/java/libraries/okhttp-gson/ApiClient.mustache
+++ b/openapi-generator/templates/java/libraries/okhttp-gson/ApiClient.mustache
@@ -656,7 +656,6 @@ public class ApiClient {
 
     public List<Pair> mappedParameterToPairs(String name, Object parameter){
         List<Pair> params = new ArrayList<Pair>();
-        StringBuilder builder = new StringBuilder();
 
         if(parameter instanceof Map){
             Map<String, String> mappedParameter = (Map<String, String>) parameter;

--- a/openapi-generator/templates/java/libraries/okhttp-gson/ApiClient.mustache
+++ b/openapi-generator/templates/java/libraries/okhttp-gson/ApiClient.mustache
@@ -658,13 +658,14 @@ public class ApiClient {
         List<Pair> params = new ArrayList<Pair>();
 
         if(parameter instanceof Map){
-            Map<String, String> mappedParameter = (Map<String, String>) parameter;
+            Map<String, Object> mappedParameter = (Map<String, Object>) parameter;
 
-            for(Map.Entry<String, String> entry : mappedParameter.entrySet()){
+            for(Map.Entry<String, Object> entry : mappedParameter.entrySet()){
                 String key = name + "[" + entry.getKey() + "]";
-                String value = entry.getValue();
+                Object value = entry.getValue();
 
-                params.add(new Pair(key, parameterToString(value)));
+                {{! TODO check why nested params ordering is different }}
+                params.addAll(parsedMappedParams(key, value, new ArrayList<Pair>()));
             }
 
         }
@@ -1465,4 +1466,21 @@ public class ApiClient {
             throw new AssertionError(e);
         }
     }
+
+    private List<Pair> parsedMappedParams(String key, Object value, List<Pair> params){
+        if(value instanceof Map){
+            Map<String, Object> mappedValue = (Map<String, Object>) value;
+
+            for(Map.Entry<String, Object> entry : mappedValue.entrySet()){
+                String nestedKey = key + "[" + entry.getKey() + "]";
+                parsedMappedParams(nestedKey, entry.getValue(), params); 
+            }
+        }
+        else{
+            params.add(new Pair(key, parameterToString(value)));    
+        }
+
+        return params;
+    }
+
 }

--- a/openapi-generator/templates/java/libraries/okhttp-gson/ApiClient.mustache
+++ b/openapi-generator/templates/java/libraries/okhttp-gson/ApiClient.mustache
@@ -654,17 +654,24 @@ public class ApiClient {
         }
     }
 
-    public List<Pair> mappedParameterToPairs(String name, Map<String, String> parameter){
+    public List<Pair> mappedParameterToPairs(String name, Object parameter){
         List<Pair> params = new ArrayList<Pair>();
         StringBuilder builder = new StringBuilder();
 
-        for(Map.Entry<String, String> entry : parameter.entrySet()){
-            {{! String key = builder.append(name).append("[").append(entry.getKey()).append("]"); }}
-            String key = name + "[" + entry.getKey() + "]";
-            String value = entry.getValue();
+        if(parameter instanceof Map){
+            Map<String, String> mappedParameter = (Map<String, String>) parameter;
 
-            params.add(new Pair(key, parameterToString(value)));
+            for(Map.Entry<String, String> entry : mappedParameter.entrySet()){
+                System.out.println(entry);
+                {{! String key = builder.append(name).append("[").append(entry.getKey()).append("]"); }}
+                String key = name + "[" + entry.getKey() + "]";
+                String value = entry.getValue();
+
+                params.add(new Pair(key, parameterToString(value)));
+            }
+
         }
+        
 
         return params;
     }

--- a/openapi-generator/templates/java/libraries/okhttp-gson/ApiClient.mustache
+++ b/openapi-generator/templates/java/libraries/okhttp-gson/ApiClient.mustache
@@ -654,6 +654,21 @@ public class ApiClient {
         }
     }
 
+    public List<Pair> mappedParameterToPairs(String name, Map<String, String> parameter){
+        List<Pair> params = new ArrayList<Pair>();
+        StringBuilder builder = new StringBuilder();
+
+        for(Map.Entry<String, String> entry : parameter.entrySet()){
+            String key = builder.append(name).append("[").append(entry.getKey()).append("]");
+            String value = entry.getValue();
+
+            params.add(new Pair(key, parameterToString(value)));
+        }
+
+        return params;
+    }
+
+
     /**
      * Formats the specified query parameter to a list containing a single {@code Pair} object.
      *

--- a/openapi-generator/templates/java/libraries/okhttp-gson/api.mustache
+++ b/openapi-generator/templates/java/libraries/okhttp-gson/api.mustache
@@ -100,12 +100,12 @@ public class {{classname}} {
         {{javaUtilPrefix}}List<Pair> localVarCollectionQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();
         {{#queryParams}}
         if ({{paramName}} != null) {
-            {{#isMap}}
+            {{#isDeepObject}}
             localVarQueryParams.addAll(localVarApiClient.mappedParameterToPairs("{{baseName}}", {{paramName}}));
-            {{/isMap}}
-            {{^isMap}}
+            {{/isDeepObject}}
+            {{^isDeepObject}}
             {{#collectionFormat}}localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("{{{collectionFormat}}}", {{/collectionFormat}}{{^collectionFormat}}localVarQueryParams.addAll(localVarApiClient.parameterToPair({{/collectionFormat}}"{{baseName}}", {{paramName}}));
-            {{/isMap}}
+            {{/isDeepObject}}
         }
 
         {{/queryParams}}

--- a/openapi-generator/templates/java/libraries/okhttp-gson/api.mustache
+++ b/openapi-generator/templates/java/libraries/okhttp-gson/api.mustache
@@ -100,7 +100,12 @@ public class {{classname}} {
         {{javaUtilPrefix}}List<Pair> localVarCollectionQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();
         {{#queryParams}}
         if ({{paramName}} != null) {
+            {{#isMap}}
+            localVarQueryParams.addAll(localVarApiClient.mappedParameterToPairs("{{baseName}}", {{paramName}}));
+            {{/isMap}}
+            {{^isMap}}
             {{#collectionFormat}}localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("{{{collectionFormat}}}", {{/collectionFormat}}{{^collectionFormat}}localVarQueryParams.addAll(localVarApiClient.parameterToPair({{/collectionFormat}}"{{baseName}}", {{paramName}}));
+            {{/isMap}}
         }
 
         {{/queryParams}}

--- a/paths/locales/download.yaml
+++ b/paths/locales/download.yaml
@@ -73,6 +73,8 @@ parameters:
     schema:
       type: object
       properties: {}
+    style: deepObject
+    explode: true
   - description: Enforces a specific encoding on the file contents. Valid options are "UTF-8", "UTF-16" and "ISO-8859-1".
     example:
     name: encoding


### PR DESCRIPTION
## Assumptions
Some assumptions made while working on the PR:

- `format_options` argument will be key-value based map with values mostly being of primitive types
- Initially explored the possibility of using params with `style` `deepObject` and `explode: true` option as suggested [here](https://stackoverflow.com/questions/48491688/how-to-define-parameters-with-square-brackets-in-openapi-swagger/48498055#48498055) as a fix but subsquently wasn't able to find appropriate mustache directive to determine if the param has any of these attributes (deepObject, explode: true) which led to adding a fix by checking if input is of the type Map and if yes, manually convert it to key value based `Pair` objects.


## Problem Statement
Phrase API accepts `format_options` argument on [locales download](https://developers.phrase.com/api/#get-/projects/-project_id-/locales/-id-/download) endpoint. 

For java-client the format_option argument was not being properly parsed and embedded in the query params resulting in a request url like below

```
https://api.phrase.com/v2/projects/e4c0450ccc8dcc087fac8351ecc89eb6/locales/01877decc84124a75fdd0a4fc147d8de/download?file_format=properties&tags=menu&format_options=%7B%22omit_separator_space%22%3Atrue%7D&encoding=UTF-8
```

## Solution
This pull requests adds the ability to parse any query params of type map and embed them to the URL's query string as proper key value pairs resulting in request URLs like:
```
localhost:3000/api/v2/projects/:project_id/locales/:id/download?file_format=i18next_4&format_options%5Bnesting%5D=false
```

