### PR TITLE
build: Clone whole history when pushing PHP and Java clients

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ jobs:
         run: |
           npm install
           npm run generate.java
-          git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/phrase/phrase-java.git clones/java &> /dev/null
+          git clone https://$API_TOKEN_GITHUB@github.com/phrase/phrase-java.git clones/java &> /dev/null
           rsync -avI --delete --exclude='.git/' clients/java/ clones/java
           cd clones/java
           git status --verbose
@@ -213,7 +213,7 @@ jobs:
         run: |
           npm install
           npm run generate.php
-          git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/phrase/phrase-php.git clones/php &> /dev/null
+          git clone https://$API_TOKEN_GITHUB@github.com/phrase/phrase-php.git clones/php &> /dev/null
           rsync -avI --delete --exclude='.git/' clients/php/ clones/php
           cd clones/php
           git status --verbose


### PR DESCRIPTION
https://github.com/phrase/openapi/actions/runs/7244950008/job/19734096647

Java build fails with:

```
no changes added to commit (use "git add" and/or "git commit -a")
[master a0da195] Deploying from  phrase/openapi@bd04c74f
 205 files changed, 206 insertions(+), 206 deletions(-)
remote: 
remote: GitHub found 2 vulnerabilities on phrase/phrase-java's default branch (1 high, 1 moderate). To find out more, visit:        
remote:      https://github.com/phrase/phrase-java/security/dependabot        
remote: 
To https://github.com/phrase/phrase-java.git
   85688b4..a0da195  master -> master
 ! [rejected]        1.18.0 -> 1.18.0 (already exists)
error: failed to push some refs to 'https://github.com/phrase/phrase-java.git'
hint: Updates were rejected because the tag already exists in the remote.
```