### PR TITLE
fix(GO): Fix format_option serialization when creating upload

### DIFF
--- a/clients/go/test/api_locales_test.go
+++ b/clients/go/test/api_locales_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 
 	"github.com/antihax/optional"
-	"github.com/phrase/phrase-go"
+	"github.com/phrase/phrase-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/clients/go/test/api_uploads_test.go
+++ b/clients/go/test/api_uploads_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	"github.com/antihax/optional"
-	"github.com/phrase/phrase-go"
+	"github.com/phrase/phrase-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/clients/go/test/api_uploads_test.go
+++ b/clients/go/test/api_uploads_test.go
@@ -23,28 +23,46 @@ import (
 )
 
 func Test_phrase_UploadsApiService(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Send the mock response
-		response := `{"id": "1", "filename": "test.json", "format": "json", "state": "valid" }`
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-
-		w.Write([]byte(response))
-	}))
-
-	defer server.Close()
-
-	configuration := phrase.NewConfiguration()
-	configuration.BasePath = server.URL
-	apiClient := phrase.NewAPIClient(configuration)
-
 	t.Run("Test UploadsApiService UploadCreate", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// assert request body for proper serialization of tested format_options
+			r.ParseMultipartForm(0)
+			assert.Equal(t, r.FormValue("format_options[translation_columns][en]"), "f")
+			assert.Equal(t, r.FormValue("format_options[translation_columns][de]"), "e")
+			assert.Equal(t, r.FormValue("format_options[top_level_key]"), "100")
+
+			// Send the mock response
+			response := `{"id": "1", "filename": "test.json", "format": "json", "state": "valid" }`
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+	
+			w.Write([]byte(response))
+		}))
+	
+		defer server.Close()
+	
+		configuration := phrase.NewConfiguration()
+		configuration.BasePath = server.URL
+		apiClient := phrase.NewAPIClient(configuration)
+
 		file, _ := os.Create("testfile.json")
 		fileFormat := optional.NewString("json")
 		fileObject := optional.NewInterface(file)
 		localeId := optional.NewString("99")
 
-		localVarOptionals := phrase.UploadCreateOpts{FileFormat: fileFormat, File: fileObject, LocaleId: localeId }
+		// setting format_options
+		formatOptions := make(map[string]interface{})
+		nestedOptions := make(map[string]interface{})
+
+		nestedOptions["en"] = "f"
+		nestedOptions["de"] = "e"
+
+		formatOptions["top_level_key"] = 100
+		formatOptions["translation_columns"] = nestedOptions
+
+		formatOptionsMap := optional.NewInterface(formatOptions)
+
+		localVarOptionals := phrase.UploadCreateOpts{FileFormat: fileFormat, File: fileObject, LocaleId: localeId, FormatOptions: formatOptionsMap }
 		resp, httpRes, err := apiClient.UploadsApi.UploadCreate(context.Background(), "project_id", &localVarOptionals)
 		requestUrl := httpRes.Request.URL
 
@@ -62,6 +80,21 @@ func Test_phrase_UploadsApiService(t *testing.T) {
 	})
 
 	t.Run("Test UploadsApiService UploadShow", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Send the mock response
+			response := `{"id": "1", "filename": "test.json", "format": "json", "state": "valid" }`
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+	
+			w.Write([]byte(response))
+		}))
+	
+		defer server.Close()
+	
+		configuration := phrase.NewConfiguration()
+		configuration.BasePath = server.URL
+		apiClient := phrase.NewAPIClient(configuration)
+		
 		localVarOptionals := phrase.UploadShowOpts{}
 		resp, httpRes, err := apiClient.UploadsApi.UploadShow(context.Background(), "project_id", "upload_id", &localVarOptionals)
 		requestUrl := httpRes.Request.URL

