### PR TITLE
fix(GO,CLI): Retrigger Go & CLI release.

### DIFF
--- a/openapi-generator/templates/go/client.mustache
+++ b/openapi-generator/templates/go/client.mustache
@@ -166,6 +166,8 @@ func parameterToJson(obj interface{}) (string, error) {
 // helper for serializing and setting mapped parameters request body
 func serializeMapParams(key string, value interface{}, localParams url.Values) url.Values {
 	if reflect.TypeOf(value).Kind() == reflect.Map {
+
+		// since we allow values of type interface, type assertion is necessary
 		for k, v := range value.(map[string]interface{}) {
 			paramKeyName := fmt.Sprintf("%s[%s]", key, k)
 			serializeMapParams(paramKeyName, v, localParams)


### PR DESCRIPTION
Previously merged #498 didn't trigger release for CLI, since the fix was meant for the CLI, this additional PR aims to retrigger it by generating a separate PR for CLI once merged.