### PR TITLE
build(CLI): Fix broken API template

### DIFF
--- a/openapi-generator/templates/cli/api.handlebars
+++ b/openapi-generator/templates/cli/api.handlebars
@@ -67,9 +67,9 @@ func init{{{nickname}}}() {
 						{{else~}}
 							if params.IsSet(helpers.ToSnakeCase("{{paramName}}")) {
 								var {{paramName}} map[string]interface{}
-								if err := json.Unmarshal([]byte(params.GetString(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}"))),
-								&{{paramName}}); err != nil {
+								if err := json.Unmarshal([]byte(params.GetString(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}"))), &{{paramName}}); err != nil {
 									HandleError(err)
+								}
 							}
 							localVarOptionals.{{{vendorExtensions.x-export-param-name}}} = optional.NewInterface({{paramName}})
 						{{/isModel~}}

--- a/openapi-generator/templates/cli/api.handlebars
+++ b/openapi-generator/templates/cli/api.handlebars
@@ -70,8 +70,8 @@ func init{{{nickname}}}() {
 								if err := json.Unmarshal([]byte(params.GetString(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}"))), &{{paramName}}); err != nil {
 									HandleError(err)
 								}
+								localVarOptionals.{{{vendorExtensions.x-export-param-name}}} = optional.NewInterface({{paramName}})
 							}
-							localVarOptionals.{{{vendorExtensions.x-export-param-name}}} = optional.NewInterface({{paramName}})
 						{{/isModel~}}
 					{{/isPrimitiveType~}}
 				{{else~}}


### PR DESCRIPTION
seems that https://github.com/phrase/openapi/pull/199/files#diff-cf7b4bb3c2d75383f6a3126d13a8ded9303fe36224c090daa1d9f29a5c75fdf5R71 broke the syntax of the generated API modules for CLI, resulting with: https://github.com/phrase/openapi/actions/runs/7194539626/job/19595281387

This fixes at least syntactic part of it.