### PR TITLE
fix(GO): fix type mismatch for nested args

### DIFF
--- a/clients/go/test/api_uploads_test.go
+++ b/clients/go/test/api_uploads_test.go
@@ -52,7 +52,7 @@ func Test_phrase_UploadsApiService(t *testing.T) {
 
 		// setting format_options
 		formatOptions := make(map[string]interface{})
-		nestedOptions := make(map[string]interface{})
+		nestedOptions := make(map[interface{}]interface{})
 
 		nestedOptions["en"] = "f"
 		nestedOptions["de"] = "e"

--- a/openapi-generator/templates/cli/api.handlebars
+++ b/openapi-generator/templates/cli/api.handlebars
@@ -101,7 +101,6 @@ func init{{{nickname}}}() {
 				{{/required~}}
 			{{/allParams~}}
 
-			 // trigger API request using phrase-go client
 			data, api_response, err := client.{{classname}}.{{{nickname}}}(auth{{#hasParams}}, {{/hasParams}}{{#allParams}}{{#required}}{{paramName}}{{#unless @last}}, {{/unless}}{{/required}}{{/allParams}}{{#hasOptionalParams}}&localVarOptionals{{/hasOptionalParams}})
 
 			if err != nil {

--- a/openapi-generator/templates/go/client.mustache
+++ b/openapi-generator/templates/go/client.mustache
@@ -166,7 +166,7 @@ func parameterToJson(obj interface{}) (string, error) {
 // helper for serializing and setting mapped parameters request body
 func serializeMapParams(key string, value interface{}, localParams url.Values) url.Values {
 	if reflect.TypeOf(value).Kind() == reflect.Map {
-		for k, v := range value.(map[string]interface{}) {
+		for k, v := range value.(map[interface{}]interface{}) {
 			paramKeyName := fmt.Sprintf("%s[%s]", key, k)
 			serializeMapParams(paramKeyName, v, localParams)
 		}


### PR DESCRIPTION
In a previous PR the assumed type of nested arg was a map with string keys and interface typed values which raised mismatch error. This PR fixes it by asserting keys to be of type interface as well.

fix(GO): fix type mismatch error

fix(CLI): retrigger release for GO