### PR TITLE
feat: add query param for properties

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -6133,6 +6133,15 @@
             "$ref": "#/components/parameters/per_page"
           },
           {
+            "description": "query to find a property by name",
+            "example": "character_name",
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "description": "Sort criteria. Can be one of: name, data_type, created_at.",
             "example": "updated_at",
             "name": "sort",

--- a/paths/custom_metadata_properties/index.yaml
+++ b/paths/custom_metadata_properties/index.yaml
@@ -19,6 +19,12 @@ parameters:
     type: string
 - "$ref": "../../parameters.yaml#/page"
 - "$ref": "../../parameters.yaml#/per_page"
+- description: query to find a property by name
+  example: character_name
+  name: q
+  in: query
+  schema:
+    type: string
 - description: 'Sort criteria. Can be one of: name, data_type, created_at.'
   example: updated_at
   name: sort


### PR DESCRIPTION
Document `q` param to filter custom metadata properties by name.