### PR TITLE
docs(Java): Correct token prefix

### DIFF
--- a/openapi-generator/templates/java/README.mustache
+++ b/openapi-generator/templates/java/README.mustache
@@ -89,8 +89,7 @@ public class {{{classname}}}Example {
         // Configure API key authorization: {{{name}}}
         ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setApiKey("YOUR API KEY");
-        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-        //{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
+        {{{name}}}.setApiKeyPrefix("token");{{/isApiKey}}{{#isOAuth}}
         // Configure OAuth2 access token for authorization: {{{name}}}
         OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}

--- a/openapi-generator/templates/java/api_doc.mustache
+++ b/openapi-generator/templates/java/api_doc.mustache
@@ -48,8 +48,7 @@ public class Example {
         // Configure API key authorization: {{{name}}}
         ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setApiKey("YOUR API KEY");
-        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-        //{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
+        {{{name}}}.setApiKeyPrefix("token");{{/isApiKey}}{{#isOAuth}}
         // Configure OAuth2 access token for authorization: {{{name}}}
         OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}

--- a/openapi-generator/templates/java/libraries/jersey2-experimental/api_doc.mustache
+++ b/openapi-generator/templates/java/libraries/jersey2-experimental/api_doc.mustache
@@ -52,8 +52,7 @@ public class Example {
         // Configure API key authorization: {{{name}}}
         ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setApiKey("YOUR API KEY");
-        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-        //{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
+        {{{name}}}.setApiKeyPrefix("token");{{/isApiKey}}{{#isOAuth}}
         // Configure OAuth2 access token for authorization: {{{name}}}
         OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}

--- a/openapi-generator/templates/java/libraries/jersey2/api_doc.mustache
+++ b/openapi-generator/templates/java/libraries/jersey2/api_doc.mustache
@@ -52,8 +52,7 @@ public class Example {
         // Configure API key authorization: {{{name}}}
         ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setApiKey("YOUR API KEY");
-        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-        //{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
+        {{{name}}}.setApiKeyPrefix("token");{{/isApiKey}}{{#isOAuth}}
         // Configure OAuth2 access token for authorization: {{{name}}}
         OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}

--- a/openapi-generator/templates/java/libraries/okhttp-gson/api_doc.mustache
+++ b/openapi-generator/templates/java/libraries/okhttp-gson/api_doc.mustache
@@ -45,8 +45,7 @@ public class Example {
     // Configure API key authorization: {{{name}}}
     ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
     {{{name}}}.setApiKey("YOUR API KEY");
-    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-    //{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
+    {{{name}}}.setApiKeyPrefix("token");{{/isApiKey}}{{#isOAuth}}
     // Configure OAuth2 access token for authorization: {{{name}}}
     OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
     {{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}


### PR DESCRIPTION
Our API expects `token` as a token prefix, so correcting the examples to show that.