### PR TITLE
chore: fix creating tags for PHP and Java

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,6 +191,7 @@ jobs:
           git config --global user.name "Phrase"
           git add .
           git commit --message "Deploying from  phrase/openapi@${GITHUB_SHA::8}"
+          PACKAGE_VERSION=$(awk '/- Package version:/{print $NF}' README.md)
           git tag -a $PACKAGE_VERSION -m $PACKAGE_VERSION || true
           git push --tags origin master
           else
@@ -221,6 +222,7 @@ jobs:
           git config --global user.name "Phrase"
           git add .
           git commit --message "Deploying from  phrase/openapi@${GITHUB_SHA::8}"
+          PACKAGE_VERSION=$(awk '/- Package version:/{print $NF}' README.md)
           git tag -a $PACKAGE_VERSION -m $PACKAGE_VERSION || true
           git push --tags origin master
           else

--- a/openapi-generator/templates/java/README.mustache
+++ b/openapi-generator/templates/java/README.mustache
@@ -3,10 +3,7 @@
 {{appName}}
 
 - API version: {{appVersion}}
-{{^hideGenerationTimestamp}}
-
-- Build date: {{generatedDate}}
-{{/hideGenerationTimestamp}}
+- Package version: {{artifactVersion}}
 
 Phrase Strings is a translation management platform for software projects. You can collaborate on language file translation with your team or order translations through our platform. The API allows you to import locale files, download locale files, tag keys or interact in other ways with the localization data stored in Phrase Strings for your account.
 


### PR DESCRIPTION
Fix creating tags for new PHP and Java releases by setting `PACKAGE_VERSION`