--- a/openapi-generator/templates/go/api.mustache
+++ b/openapi-generator/templates/go/api.mustache
@@ -249,7 +249,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 {{^isModel}}
 	if localVarOptionals != nil && localVarOptionals.{{vendorExtensions.x-export-param-name}}.IsSet() {
 		{{#isPrimitiveType}}localVarFormParams.Add("{{baseName}}", parameterToString(localVarOptionals.{{vendorExtensions.x-export-param-name}}.Value(), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")){{/isPrimitiveType}}{{^isPrimitiveType}}for key, value := range localVarOptionals.{{vendorExtensions.x-export-param-name}}.Value().(map[string]interface{}) {
-			localVarFormParams.Add(fmt.Sprintf("{{baseName}}[%s]", key), parameterToString(value, ""))
+			localVarFormParams = serializeMapParams(fmt.Sprintf("{{baseName}}[%s]", key), value, localVarFormParams)
 		}{{/isPrimitiveType}}
 	}
 {{/isModel}}

--- a/openapi-generator/templates/go/api.mustache
+++ b/openapi-generator/templates/go/api.mustache
@@ -249,12 +249,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 {{^isModel}}
 	if localVarOptionals != nil && localVarOptionals.{{vendorExtensions.x-export-param-name}}.IsSet() {
 		{{#isPrimitiveType}}localVarFormParams.Add("{{baseName}}", parameterToString(localVarOptionals.{{vendorExtensions.x-export-param-name}}.Value(), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")){{/isPrimitiveType}}{{^isPrimitiveType}}for key, value := range localVarOptionals.{{vendorExtensions.x-export-param-name}}.Value().(map[string]interface{}) {
-			{{#isDeepObject}}
-				localVarFormParams = serializeMapParams(fmt.Sprintf("{{baseName}}[%s]", key), value, localVarFormParams)
-			{{/isDeepObject}}
-			{{^isDeepObject}}
-				localVarFormParams.Add(fmt.Sprintf("{{baseName}}[%s]", key), parameterToString(value, ""))
-			{{/isDeepObject}}
+			localVarFormParams.Add(fmt.Sprintf("{{baseName}}[%s]", key), parameterToString(value, ""))
 		}{{/isPrimitiveType}}
 	}
 {{/isModel}}

--- a/openapi-generator/templates/go/api.mustache
+++ b/openapi-generator/templates/go/api.mustache
@@ -249,7 +249,12 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 {{^isModel}}
 	if localVarOptionals != nil && localVarOptionals.{{vendorExtensions.x-export-param-name}}.IsSet() {
 		{{#isPrimitiveType}}localVarFormParams.Add("{{baseName}}", parameterToString(localVarOptionals.{{vendorExtensions.x-export-param-name}}.Value(), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")){{/isPrimitiveType}}{{^isPrimitiveType}}for key, value := range localVarOptionals.{{vendorExtensions.x-export-param-name}}.Value().(map[string]interface{}) {
-			localVarFormParams.Add(fmt.Sprintf("{{baseName}}[%s]", key), parameterToString(value, ""))
+			{{#isDeepObject}}
+				localVarFormParams = serializeMapParams(fmt.Sprintf("{{baseName}}[%s]", key), value, localVarFormParams)
+			{{/isDeepObject}}
+			{{^isDeepObject}}
+				localVarFormParams.Add(fmt.Sprintf("{{baseName}}[%s]", key), parameterToString(value, ""))
+			{{/isDeepObject}}
 		}{{/isPrimitiveType}}
 	}
 {{/isModel}}

--- a/openapi-generator/templates/go/client.mustache
+++ b/openapi-generator/templates/go/client.mustache
@@ -163,6 +163,19 @@ func parameterToJson(obj interface{}) (string, error) {
 	return string(jsonBuf), err
 }
 
+// helper for serializing and setting mappeed parameters to query string
+func serializeMapParams(key string, value interface{}, localParams url.Values) url.Values {
+	if reflect.TypeOf(value).Kind() == reflect.Map {
+		for k, v := range value.(map[string]interface{}) {
+			paramKeyName := fmt.Sprintf("%s[%s]", key, k)
+			serializeMapParams(paramKeyName, v, localParams)
+		}
+	} else {
+		localParams.Add(key, parameterToString(value, ""))
+	}
+	return localParams
+}
+
 
 // callAPI do the request.
 func (c *APIClient) callAPI(request *http.Request) (*APIResponse, error) {

--- a/openapi-generator/templates/go/client.mustache
+++ b/openapi-generator/templates/go/client.mustache
@@ -163,7 +163,7 @@ func parameterToJson(obj interface{}) (string, error) {
 	return string(jsonBuf), err
 }
 
-// helper for serializing and setting mappeed parameters to query string
+// helper for serializing and setting mapped parameters request body
 func serializeMapParams(key string, value interface{}, localParams url.Values) url.Values {
 	if reflect.TypeOf(value).Kind() == reflect.Map {
 		for k, v := range value.(map[string]interface{}) {

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -113,10 +113,8 @@ requestBody:
             example: '{"en": "2"}'
           format_options:
             description: Additional options available for specific formats. See our format guide for complete list.
-            schema:
-              type: object
-              properties: {}
-            example:
+            type: object
+            properties: {}
             style: deepObject
             explode: true
           autotranslate:

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -116,6 +116,8 @@ requestBody:
             type: object
             properties: {}
             example: '{"foo": "bar"}'
+            style: deepObject
+            explode: true
           autotranslate:
             description: If set, translations for the uploaded language will be fetched automatically.
             type: boolean

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -116,7 +116,7 @@ requestBody:
             schema:
               type: object
               properties: {}
-            example: '{"foo": "bar"}'
+            example:
             style: deepObject
             explode: true
           autotranslate:

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -113,8 +113,9 @@ requestBody:
             example: '{"en": "2"}'
           format_options:
             description: Additional options available for specific formats. See our format guide for complete list.
-            type: object
-            properties: {}
+            schema:
+              type: object
+              properties: {}
             example: '{"foo": "bar"}'
             style: deepObject
             explode: true

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -115,8 +115,7 @@ requestBody:
             description: Additional options available for specific formats. See our format guide for complete list.
             type: object
             properties: {}
-            style: deepObject
-            explode: true
+            example: '{"foo": "bar"}'
           autotranslate:
             description: If set, translations for the uploaded language will be fetched automatically.
             type: boolean


### PR DESCRIPTION
Format Options with nested properties/map was not being properly serialized in the upload creation request.
This PR adds a custom method to serialize the nested format_options appropriately as a part of the request.

Related Issue: https://phrase.atlassian.net/browse/TSI-2192