### PR TITLE
build(java): Disable parallel test execution

### DIFF
--- a/openapi-generator/templates/java/libraries/okhttp-gson/pom.mustache
+++ b/openapi-generator/templates/java/libraries/okhttp-gson/pom.mustache
@@ -86,7 +86,6 @@
                         </property>
                     </systemProperties>
                     <argLine>-Xms512m -Xmx1500m</argLine>
-                    <parallel>methods</parallel>
                     <threadCount>10</threadCount>
                 </configuration>
             </plugin>


### PR DESCRIPTION
https://github.com/phrase/phrase-java/actions/runs/7220213663/job/19672689047

Seems that parallel test execution doesn't work well with HTTP request mocking