### PR TITLE
docs: correct upload create docs (add required fields)

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -12908,6 +12908,11 @@
               "schema": {
                 "type": "object",
                 "title": "upload/create/parameters",
+                "required": [
+                  "file",
+                  "file_format",
+                  "locale_id"
+                ],
                 "properties": {
                   "branch": {
                     "description": "specify the branch to use",

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -59,6 +59,10 @@ requestBody:
       schema:
         type: object
         title: upload/create/parameters
+        required:
+          - file
+          - file_format
+          - locale_id
         properties:
           branch:
             description: specify the branch to use


### PR DESCRIPTION
It's not possible to use Upload Create endpoint without those fields, they are required:

```
"file",
"file_format",
"locale_id"
```