### PR TITLE
fix(API): Create Custom Metadata endpoint fix [TSI-2222]

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,31 @@ https://github.com/phrase/phrase-cli
 
 [https://swagger.io/docs/specification/about/](https://swagger.io/docs/specification/about/)
 
+### Defining parameters
+
+`POST`/`PUT` requests should define parameters within `requestBody` section, like the following:
+
+```yaml
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        title: key/create/parameters
+        properties:
+          branch:
+            description: specify the branch to use
+            type: string
+            example: my-feature-branch
+          name:
+            description: Key name
+            type: string
+            example: home.index.headline
+```
+
+`parameters` section should contain only those parameters which are part of the URL (typically `project_id` and/or `account_id`)
+
 ## Get help / support
 
 Please contact [support@phrase.com](mailto:support@phrase.com?subject=[GitHub]%20openapi) and we can take more direct action toward finding a solution.

--- a/clients/go/test/api_custom_metadata_test.go
+++ b/clients/go/test/api_custom_metadata_test.go
@@ -19,7 +19,7 @@ func Test_phrase_CustomMetadataApiService(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		assert.Equal(t, "{\"project_ids\":[\"project_id\",\"project_id2\"],\"description\":\"my description\"}\n", string(b))
+		assert.Equal(t, "{\"name\":\"my_property\",\"data_type\":\"string\",\"project_ids\":[\"project_id\",\"project_id2\"],\"description\":\"my description\"}\n", string(b))
 
 		// Send the mock response
 		w.Header().Set("Content-Type", "application/json")
@@ -37,11 +37,13 @@ func Test_phrase_CustomMetadataApiService(t *testing.T) {
 
 	t.Run("Test CustomMetadataService CustomMetadataCreate", func(t *testing.T) {
 		customMetadataPropertiesCreateParameters := phrase.CustomMetadataPropertiesCreateParameters{
+			Name:        "my_property",
+			DataType:    phrase.STRING,
 			Description: "my description",
 			ProjectIds:  []string{"project_id", "project_id2"},
 		}
 		localVarOptionals := phrase.CustomMetadataPropertyCreateOpts{}
-		resp, httpRes, err := apiClient.CustomMetadataApi.CustomMetadataPropertyCreate(context.Background(), "account_id", "my_property", phrase.STRING, customMetadataPropertiesCreateParameters, &localVarOptionals)
+		resp, httpRes, err := apiClient.CustomMetadataApi.CustomMetadataPropertyCreate(context.Background(), "account_id", customMetadataPropertiesCreateParameters, &localVarOptionals)
 		requestUrl := httpRes.Request.URL
 
 		require.Nil(t, err)
@@ -51,7 +53,7 @@ func Test_phrase_CustomMetadataApiService(t *testing.T) {
 		assert.Equal(t, "my_property", resp.Name)
 		assert.Equal(t, phrase.STRING, resp.DataType)
 		assert.Equal(t, "/accounts/account_id/custom_metadata/properties", requestUrl.Path)
-		assert.Equal(t, "data_type=string&name=my_property", requestUrl.RawQuery)
+		assert.Equal(t, "", requestUrl.RawQuery)
 		assert.Equal(t, "POST", httpRes.Request.Method)
 	})
 

--- a/clients/go/test/api_custom_metadata_test.go
+++ b/clients/go/test/api_custom_metadata_test.go
@@ -1,0 +1,48 @@
+package phrase
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/antihax/optional"
+	"github.com/phrase/phrase-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_phrase_CustomMetadataApiService(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Send the mock response
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		response := `{"id": "1", "data_type": "string", "name": "my_property" }`
+		w.Write([]byte(response))
+	}))
+
+	defer server.Close()
+
+	configuration := phrase.NewConfiguration()
+	configuration.BasePath = server.URL
+	apiClient := phrase.NewAPIClient(configuration)
+
+	t.Run("Test CustomMetadataService CustomMetadataCreate", func(t *testing.T) {
+		localVarOptionals := phrase.CustomMetadataPropertyCreateOpts{}
+		localVarOptionals.ProjectIds = optional.NewInterface([]string{"project_id", "project_id2"})
+		resp, httpRes, err := apiClient.CustomMetadataApi.CustomMetadataPropertyCreate(context.Background(), "account_id", "my_property", phrase.STRING, &localVarOptionals)
+		requestUrl := httpRes.Request.URL
+
+		require.Nil(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, 200, httpRes.StatusCode)
+		assert.Equal(t, "1", resp.Id)
+		assert.Equal(t, "my_property", resp.Name)
+		assert.Equal(t, phrase.STRING, resp.DataType)
+		assert.Equal(t, "/accounts/account_id/custom_metadata/properties", requestUrl.Path)
+		assert.Equal(t, "data_type=string&name=my_property&project_ids=project_id&project_ids=project_id2", requestUrl.RawQuery)
+		assert.Equal(t, "POST", httpRes.Request.Method)
+	})
+
+}

