### PR TITLE
feat: Add missing pagination header for collections

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -326,6 +326,43 @@
         "schema": {
           "type": "integer"
         }
+      },
+      "Pagination": {
+        "description": "Pagination details for navigating through a collection of resources, provided in JSON format.",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "total_count": {
+              "description": "Total count of items in the collection.",
+              "type": "integer",
+              "example": 10
+            },
+            "total_pages_count": {
+              "description": "Total number of pages available for the collection.",
+              "type": "integer",
+              "example": 2
+            },
+            "current_page": {
+              "description": "The current page number.",
+              "type": "integer",
+              "example": 1
+            },
+            "current_per_page": {
+              "description": "Number of items currently displayed per page.",
+              "type": "integer",
+              "example": 5
+            },
+            "previous_page": {
+              "description": "Page number of the previous page, if available.",
+              "type": "integer"
+            },
+            "next_page": {
+              "description": "Page number of the next page, if available.",
+              "type": "integer",
+              "example": 2
+            }
+          }
+        }
       }
     },
     "schemas": {
@@ -4803,6 +4840,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -4899,6 +4939,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -5188,6 +5231,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -5688,6 +5734,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -6185,6 +6234,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -6589,6 +6641,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -7253,6 +7308,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -7664,6 +7722,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -7755,6 +7816,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -8443,6 +8507,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -8894,6 +8961,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -9401,6 +9471,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -9630,6 +9703,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -10455,6 +10531,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -10837,6 +10916,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -11204,6 +11286,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -11564,6 +11649,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -11847,6 +11935,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -12490,6 +12581,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -12844,6 +12938,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -13317,6 +13414,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -13928,6 +14028,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -14218,6 +14321,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -14500,6 +14606,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -14679,6 +14788,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -14764,6 +14876,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -15167,6 +15282,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -15752,6 +15870,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -16480,6 +16601,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -16941,6 +17065,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -17289,6 +17416,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -17765,6 +17895,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -17957,6 +18090,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -18407,6 +18543,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -18798,6 +18937,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -19187,6 +19329,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -19477,6 +19622,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -19860,6 +20008,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -20962,6 +21113,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -21571,6 +21725,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -21912,6 +22069,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -22107,6 +22267,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -22859,6 +23022,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -23083,6 +23249,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -23195,6 +23364,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -24420,6 +24592,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -24618,6 +24793,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -25263,6 +25441,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -25416,6 +25597,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -25556,6 +25740,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -25629,6 +25816,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },
@@ -25986,6 +26176,9 @@
               },
               "Link": {
                 "$ref": "#/components/headers/Link"
+              },
+              "Pagination": {
+                "$ref": "#/components/headers/Pagination"
               }
             }
           },

--- a/headers.yaml
+++ b/headers.yaml
@@ -22,3 +22,31 @@ X-Rate-Limit-Reset:
   description: The number of seconds left in the current period
   schema:
     type: integer
+Pagination:
+  description: Pagination details for navigating through a collection of resources, provided in JSON format.
+  schema:
+    type: object
+    properties:
+      total_count:
+        description: Total count of items in the collection.
+        type: integer
+        example: 10
+      total_pages_count:
+        description: Total number of pages available for the collection.
+        type: integer
+        example: 2
+      current_page:
+        description: The current page number.
+        type: integer
+        example: 1
+      current_per_page:
+        description: Number of items currently displayed per page.
+        type: integer
+        example: 5
+      previous_page:
+        description: Page number of the previous page, if available.
+        type: integer
+      next_page:
+        description: Page number of the next page, if available.
+        type: integer
+        example: 2

--- a/paths/accounts/index.yaml
+++ b/paths/accounts/index.yaml
@@ -26,6 +26,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/accounts/locales.yaml
+++ b/paths/accounts/locales.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/authorizations/index.yaml
+++ b/paths/authorizations/index.yaml
@@ -26,6 +26,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/bitbucket_syncs/index.yaml
+++ b/paths/bitbucket_syncs/index.yaml
@@ -30,6 +30,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/blacklisted_keys/index.yaml
+++ b/paths/blacklisted_keys/index.yaml
@@ -33,6 +33,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/branches/index.yaml
+++ b/paths/branches/index.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/comment_reactions/index.yaml
+++ b/paths/comment_reactions/index.yaml
@@ -35,6 +35,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '403':

--- a/paths/comment_replies/index.yaml
+++ b/paths/comment_replies/index.yaml
@@ -55,6 +55,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '403':

--- a/paths/comments/index.yaml
+++ b/paths/comments/index.yaml
@@ -62,6 +62,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/custom_metadata_properties/index.yaml
+++ b/paths/custom_metadata_properties/index.yaml
@@ -55,6 +55,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/distributions/index.yaml
+++ b/paths/distributions/index.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/documents/index.yaml
+++ b/paths/documents/index.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/figma_attachments/index.yaml
+++ b/paths/figma_attachments/index.yaml
@@ -33,6 +33,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   "400":
     "$ref": "../../responses.yaml#/400"
   "404":

