### PR TITLE
feat(CLI): Improve push error display [TSI-1736]

### DIFF
--- a/clients/cli/cmd/internal/push.go
+++ b/clients/cli/cmd/internal/push.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -150,6 +151,7 @@ func (source *Source) Push(client *phrase.APIClient, waitForResults bool, branch
 		return err
 	}
 
+	noErrors := true
 	for _, localeFile := range localeFiles {
 		print.NonBatchPrintf("Uploading %s... ", localeFile.RelPath())
 
@@ -167,6 +169,9 @@ func (source *Source) Push(client *phrase.APIClient, waitForResults bool, branch
 
 		upload, err := source.uploadFile(client, localeFile, branch, tag)
 		if err != nil {
+			if openapiError, ok := err.(phrase.GenericOpenAPIError); ok {
+				print.Warn("API response: %s", openapiError.Body())
+			}
 			return err
 		}
 
@@ -193,6 +198,8 @@ func (source *Source) Push(client *phrase.APIClient, waitForResults bool, branch
 				print.Success("Successfully uploaded and processed %s.", localeFile.RelPath())
 			case "error":
 				print.Failure("There was an error processing %s. Your changes were not saved online.", localeFile.RelPath())
+				print.NonBatchPrintf("More info at: %s\n", upload.Url)
+				noErrors = false
 			}
 		} else {
 			outputUpload(upload)
@@ -201,6 +208,9 @@ func (source *Source) Push(client *phrase.APIClient, waitForResults bool, branch
 		if Debug {
 			fmt.Fprintln(os.Stderr, strings.Repeat("-", 10))
 		}
+	}
+	if !noErrors {
+		return errors.New("not_all_files_processed")
 	}
 
 	return nil

--- a/clients/cli/cmd/internal/push.go
+++ b/clients/cli/cmd/internal/push.go
@@ -170,7 +170,7 @@ func (source *Source) Push(client *phrase.APIClient, waitForResults bool, branch
 		upload, err := source.uploadFile(client, localeFile, branch, tag)
 		if err != nil {
 			if openapiError, ok := err.(phrase.GenericOpenAPIError); ok {
-				print.Warn("API response: %s", openapiError.Body())
+				print.Warn("\nAPI response: %s", openapiError.Body())
 			}
 			return err
 		}

--- a/clients/cli/cmd/internal/push.go
+++ b/clients/cli/cmd/internal/push.go
@@ -210,7 +210,7 @@ func (source *Source) Push(client *phrase.APIClient, waitForResults bool, branch
 		}
 	}
 	if !noErrors {
-		return errors.New("not_all_files_processed")
+		return errors.New("not all files were uploaded successfully")
 	}
 
 	return nil


### PR DESCRIPTION
Several smaller improvements on push errors:
* Print error response from server on upload create
* Print link to the upload upon upload processing error (the response does not contain more info)
* Return non-zero exit code when any of the uploads were not processed successfully (https://github.com/phrase/phrase-cli/issues/135)