--- a/clients/go/test/api_locales_test.go
+++ b/clients/go/test/api_locales_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 
 	"github.com/antihax/optional"
-	"github.com/phrase/phrase-go"
+	"github.com/phrase/phrase-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,7 +46,6 @@ func Test_phrase_LocalesApiService(t *testing.T) {
 
 		resp, httpRes, err := apiClient.LocalesApi.LocaleDownload(context.Background(), "project_id_example", "locale_id", &localeDownloadOpts)
 		requestUrl := httpRes.Request.URL
-		
 
 		require.Nil(t, err)
 		require.NotNil(t, resp)
@@ -60,7 +59,6 @@ func Test_phrase_LocalesApiService(t *testing.T) {
 		localeShowOpts := phrase.LocaleShowOpts{}
 		resp, httpRes, err := apiClient.LocalesApi.LocaleShow(context.Background(), "project_id_example", "locale_id", &localeShowOpts)
 		requestUrl := httpRes.Request.URL
-		
 
 		require.Nil(t, err)
 		require.NotNil(t, resp)
@@ -77,7 +75,6 @@ func Test_phrase_LocalesApiService(t *testing.T) {
 		localeUpdateParameters := phrase.LocaleUpdateParameters{}
 		resp, httpRes, err := apiClient.LocalesApi.LocaleUpdate(context.Background(), "project_id_example", "locale_id", localeUpdateParameters, &localeUpdateOpts)
 		requestUrl := httpRes.Request.URL
-		
 
 		require.Nil(t, err)
 		require.NotNil(t, resp)
@@ -98,9 +95,9 @@ func Test_phrase_LocalesApiService(t *testing.T) {
 
 			w.Write([]byte(response))
 		}))
-	
+
 		defer server.Close()
-	
+
 		configuration := phrase.NewConfiguration()
 		configuration.BasePath = server.URL
 		apiClient := phrase.NewAPIClient(configuration)

--- a/clients/go/test/api_uploads_test.go
+++ b/clients/go/test/api_uploads_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	"github.com/antihax/optional"
-	"github.com/phrase/phrase-go"
+	"github.com/phrase/phrase-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,10 +44,9 @@ func Test_phrase_UploadsApiService(t *testing.T) {
 		fileObject := optional.NewInterface(file)
 		localeId := optional.NewString("99")
 
-		localVarOptionals := phrase.UploadCreateOpts{FileFormat: fileFormat, File: fileObject, LocaleId: localeId }
+		localVarOptionals := phrase.UploadCreateOpts{FileFormat: fileFormat, File: fileObject, LocaleId: localeId}
 		resp, httpRes, err := apiClient.UploadsApi.UploadCreate(context.Background(), "project_id", &localVarOptionals)
 		requestUrl := httpRes.Request.URL
-
 
 		require.Nil(t, err)
 		require.NotNil(t, resp)

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -6230,49 +6230,49 @@
               "$ref": "#/components/schemas/custom_metadata_data_type"
             },
             "example": "boolean"
