### PR TITLE
fix(CLI): fix required parameter handling

### DIFF
--- a/openapi-generator/templates/cli/api.handlebars
+++ b/openapi-generator/templates/cli/api.handlebars
@@ -56,23 +56,13 @@ func init{{{nickname}}}() {
 					{{#isPrimitiveType~}}
 						{{paramName}} := params.Get{{{capitalizeFirst dataType}}}(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}"))
 					{{else~}}
-						{{#isModel~}}
-							{{paramName}} := api.{{{dataType}}}{}
-							if err := json.Unmarshal([]byte(params.GetString("data")), &{{paramName}}); err != nil {
-								HandleError(err)
-							}
-							if Config.Debug {
-								fmt.Printf("%+v\n", {{paramName}})
-							}
-						{{else~}}
-							if params.IsSet(helpers.ToSnakeCase("{{paramName}}")) {
-								var {{paramName}} map[string]interface{}
-								if err := json.Unmarshal([]byte(params.GetString(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}"))), &{{paramName}}); err != nil {
-									HandleError(err)
-								}
-								localVarOptionals.{{{vendorExtensions.x-export-param-name}}} = optional.NewInterface({{paramName}})
-							}
-						{{/isModel~}}
+						var {{paramName}} api.{{{dataType}}}
+						if err := json.Unmarshal([]byte(params.GetString("data")), &{{paramName}}); err != nil {
+							HandleError(err)
+						}
+						if Config.Debug {
+							fmt.Printf("%+v\n", {{paramName}})
+						}
 					{{/isPrimitiveType~}}
 				{{else~}}
 					{{#if (or (eq paramName "file") (eq paramName "filename"))~}}


### PR DESCRIPTION
Custom metadata API introduced combination of parameters for `create` endpoint which was broken in CLI generator template. This PR at least makes it compile. However, this endpoint is broken as the generator hardcodes POST data expected to be in `data` JSON, rather then set of individual parameters. We'll address this in separate PR.