### PR TITLE
feat: update translation key create/update with custom metadata. Add CM schema in translation key response

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -19897,11 +19897,11 @@
         "x-code-samples": [
           {
             "lang": "Curl",
-            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/keys\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X POST \\\n  -F branch=my-feature-branch \\\n  -F name=home.index.headline \\\n  -F description=Some%20description%20worth%20knowing... \\\n  -F name_plural=home.index.headlines \\\n  -F data_type=number \\\n  -F tags=awesome-feature,needs-proofreading \\\n  -F max_characters_allowed=140 \\\n  -F screenshot=@/path/to/my/screenshot.png"
+            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/keys\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X POST \\\n  -F branch=my-feature-branch \\\n  -F name=home.index.headline \\\n  -F description=Some%20description%20worth%20knowing... \\\n  -F name_plural=home.index.headlines \\\n  -F data_type=number \\\n  -F tags=awesome-feature,needs-proofreading \\\n  -F max_characters_allowed=140 \\\n  -F screenshot=@/path/to/my/screenshot.png\n  -F custom_metadata[property]=value"
           },
           {
             "lang": "CLI v2",
-            "source": "phrase keys create \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"name\":\"home.index.headline\", \"description\": \"Some description worth knowing...\", \"name_plural\":\"home.index.headlines\", \"data_type\":\"number\", \"tags\":\"awesome-feature,needs-proofreading\", \"max_characters_allowed\":\"140\", \"screenshot\":\"/path/to/my/screenshot.png\"}' \\\n--access_token <token>"
+            "source": "phrase keys create \\\n--project_id <project_id> \\\n--data '{\"branch\":\"my-feature-branch\", \"name\":\"home.index.headline\", \"description\": \"Some description worth knowing...\", \"name_plural\":\"home.index.headlines\", \"data_type\":\"number\", \"tags\":\"awesome-feature,needs-proofreading\", \"max_characters_allowed\":\"140\", \"screenshot\":\"/path/to/my/screenshot.png\", \"custom_metadata\": {\"property\" => \"value\"}}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -19994,6 +19994,14 @@
                     "description": "NSStringLocalizedFormatKey attribute. Used in .stringsdict format.",
                     "type": "string",
                     "example": null
+                  },
+                  "custom_metadata": {
+                    "description": "Custom metadata property name and value pairs to be associated with key.",
+                    "type": "object",
+                    "example": {
+                      "fruit": "Apple",
+                      "vegetable": "Tomato"
+                    }
                   }
                 }
               }