-          },
-          {
-            "description": "description of property",
-            "example": [
-              "A healthy snack for all ages"
-            ],
-            "name": "description",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "ids of projects that the property belongs to",
-            "example": [
-              "abcd1234cdef1234abcd1234cdef1234"
-            ],
-            "name": "project_ids",
-            "in": "query",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "description": "value options of property (only applies to single or multi select properties)",
-            "example": [
-              "Apple",
-              "Banana",
-              "Coconut"
-            ],
-            "name": "value_options",
-            "in": "query",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "title": "custom_metadata_properties/create/parameters",
+                "properties": {
+                  "project_ids": {
+                    "description": "ids of projects that the property belongs to",
+                    "type": "array",
+                    "example": [
+                      "abcd1234cdef1234abcd1234cdef1234",
+                      "abcd1234cdef1234abcd1234cdef4321"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "description": {
+                    "description": "description of property",
+                    "example": "A healthy snack for all ages",
+                    "type": "string"
+                  },
+                  "value_options": {
+                    "description": "value options of property (only applies to single or multi select properties)",
+                    "example": [
+                      "Apple",
+                      "Banana",
+                      "Coconut"
+                    ],
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
               }
             }
           }
-        ],
+        },
         "responses": {
           "200": {
             "description": "OK",

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -6392,60 +6392,54 @@
           },
           {
             "$ref": "#/components/parameters/id"
-          },
-          {
-            "description": "name of the property",
-            "example": [
-              "Fruit"
-            ],
-            "name": "name",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "description of property",
-            "example": [
-              "A healthy snack for all ages"
-            ],
-            "name": "description",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "ids of projects that the property belongs to",
-            "example": [
-              "abcd1234cdef1234abcd1234cdef1234"
-            ],
-            "name": "project_ids",
-            "in": "query",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "description": "value options of property (only applies to single or multi select properties)",
-            "example": [
-              "Apple",
-              "Banana",
-              "Coconut"
-            ],
-            "name": "value_options",
-            "in": "query",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "title": "custom_metadata_properties/update/parameters",
+                "properties": {
+                  "name": {
+                    "description": "name of the property",
+                    "example": "Fruit",
+                    "type": "string"
+                  },
+                  "project_ids": {
+                    "description": "ids of projects that the property belongs to",
+                    "type": "array",
+                    "example": [
+                      "abcd1234cdef1234abcd1234cdef1234",
+                      "abcd1234cdef1234abcd1234cdef4321"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "description": {
+                    "description": "description of property",
+                    "example": "A healthy snack for all ages",
+                    "type": "string"
+                  },
+                  "value_options": {
+                    "description": "value options of property (only applies to single or multi select properties)",
+                    "example": [
+                      "Apple",
+                      "Banana",
+                      "Coconut"
+                    ],
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
               }
             }
           }
-        ],
+        },
         "responses": {
           "200": {
             "description": "OK",

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -768,6 +768,7 @@
       },
       "custom_metadata_data_type": {
         "type": "string",
+        "description": "data type of the property",
         "enum": [
           "boolean",
           "date",
@@ -777,7 +778,8 @@
           "single_select",
           "string",
           "text"
-        ]
+        ],
+        "example": "string"
       },
       "key_preview": {
         "type": "object",
@@ -6208,28 +6210,6 @@
           },
           {
             "$ref": "#/components/parameters/account_id"
-          },
-          {
-            "description": "name of the property",
-            "example": [
-              "Fruit"
-            ],
-            "name": "name",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "data_type",
-            "in": "query",
-            "description": "Data Type of Custom Metadata Property",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/custom_metadata_data_type"
-            },
-            "example": "boolean"
           }
         ],
         "requestBody": {
@@ -6237,9 +6217,21 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "name",
+                  "data_type"
+                ],
                 "type": "object",
                 "title": "custom_metadata_properties/create/parameters",
                 "properties": {
+                  "name": {
+                    "description": "name of the property",
+                    "example": "Fruit",
+                    "type": "string"
+                  },
+                  "data_type": {
+                    "$ref": "#/components/schemas/custom_metadata_data_type"
+                  },
                   "project_ids": {
                     "description": "ids of projects that the property belongs to",
                     "type": "array",

--- a/paths/custom_metadata_properties/create.yaml
+++ b/paths/custom_metadata_properties/create.yaml
@@ -7,46 +7,24 @@ tags:
 parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/account_id"
-- description: name of the property
-  example:
-  - Fruit
-  name: name
-  in: query
-  required: true
-  schema:
-    type: string
-- name: data_type
-  in: query
-  description: Data Type of Custom Metadata Property
-  required: true
-  schema:
-    "$ref": "../../schemas/custom_metadata_data_type.yaml#/data_type"
-  example: boolean
-# - description: description of property
-#   example:
-#   - A healthy snack for all ages
-#   name: description
-#   in: query
-#   schema:
-#     type: string
-# - description: ids of projects that the property belongs to
-#   example:
-#     - abcd1234cdef1234abcd1234cdef1234
-  # name: project_ids
-  # in: query
-  # schema:
-  #   type: array
-  #   items:
-  #     type: string
-  # explode: false
 requestBody:
   required: true
   content:
     application/json:
       schema:
+        required:
+        - name
+        - data_type
         type: object
         title: custom_metadata_properties/create/parameters
         properties:
+          name:
+            description: name of the property
+            example: Fruit
+            type: string
+          data_type:
+            "$ref": "../../schemas/custom_metadata_data_type.yaml#/data_type"
+
           project_ids:
             description: ids of projects that the property belongs to
             type: array

--- a/paths/custom_metadata_properties/create.yaml
+++ b/paths/custom_metadata_properties/create.yaml
@@ -22,33 +22,53 @@ parameters:
   schema:
     "$ref": "../../schemas/custom_metadata_data_type.yaml#/data_type"
   example: boolean
-- description: description of property
-  example:
-  - A healthy snack for all ages
-  name: description
-  in: query
-  schema:
-    type: string
-- description: ids of projects that the property belongs to
-  example:
-    - abcd1234cdef1234abcd1234cdef1234
-  name: project_ids
-  in: query
-  schema:
-    type: array
-    items:
-      type: string
-- description: value options of property (only applies to single or multi select properties)
-  example:
-    - Apple
-    - Banana
-    - Coconut
-  name: value_options
-  in: query
-  schema:
-    type: array
-    items:
-      type: string
+# - description: description of property
+#   example:
+#   - A healthy snack for all ages
+#   name: description
+#   in: query
+#   schema:
+#     type: string
+# - description: ids of projects that the property belongs to
+#   example:
+#     - abcd1234cdef1234abcd1234cdef1234
+  # name: project_ids
+  # in: query
+  # schema:
+  #   type: array
+  #   items:
+  #     type: string
+  # explode: false
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        title: custom_metadata_properties/create/parameters
+        properties:
+          project_ids:
+            description: ids of projects that the property belongs to
+            type: array
+            example:
+            - abcd1234cdef1234abcd1234cdef1234
+            - abcd1234cdef1234abcd1234cdef4321
+            items:
+              type: string
+          description:
+            description: description of property
+            example: A healthy snack for all ages
+            type: string
+          value_options:
+            description: value options of property (only applies to single or multi select properties)
+            example:
+            - Apple
+            - Banana
+            - Coconut
+            type: array
+            items:
+              type: string
+
 responses:
   '200':
     description: OK

--- a/paths/custom_metadata_properties/update.yaml
+++ b/paths/custom_metadata_properties/update.yaml
@@ -8,40 +8,40 @@ parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/account_id"
 - "$ref": "../../parameters.yaml#/id"
-- description: name of the property
-  example:
-  - Fruit
-  name: name
-  in: query
-  schema:
-    type: string
-- description: description of property
-  example:
-  - A healthy snack for all ages
-  name: description
-  in: query
-  schema:
-    type: string
-- description: ids of projects that the property belongs to
-  example:
-    - abcd1234cdef1234abcd1234cdef1234
-  name: project_ids
-  in: query
-  schema:
-    type: array
-    items:
-      type: string
-- description: value options of property (only applies to single or multi select properties)
-  example:
-    - Apple
-    - Banana
-    - Coconut
-  name: value_options
-  in: query
-  schema:
-    type: array
-    items:
-      type: string
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        title: custom_metadata_properties/update/parameters
+        properties:
+          name:
+            description: name of the property
+            example: Fruit
+            type: string
+          project_ids:
+            description: ids of projects that the property belongs to
+            type: array
+            example:
+            - abcd1234cdef1234abcd1234cdef1234
+            - abcd1234cdef1234abcd1234cdef4321
+            items:
+              type: string
+          description:
+            description: description of property
+            example: A healthy snack for all ages
+            type: string
+          value_options:
+            description: value options of property (only applies to single or multi select properties)
+            example:
+            - Apple
+            - Banana
+            - Coconut
+            type: array
+            items:
+              type: string
+
 responses:
   '200':
     description: OK

--- a/schemas/custom_metadata_data_type.yaml
+++ b/schemas/custom_metadata_data_type.yaml
@@ -1,6 +1,7 @@
 ---
 data_type:
   type: string
+  description: data type of the property
   enum:
     - boolean
     - date
@@ -10,3 +11,4 @@ data_type:
     - single_select
     - string
     - text
+  example: string


### PR DESCRIPTION
Update Custom Metadata non-GET endpoints so that they comply with our standard way of passing parameters.