### PR TITLE
feat(CLI): On pull error, print the API response [TSI-1750]

### DIFF
--- a/clients/cli/cmd/internal/pull.go
+++ b/clients/cli/cmd/internal/pull.go
@@ -120,6 +120,9 @@ func (target *Target) Pull(client *phrase.APIClient, branch string) error {
 
 		err = target.DownloadAndWriteToFile(client, localeFile, branch)
 		if err != nil {
+			if openapiError, ok := err.(phrase.GenericOpenAPIError); ok {
+				print.Warn("API response: %s", openapiError.Body())
+			}
 			return fmt.Errorf("%s for %s", err, localeFile.Path)
 		} else {
 			print.Success("Downloaded %s to %s", localeFile.Message(), localeFile.RelPath())


### PR DESCRIPTION
Now when there's an error on CLI pull, the users are left in dark as the server response (which usually explains the reason for the error) is not printed out. This PR addresses that.

https://phrase.atlassian.net/browse/TSI-1750

Related: https://github.com/phrase/phrase-cli/issues/126