### PR TITLE
feat(API): Add url field to uploads [TSI-1735]

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -1724,6 +1724,10 @@
           "tag": {
             "type": "string"
           },
+          "url": {
+            "type": "string",
+            "description": "The URL to the upload in Phrase Strings app.\n"
+          },
           "summary": {
             "type": "object",
             "properties": {

--- a/schemas/upload.yaml
+++ b/schemas/upload.yaml
@@ -13,6 +13,10 @@ upload:
       type: string
     tag:
       type: string
+    url:
+      type: string
+      description: |
+        The URL to the upload in Phrase Strings app.
     summary:
       type: object
       properties:


### PR DESCRIPTION
Adds `url` field to upload payload, so that users can easily visit the Phrase App and see the corresponding upload