--- a/paths/formats/index.yaml
+++ b/paths/formats/index.yaml
@@ -24,6 +24,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/gitlab_syncs/history.yaml
+++ b/paths/gitlab_syncs/history.yaml
@@ -33,6 +33,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/gitlab_syncs/import.yaml
+++ b/paths/gitlab_syncs/import.yaml
@@ -25,6 +25,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/gitlab_syncs/index.yaml
+++ b/paths/gitlab_syncs/index.yaml
@@ -30,6 +30,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/glossaries/index.yaml
+++ b/paths/glossaries/index.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/glossary_terms/index.yaml
+++ b/paths/glossary_terms/index.yaml
@@ -28,6 +28,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/invitations/index.yaml
+++ b/paths/invitations/index.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '401':

--- a/paths/job_comments/index.yaml
+++ b/paths/job_comments/index.yaml
@@ -38,6 +38,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/job_locales/index.yaml
+++ b/paths/job_locales/index.yaml
@@ -34,6 +34,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/job_template_locales/index.yaml
+++ b/paths/job_template_locales/index.yaml
@@ -34,6 +34,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/job_templates/index.yaml
+++ b/paths/job_templates/index.yaml
@@ -33,6 +33,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   "400":
     "$ref": "../../responses.yaml#/400"
   "404":

--- a/paths/jobs/index.yaml
+++ b/paths/jobs/index.yaml
@@ -51,6 +51,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/jobs/index_account.yaml
+++ b/paths/jobs/index_account.yaml
@@ -45,6 +45,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/keys/index.yaml
+++ b/paths/keys/index.yaml
@@ -70,6 +70,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/locales/index.yaml
+++ b/paths/locales/index.yaml
@@ -39,6 +39,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/members/index.yaml
+++ b/paths/members/index.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '401':

--- a/paths/notification_groups/index.yaml
+++ b/paths/notification_groups/index.yaml
@@ -26,6 +26,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/notifications/index.yaml
+++ b/paths/notifications/index.yaml
@@ -32,6 +32,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/orders/index.yaml
+++ b/paths/orders/index.yaml
@@ -33,6 +33,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/organization_job_template_locales/index.yaml
+++ b/paths/organization_job_template_locales/index.yaml
@@ -28,6 +28,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/organization_job_templates/index.yaml
+++ b/paths/organization_job_templates/index.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   "400":
     "$ref": "../../responses.yaml#/400"
   "404":

--- a/paths/projects/index.yaml
+++ b/paths/projects/index.yaml
@@ -41,6 +41,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/releases/index.yaml
+++ b/paths/releases/index.yaml
@@ -28,6 +28,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/screenshot_markers/index.yaml
+++ b/paths/screenshot_markers/index.yaml
@@ -34,6 +34,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/screenshots/index.yaml
+++ b/paths/screenshots/index.yaml
@@ -39,6 +39,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/spaces/index.yaml
+++ b/paths/spaces/index.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/spaces/spaces_projects.yaml
+++ b/paths/spaces/spaces_projects.yaml
@@ -28,6 +28,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/styleguides/index.yaml
+++ b/paths/styleguides/index.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/tags/index.yaml
+++ b/paths/tags/index.yaml
@@ -33,6 +33,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/teams/index.yaml
+++ b/paths/teams/index.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/translations/index.yaml
+++ b/paths/translations/index.yaml
@@ -65,6 +65,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/translations/index_keys.yaml
+++ b/paths/translations/index_keys.yaml
@@ -62,6 +62,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/translations/index_locale.yaml
+++ b/paths/translations/index_locale.yaml
@@ -63,6 +63,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/uploads/index.yaml
+++ b/paths/uploads/index.yaml
@@ -33,6 +33,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/variables/index.yaml
+++ b/paths/variables/index.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/versions/index.yaml
+++ b/paths/versions/index.yaml
@@ -34,6 +34,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/webhook_deliveries/index.yaml
+++ b/paths/webhook_deliveries/index.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/webhook_deliveries/redeliver.yaml
+++ b/paths/webhook_deliveries/redeliver.yaml
@@ -25,6 +25,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':

--- a/paths/webhooks/index.yaml
+++ b/paths/webhooks/index.yaml
@@ -27,6 +27,8 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
       Link:
         "$ref": "../../headers.yaml#/Link"
+      Pagination:
+        "$ref": "../../headers.yaml#/Pagination"
   '400':
     "$ref": "../../responses.yaml#/400"
   '404':


### PR DESCRIPTION
Headers include Pagination header

```json
{"total_count":12,"total_pages_count":2,"current_page":1,"current_per_page":10,"previous_page":null,"next_page":2}
```

I added it to the documentation, as it will be heavily used by the orchestrator.

Backend PR: https://github.com/phrase/phrase/pull/12890