@@ -20322,11 +20330,11 @@
         "x-code-samples": [
           {
             "lang": "Curl",
-            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/keys/:id\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X PATCH \\\n  -F branch=my-feature-branch \\\n  -F name=home.index.headline \\\n  -F description=Some%20description%20worth%20knowing... \\\n  -F name_plural=home.index.headlines \\\n  -F data_type=number \\\n  -F tags=awesome-feature,needs-proofreading \\\n  -F max_characters_allowed=140 \\\n  -F screenshot=@/path/to/my/screenshot.png"
+            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/keys/:id\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X PATCH \\\n  -F branch=my-feature-branch \\\n  -F name=home.index.headline \\\n  -F description=Some%20description%20worth%20knowing... \\\n  -F name_plural=home.index.headlines \\\n  -F data_type=number \\\n  -F tags=awesome-feature,needs-proofreading \\\n  -F max_characters_allowed=140 \\\n  -F screenshot=@/path/to/my/screenshot.png\n  -F custom_metadata[property]=value"
           },
           {
             "lang": "CLI v2",
-            "source": "phrase keys update \\\n--project_id <project_id> \\\n--id <id> \\\n--data '{\"branch\":\"my-feature-branch\", \"name\":\"home.index.headline\", \"description\": \"Some description worth knowing...\", \"name_plural\":\"home.index.headlines\", \"data_type\":\"number\", \"tags\":\"awesome-feature,needs-proofreading\", \"max_characters_allowed\":\"140\", \"screenshot\":\"/path/to/my/screenshot.png\"}' \\\n--access_token <token>"
+            "source": "phrase keys update \\\n--project_id <project_id> \\\n--id <id> \\\n--data '{\"branch\":\"my-feature-branch\", \"name\":\"home.index.headline\", \"description\": \"Some description worth knowing...\", \"name_plural\":\"home.index.headlines\", \"data_type\":\"number\", \"tags\":\"awesome-feature,needs-proofreading\", \"max_characters_allowed\":\"140\", \"screenshot\":\"/path/to/my/screenshot.png\", \"custom_metadata\": {\"property\" => \"value\"}}' \\\n--access_token <token>"
           }
         ],
         "requestBody": {
@@ -20414,6 +20422,14 @@
                     "description": "NSStringLocalizedFormatKey attribute. Used in .stringsdict format.",
                     "type": "string",
                     "example": null
+                  },
+                  "custom_metadata": {
+                    "description": "Custom metadata property name and value pairs to be associated with key.",
+                    "type": "object",
+                    "example": {
+                      "fruit": "Apple",
+                      "vegetable": "Tomato"
+                    }
                   }
                 }
               }

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -2389,6 +2389,13 @@
               },
               "creator": {
                 "$ref": "#/components/schemas/user_preview"
+              },
+              "custom_metadata": {
+                "type": "object",
+                "title": "custom_metadata",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             },
             "example": {
@@ -2405,6 +2412,10 @@
                 "id": "abcd1234cdef1234abcd1234cdef1234",
                 "username": "joe.doe",
                 "name": "Joe Doe"
+              },
+              "custom_metadata": {
+                "fruit": "Apple",
+                "vegetable": "Tomato"
               }
             }
           }

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -20435,7 +20435,7 @@
                     "example": null
                   },
                   "custom_metadata": {
-                    "description": "Custom metadata property name and value pairs to be associated with key.",
+                    "description": "Updates/Creates custom metadata property name and value pairs to be associated with key. If you want to delete a custom metadata property, you can set its value to null. If you want to update a custom metadata property, you can set its value to the new value.",
                     "type": "object",
                     "example": {
                       "fruit": "Apple",

--- a/paths/keys/create.yaml
+++ b/paths/keys/create.yaml
@@ -126,5 +126,8 @@ requestBody:
           custom_metadata:
             description: Custom metadata property name and value pairs to be associated with key.
             type: object
+            example:
+              fruit: Apple
+              vegetable: Tomato
             
 x-cli-version: '2.5'

--- a/paths/keys/create.yaml
+++ b/paths/keys/create.yaml
@@ -41,11 +41,12 @@ x-code-samples:
       -F tags=awesome-feature,needs-proofreading \
       -F max_characters_allowed=140 \
       -F screenshot=@/path/to/my/screenshot.png
+      -F custom_metadata[property]=value
 - lang: CLI v2
   source: |-
     phrase keys create \
     --project_id <project_id> \
-    --data '{"branch":"my-feature-branch", "name":"home.index.headline", "description": "Some description worth knowing...", "name_plural":"home.index.headlines", "data_type":"number", "tags":"awesome-feature,needs-proofreading", "max_characters_allowed":"140", "screenshot":"/path/to/my/screenshot.png"}' \
+    --data '{"branch":"my-feature-branch", "name":"home.index.headline", "description": "Some description worth knowing...", "name_plural":"home.index.headlines", "data_type":"number", "tags":"awesome-feature,needs-proofreading", "max_characters_allowed":"140", "screenshot":"/path/to/my/screenshot.png", "custom_metadata": {"property" => "value"}}' \
     --access_token <token>
 requestBody:
   required: true
@@ -122,4 +123,8 @@ requestBody:
             description: NSStringLocalizedFormatKey attribute. Used in .stringsdict format.
             type: string
             example:
+          custom_metadata:
+            description: Custom metadata property name and value pairs to be associated with key.
+            type: object
+            
 x-cli-version: '2.5'

--- a/paths/keys/update.yaml
+++ b/paths/keys/update.yaml
@@ -42,12 +42,13 @@ x-code-samples:
       -F tags=awesome-feature,needs-proofreading \
       -F max_characters_allowed=140 \
       -F screenshot=@/path/to/my/screenshot.png
+      -F custom_metadata[property]=value
 - lang: CLI v2
   source: |-
     phrase keys update \
     --project_id <project_id> \
     --id <id> \
-    --data '{"branch":"my-feature-branch", "name":"home.index.headline", "description": "Some description worth knowing...", "name_plural":"home.index.headlines", "data_type":"number", "tags":"awesome-feature,needs-proofreading", "max_characters_allowed":"140", "screenshot":"/path/to/my/screenshot.png"}' \
+    --data '{"branch":"my-feature-branch", "name":"home.index.headline", "description": "Some description worth knowing...", "name_plural":"home.index.headlines", "data_type":"number", "tags":"awesome-feature,needs-proofreading", "max_characters_allowed":"140", "screenshot":"/path/to/my/screenshot.png", "custom_metadata": {"property" => "value"}}' \
     --access_token <token>
 requestBody:
   required: true
@@ -120,4 +121,10 @@ requestBody:
             description: NSStringLocalizedFormatKey attribute. Used in .stringsdict format.
             type: string
             example:
+          custom_metadata:
+            description: Custom metadata property name and value pairs to be associated with key.
+            type: object
+            example:
+              fruit: Apple
+              vegetable: Tomato
 x-cli-version: '2.5'

--- a/paths/keys/update.yaml
+++ b/paths/keys/update.yaml
@@ -122,7 +122,7 @@ requestBody:
             type: string
             example:
           custom_metadata:
-            description: Custom metadata property name and value pairs to be associated with key.
+            description: Updates/Creates custom metadata property name and value pairs to be associated with key. If you want to delete a custom metadata property, you can set its value to null. If you want to update a custom metadata property, you can set its value to the new value.
             type: object
             example:
               fruit: Apple

--- a/schemas/translation_key_details.yaml
+++ b/schemas/translation_key_details.yaml
@@ -23,6 +23,11 @@ translation_key_details:
         type: string
       creator:
         "$ref": "./user_preview.yaml#/user_preview"
+      custom_metadata:
+        type: object
+        title: custom_metadata
+        additionalProperties:
+          type: string
     example:
       name_plural: home.index.headlines
       comments_count: 2
@@ -37,3 +42,6 @@ translation_key_details:
         id: abcd1234cdef1234abcd1234cdef1234
         username: joe.doe
         name: Joe Doe
+      custom_metadata:
+        fruit: Apple
+        vegetable: Tomato


### PR DESCRIPTION
### Description
update translation key create/update with custom metadata. Also. add CM in translation key schema response


response CM in translation key
<img width="443" alt="Screenshot 2023-12-12 at 14 20 33" src="https://github.com/phrase/openapi/assets/1410408/15edc216-8424-4301-88fd-ec0c63bacd50">

Update/Create CM on translation key

https://github.com/phrase/openapi/assets/108525179/cecd517f-6d0e-42fc-a172-812c80612d69


### Ticket
https://phrase.atlassian.net/browse/TSS-2504