### PR TITLE
docs: Correct example data for get a single job spec

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -2921,13 +2921,11 @@
                 "name": "Joe Doe"
               },
               "job_tag_name": "Job_123",
-              "source_locale": [
-                {
-                  "id": "abcd1234cdef1234abcd1234cdef1235",
-                  "name": "de-DE",
-                  "code": "de-DE"
-                }
-              ],
+              "source_locale": {
+                "id": "abcd1234cdef1234abcd1234cdef1235",
+                "name": "de-DE",
+                "code": "de-DE"
+              },
               "locales": [
                 {
                   "id": "abcd1234cdef1234abcd1234cdef1234",

--- a/schemas/job_details.yaml
+++ b/schemas/job_details.yaml
@@ -26,7 +26,7 @@ job_details:
         name: Joe Doe
       job_tag_name: Job_123
       source_locale:
-      - id: abcd1234cdef1234abcd1234cdef1235
+        id: abcd1234cdef1234abcd1234cdef1235
         name: de-DE
         code: de-DE
       locales:


### PR DESCRIPTION
Fixed example data for get a single job spec.

There is actual response, the source locale is object, not array.

```
{
    "id": "5dabeecef237159f189b2af75b8da44c",
    "name": "Translations from 2023-10-18",
    "owner": {
        "id": "b233e...",
        "username": "Maksym...",
        "name": "Maksym..."
    },
    "briefing": "",
    "job_tag_name": "job-12B309E9",
    "due_date": "2023-10-25T11:00:00Z",
    "state": "draft",
    "ticket_url": "",
    "project": {
        "id": "87d8b621...",
        "name": "test",
        "main_format": "",
        "created_at": "2023-07-19T12: 10: 01Z",
        "updated_at": "2023-10-18T13: 51: 50Z"
    },
    "branch": null,
    "created_at": "2023-10-18T13: 51: 50Z",
    "updated_at": "2023-10-18T13: 51: 50Z",
    "source_locale": {
        "id": "0f4bc54...",
        "name": "en",
        "code": "en"
    },
    "locales": [],
    "keys": [],
    "locked": false
}
```