### PR TITLE
refactor!: add missing required params

### DIFF
--- a/clients/go/test/api_uploads_test.go
+++ b/clients/go/test/api_uploads_test.go
@@ -46,9 +46,8 @@ func Test_phrase_UploadsApiService(t *testing.T) {
 		apiClient := phrase.NewAPIClient(configuration)
 
 		file, _ := os.Create("testfile.json")
-		fileFormat := optional.NewString("json")
-		fileObject := optional.NewInterface(file)
-		localeId := optional.NewString("99")
+		fileFormat := "json"
+		localeId := "99"
 
 		// setting format_options
 		formatOptions := make(map[string]interface{})
@@ -62,8 +61,8 @@ func Test_phrase_UploadsApiService(t *testing.T) {
 
 		formatOptionsMap := optional.NewInterface(formatOptions)
 
-		localVarOptionals := phrase.UploadCreateOpts{FileFormat: fileFormat, File: fileObject, LocaleId: localeId, FormatOptions: formatOptionsMap}
-		resp, httpRes, err := apiClient.UploadsApi.UploadCreate(context.Background(), "project_id", &localVarOptionals)
+		localVarOptionals := phrase.UploadCreateOpts{FormatOptions: formatOptionsMap}
+		resp, httpRes, err := apiClient.UploadsApi.UploadCreate(context.Background(), "project_id", file, fileFormat, localeId, &localVarOptionals)
 		requestUrl := httpRes.Request.URL
 
 		require.Nil(t, err)

--- a/clients/go/test/api_uploads_test.go
+++ b/clients/go/test/api_uploads_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	"github.com/antihax/optional"
-	"github.com/phrase/phrase-go/v2"
+	"github.com/phrase/phrase-go/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/clients/go/test/api_uploads_test.go
+++ b/clients/go/test/api_uploads_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	"github.com/antihax/optional"
-	"github.com/phrase/phrase-go/v3"
+	"github.com/phrase/phrase-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/clients/java/src/test/java/com/phrase/client/api/LocalesApiTest.java
+++ b/clients/java/src/test/java/com/phrase/client/api/LocalesApiTest.java
@@ -114,6 +114,7 @@ public class LocalesApiTest {
         String id = null;
         String xPhraseAppOTP = null;
         String branch = null;
+
         api.localeDelete(projectId, id, xPhraseAppOTP, branch);
 
         // TODO: test validations

--- a/clients/java/src/test/java/com/phrase/client/api/UploadsApiTest.java
+++ b/clients/java/src/test/java/com/phrase/client/api/UploadsApiTest.java
@@ -92,8 +92,8 @@ public class UploadsApiTest {
         String branch = "branch_example";
         File file = File.createTempFile("test", "test");
         file.deleteOnExit();
-        String fileFormat = null;
-        String localeId = null;
+        String fileFormat = "simple_json";
+        String localeId = "en";
         String tags = null;
         Boolean updateTranslations = null;
         Boolean updateDescriptions = null;
@@ -106,7 +106,7 @@ public class UploadsApiTest {
         Boolean autotranslate = null;
         Boolean markReviewed = null;
         Boolean tagOnlyAffectedKeys = null;
-        Upload response = api.uploadCreate(projectId, xPhraseAppOTP, branch, file, fileFormat, localeId, tags, updateTranslations, updateDescriptions, convertEmoji, skipUploadTags, skipUnverification, fileEncoding, localeMapping, formatOptions, autotranslate, markReviewed, tagOnlyAffectedKeys);
+        Upload response = api.uploadCreate(projectId, file, fileFormat, localeId, xPhraseAppOTP, branch, tags, updateTranslations, updateDescriptions, convertEmoji, skipUploadTags, skipUnverification, fileEncoding, localeMapping, formatOptions, autotranslate, markReviewed, tagOnlyAffectedKeys);
 
         Assert.assertEquals("valid id returned", "id_example", response.getId());
         Assert.assertEquals("valid creation date returned", OffsetDateTime.parse("2015-01-28T09:52:53Z"), response.getCreatedAt());

--- a/clients/php/test/Api/UploadsApiTest.php
+++ b/clients/php/test/Api/UploadsApiTest.php
@@ -107,7 +107,7 @@ class UploadsApiTest extends TestCase
         $file = new \SplFileObject($fileName, 'w+');
         $file->fwrite('test');
 
-        $result = $this->apiInstance->uploadCreate($projectId, null, null, $file);
+        $result = $this->apiInstance->uploadCreate($projectId, $file, "yml", "en", null, null);
         $file = null;
         unlink($fileName);
 

--- a/clients/python/test/test_uploads_api.py
+++ b/clients/python/test/test_uploads_api.py
@@ -48,7 +48,8 @@ class TestUploadsApi(unittest.TestCase):
             api_response = api_instance.upload_create(
                 project_id,
                 file="./test/fixtures/en.json",
-                file_format="simple_json"
+                file_format="simple_json",
+                locale_id="en"
             )
 
             self.assertEqual("https://api.phrase.com/v2/projects/project_id_example/uploads", mock_post.call_args_list[0].args[1])

--- a/clients/ruby/spec/api/locales_api_spec.rb
+++ b/clients/ruby/spec/api/locales_api_spec.rb
@@ -87,7 +87,7 @@ describe 'LocalesApi' do
   # @option opts [Boolean] :skip_unverified_translations Indicates whether the locale file should skip all unverified translations. This parameter is deprecated and should be replaced with &lt;code&gt;include_unverified_translations&lt;/code&gt;.
   # @option opts [Boolean] :include_unverified_translations if set to false unverified translations are excluded
   # @option opts [Boolean] :use_last_reviewed_version If set to true the last reviewed version of a translation is used. This is only available if the review workflow is enabled for the project.
-  # @option opts [String] :fallback_locale_id If a key has no translation in the locale being downloaded the translation in the fallback locale will be used. Provide the public ID of the locale that should be used as the fallback. Requires include_empty_translations to be set to &lt;code&gt;true&lt;/code&gt;.
+  # @option opts [String] :fallback_locale_id If a key has no translation in the locale being downloaded the translation in the fallback locale will be used. Provide the ID of the locale that should be used as the fallback. Requires include_empty_translations to be set to &lt;code&gt;true&lt;/code&gt;.
   # @option opts [String] :source_locale_id Provides the source language of a corresponding job as the source language of the generated locale file. This parameter will be ignored unless used in combination with a &lt;code&gt;tag&lt;/code&gt; parameter indicating a specific job.
   # @return [File]
   describe 'locale_download test' do

--- a/clients/ruby/spec/api/uploads_api_spec.rb
+++ b/clients/ruby/spec/api/uploads_api_spec.rb
@@ -53,7 +53,7 @@ describe 'UploadsApi' do
     end
 
     it 'should work' do
-      @api_instance.upload_create('project_id', file: File.new('Gemfile'))
+      @api_instance.upload_create('project_id', File.new('Gemfile'), "yml", "en")
 
       expect(a_request(:post, 'https://api.phrase.com/v2/projects/project_id/uploads')
         .with { |req|

--- a/clients/ruby/spec/api/uploads_api_spec.rb
+++ b/clients/ruby/spec/api/uploads_api_spec.rb
@@ -29,7 +29,7 @@ describe 'UploadsApi' do
   # @option opts [String] :branch specify the branch to use
   # @option opts [File] :file File to be imported
   # @option opts [String] :file_format File format. Auto-detected when possible and not specified.
-  # @option opts [String] :locale_id Locale of the file&#39;s content. Can be the name or public id of the locale. Preferred is the public id.
+  # @option opts [String] :locale_id Locale of the file&#39;s content. Can be the name or id of the locale. Preferred is id.
   # @option opts [String] :tags List of tags separated by comma to be associated with the new keys contained in the upload.
   # @option opts [Boolean] :update_translations Indicates whether existing translations should be updated with the file content.
   # @option opts [Boolean] :update_descriptions Existing key descriptions will be updated with the file content. Empty descriptions overwrite existing descriptions.

--- a/clients/typescript/__tests__/BasicApiTest.ts
+++ b/clients/typescript/__tests__/BasicApiTest.ts
@@ -89,8 +89,10 @@ describe('UploadsApi', () => {
     test('uploads a file', async () => {
       const projectId = 'my-project-id';
       const file = fs.createReadStream('package.json');
+      const fileFormat = 'json';
+      const localeId = 'en';
 
-      await api.uploadCreate({projectId, file}).then((response) => {
+      await api.uploadCreate({projectId, file, fileFormat, localeId}).then((response) => {
         expect(response.id).toBe('upload_id');
       });
 

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -8143,7 +8143,7 @@
                     "example": null
                   },
                   "source_locale_id": {
-                    "description": "Source locale. Can be the name or public id of the locale. Preferred is the public id.",
+                    "description": "Source locale. Can be the name or id of the locale. Preferred is id.",
                     "type": "string",
                     "example": "abcd1234abcd1234abcd1234abcd1234"
                   },
@@ -8346,7 +8346,7 @@
                     "example": null
                   },
                   "source_locale_id": {
-                    "description": "Source locale. Can be the name or public id of the locale. Preferred is the public id.",
+                    "description": "Source locale. Can be the name or id of the locale. Preferred is id.",
                     "type": "string",
                     "example": "abcd1234abcd1234abcd1234abcd1234"
                   },
@@ -8588,7 +8588,7 @@
             }
           },
           {
-            "description": "If a key has no translation in the locale being downloaded the translation in the fallback locale will be used. Provide the public ID of the locale that should be used as the fallback. Requires include_empty_translations to be set to <code>true</code>.",
+            "description": "If a key has no translation in the locale being downloaded the translation in the fallback locale will be used. Provide the ID of the locale that should be used as the fallback. Requires include_empty_translations to be set to <code>true</code>.",
             "example": null,
             "name": "fallback_locale_id",
             "in": "query",
@@ -14122,7 +14122,7 @@
                     "example": "json"
                   },
                   "locale_id": {
-                    "description": "Locale of the file's content. Can be the name or public id of the locale. Preferred is the public id.",
+                    "description": "Locale of the file's content. Can be the name or id of the locale. Preferred is id.",
                     "type": "string",
                     "example": "abcd1234cdef1234abcd1234cdef1234"
                   },
@@ -21475,12 +21475,12 @@
                     "example": "textmaster"
                   },
                   "source_locale_id": {
-                    "description": "Source locale for the order. Can be the name or public id of the source locale. Preferred is the public id.",
+                    "description": "Source locale for the order. Can be the name or id of the source locale. Preferred is id.",
                     "type": "string",
                     "example": "abcd1234abcd1234abcd1234abcd1234"
                   },
                   "target_locale_ids": {
-                    "description": "List of target locales you want the source content translate to. Can be the name or public id of the target locales. Preferred is the public id.",
+                    "description": "List of target locales you want the source content translate to. Can be the name or id of the target locales. Preferred is id.",
                     "type": "array",
                     "items": {
                       "type": "string"
@@ -23869,7 +23869,7 @@
                     "example": "my-feature-branch"
                   },
                   "locale_id": {
-                    "description": "Locale. Can be the name or id of the locale. Preferred is the id",
+                    "description": "Locale. Can be the name or id of the locale. Preferred is id",
                     "type": "string",
                     "example": "abcd1234cdef1234abcd1234cdef1234"
                   },

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -4297,16 +4297,7 @@
             },
             "description": "The child translation keys linked to the parent."
           }
-        },
-        "required": [
-          "created_at",
-          "updated_at",
-          "created_by",
-          "updated_by",
-          "account",
-          "parent",
-          "children"
-        ]
+        }
       },
       "repo_sync": {
         "type": "object",
@@ -4894,8 +4885,8 @@
   "paths": {
     "/icu/skeleton": {
       "post": {
-        "summary": "Build icu skeletons",
-        "description": "Returns icu skeletons for multiple locale codes based on a source content.",
+        "summary": "Build ICU skeletons",
+        "description": "Returns ICU skeletons for multiple locale codes based on a source content.",
         "operationId": "icu/skeleton",
         "tags": [
           "ICU"
@@ -5527,6 +5518,9 @@
               "schema": {
                 "type": "object",
                 "title": "figma_attachment/create/parameters",
+                "required": [
+                  "url"
+                ],
                 "properties": {
                   "branch": {
                     "description": "specify the branch to use",
@@ -6021,6 +6015,9 @@
               "schema": {
                 "type": "object",
                 "title": "styleguide/create/parameters",
+                "required": [
+                  "title"
+                ],
                 "properties": {
                   "title": {
                     "description": "Style guide title",
@@ -6943,6 +6940,10 @@
               "schema": {
                 "type": "object",
                 "title": "invitation/create/parameters",
+                "required": [
+                  "email",
+                  "role"
+                ],
                 "properties": {
                   "email": {
                     "description": "The email of the invited user. The <code>email</code> can not be updated once created. Create a new invitation for each unique email.",
@@ -7676,6 +7677,9 @@
               "schema": {
                 "type": "object",
                 "title": "screenshot_marker/create/parameters",
+                "required": [
+                  "key_id"
+                ],
                 "properties": {
                   "branch": {
                     "description": "specify the branch to use",
@@ -8103,6 +8107,10 @@
               "schema": {
                 "type": "object",
                 "title": "locale/create/parameters",
+                "required": [
+                  "name",
+                  "code"
+                ],
                 "properties": {
                   "branch": {
                     "description": "specify the branch to use",
@@ -8794,6 +8802,9 @@
               "schema": {
                 "type": "object",
                 "title": "distribution/create/parameters",
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "description": "Name of the distribution",
@@ -9758,6 +9769,9 @@
               "schema": {
                 "type": "object",
                 "title": "job/create/parameters",
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "branch": {
                     "description": "specify the branch to use",
@@ -11203,6 +11217,9 @@
               "schema": {
                 "type": "object",
                 "title": "glossary/create/parameters",
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "description": "Name of the glossary",
@@ -11570,6 +11587,9 @@
               "schema": {
                 "type": "object",
                 "title": "authorization/create/parameters",
+                "required": [
+                  "note"
+                ],
                 "properties": {
                   "note": {
                     "description": "A note to help you remember what the access is used for.",
@@ -13701,6 +13721,9 @@
               "schema": {
                 "type": "object",
                 "title": "webhook/create/parameters",
+                "required": [
+                  "callback_url"
+                ],
                 "properties": {
                   "callback_url": {
                     "description": "Callback URL to send requests to",
@@ -14075,6 +14098,11 @@
               "schema": {
                 "type": "object",
                 "title": "upload/create/parameters",
+                "required": [
+                  "file",
+                  "file_format",
+                  "locale_id"
+                ],
                 "properties": {
                   "branch": {
                     "description": "specify the branch to use",
@@ -14134,7 +14162,7 @@
                     "example": null
                   },
                   "locale_mapping": {
-                    "description": "Optional, format specific mapping between locale names and the columns the translations to those locales are contained in.",
+                    "description": "Mapping between locale names and translation columns. Required in some formats like CSV or XLSX.",
                     "type": "object",
                     "properties": {},
                     "example": "{\"en\": \"2\"}"
@@ -15247,6 +15275,10 @@
               "schema": {
                 "type": "object",
                 "title": "glossary_term_translation/create/parameters",
+                "required": [
+                  "locale_code",
+                  "content"
+                ],
                 "properties": {
                   "locale_code": {
                     "description": "Identifies the language for this translation",
@@ -15566,6 +15598,9 @@
               "schema": {
                 "type": "object",
                 "title": "project/create/parameters",
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "description": "Name of the project",
@@ -17352,6 +17387,9 @@
               "schema": {
                 "type": "object",
                 "title": "variable/create/parameters",
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "description": "Name of the variable",
@@ -17703,6 +17741,9 @@
               "schema": {
                 "type": "object",
                 "title": "branch/create/parameters",
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "description": "Name of the branch",
@@ -19227,6 +19268,9 @@
               "schema": {
                 "type": "object",
                 "title": "glossary_term/create/parameters",
+                "required": [
+                  "term"
+                ],
                 "properties": {
                   "term": {
                     "description": "Glossary term",
@@ -19616,6 +19660,9 @@
               "schema": {
                 "type": "object",
                 "title": "tag/create/parameters",
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "branch": {
                     "description": "specify the branch to use",
@@ -19909,6 +19956,9 @@
               "schema": {
                 "type": "object",
                 "title": "blacklisted_key/create/parameters",
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "description": "Blocked key name",
@@ -20295,6 +20345,9 @@
               "schema": {
                 "type": "object",
                 "title": "key/create/parameters",
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "branch": {
                     "description": "specify the branch to use",
@@ -21400,6 +21453,10 @@
               "schema": {
                 "type": "object",
                 "title": "order/create/parameters",
+                "required": [
+                  "name",
+                  "lsp"
+                ],
                 "properties": {
                   "branch": {
                     "description": "specify the branch to use",
@@ -22489,6 +22546,9 @@
               "schema": {
                 "type": "object",
                 "title": "space/create/parameters",
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "description": "Name of the space",
@@ -22829,6 +22889,9 @@
               "schema": {
                 "type": "object",
                 "title": "spaces/projects/create/parameters",
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "description": "Project ID to add or to the Space",
@@ -23031,6 +23094,9 @@
               "schema": {
                 "type": "object",
                 "title": "team/create/parameters",
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "description": "Name of the team",
@@ -23294,6 +23360,9 @@
               "schema": {
                 "type": "object",
                 "title": "teams/projects/create/parameters",
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "description": "Project ID to add to the Team",
@@ -23418,6 +23487,9 @@
               "schema": {
                 "type": "object",
                 "title": "teams/spaces/create/parameters",
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "description": "Space ID to add to the Team",
@@ -23542,6 +23614,9 @@
               "schema": {
                 "type": "object",
                 "title": "teams/users/create/parameters",
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "description": "User ID to add to the Team",
@@ -23793,7 +23868,7 @@
                     "example": "my-feature-branch"
                   },
                   "locale_id": {
-                    "description": "Locale. Can be the name or public id of the locale. Preferred is the public id.",
+                    "description": "Locale. Can be the name or id of the locale. Preferred is the id",
                     "type": "string",
                     "example": "abcd1234cdef1234abcd1234cdef1234"
                   },
@@ -27265,15 +27340,6 @@
           },
           {
             "$ref": "#/components/parameters/key_id_as_id"
-          },
-          {
-            "in": "query",
-            "name": "unlink_parent",
-            "required": false,
-            "description": "Whether to unlink the parent key as well and unmark it as linked-key.",
-            "schema": {
-              "type": "boolean"
-            }
           }
         ],
         "requestBody": {
@@ -27297,6 +27363,11 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "unlink_parent": {
+                    "description": "Whether to unlink the parent key as well and unmark it as linked-key.",
+                    "type": "boolean",
+                    "default": false
                   }
                 }
               }
@@ -27313,7 +27384,7 @@
         }
       },
       "get": {
-        "summary": "Retrieve all child keys linked to a specific parent key",
+        "summary": "List child keys of a parent key",
         "description": "Returns detailed information about a parent key, including its linked child keys.",
         "operationId": "key_links/index",
         "tags": [

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -8803,7 +8803,8 @@
                 "type": "object",
                 "title": "distribution/create/parameters",
                 "required": [
-                  "name"
+                  "name",
+                  "project_id"
                 ],
                 "properties": {
                   "name": {

--- a/openapi-generator/templates/go/README.mustache
+++ b/openapi-generator/templates/go/README.mustache
@@ -17,7 +17,7 @@ import (
 	"context"
 	"fmt"
 
-	phrase "github.com/phrase/phrase-go/v3"
+	phrase "github.com/phrase/phrase-go/v2" // x-release-please-major
 )
 
 func main() {

--- a/openapi-generator/templates/go/README.mustache
+++ b/openapi-generator/templates/go/README.mustache
@@ -17,7 +17,7 @@ import (
 	"context"
 	"fmt"
 
-	phrase "github.com/phrase/phrase-go/v2"
+	phrase "github.com/phrase/phrase-go/v3"
 )
 
 func main() {

--- a/openapi-generator/templates/go/go.mod.mustache
+++ b/openapi-generator/templates/go/go.mod.mustache
@@ -1,4 +1,4 @@
-module {{gitHost}}/{{gitUserId}}/{{gitRepoId}}{{#isGoSubmodule}}/{{packageName}}{{/isGoSubmodule}}/v3
+module {{gitHost}}/{{gitUserId}}/{{gitRepoId}}{{#isGoSubmodule}}/{{packageName}}{{/isGoSubmodule}}/v2 // x-release-please-major
 
 go 1.14
 

--- a/openapi-generator/templates/go/go.mod.mustache
+++ b/openapi-generator/templates/go/go.mod.mustache
@@ -1,4 +1,4 @@
-module {{gitHost}}/{{gitUserId}}/{{gitRepoId}}{{#isGoSubmodule}}/{{packageName}}{{/isGoSubmodule}}/v2
+module {{gitHost}}/{{gitUserId}}/{{gitRepoId}}{{#isGoSubmodule}}/{{packageName}}{{/isGoSubmodule}}/v3
 
 go 1.14
 

--- a/paths/authorizations/create.yaml
+++ b/paths/authorizations/create.yaml
@@ -45,6 +45,8 @@ requestBody:
       schema:
         type: object
         title: authorization/create/parameters
+        required:
+          - note
         properties:
           note:
             description: A note to help you remember what the access is used for.

--- a/paths/blacklisted_keys/create.yaml
+++ b/paths/blacklisted_keys/create.yaml
@@ -48,6 +48,8 @@ requestBody:
       schema:
         type: object
         title: blacklisted_key/create/parameters
+        required:
+          - name
         properties:
           name:
             description: Blocked key name

--- a/paths/branches/create.yaml
+++ b/paths/branches/create.yaml
@@ -48,6 +48,8 @@ requestBody:
       schema:
         type: object
         title: branch/create/parameters
+        required:
+          - name
         properties:
           name:
             description: Name of the branch

--- a/paths/distributions/create.yaml
+++ b/paths/distributions/create.yaml
@@ -48,6 +48,8 @@ requestBody:
       schema:
         type: object
         title: distribution/create/parameters
+        required:
+          - name
         properties:
           name:
             description: Name of the distribution

--- a/paths/distributions/create.yaml
+++ b/paths/distributions/create.yaml
@@ -50,6 +50,7 @@ requestBody:
         title: distribution/create/parameters
         required:
           - name
+          - project_id
         properties:
           name:
             description: Name of the distribution

--- a/paths/figma_attachments/create.yaml
+++ b/paths/figma_attachments/create.yaml
@@ -54,6 +54,8 @@ requestBody:
       schema:
         type: object
         title: figma_attachment/create/parameters
+        required:
+          - url
         properties:
           branch:
             description: specify the branch to use

--- a/paths/glossaries/create.yaml
+++ b/paths/glossaries/create.yaml
@@ -48,6 +48,8 @@ requestBody:
       schema:
         type: object
         title: glossary/create/parameters
+        required:
+          - name
         properties:
           name:
             description: Name of the glossary

--- a/paths/glossary_term_translations/create.yaml
+++ b/paths/glossary_term_translations/create.yaml
@@ -52,6 +52,9 @@ requestBody:
       schema:
         type: object
         title: glossary_term_translation/create/parameters
+        required:
+          - locale_code
+          - content
         properties:
           locale_code:
             description: Identifies the language for this translation

--- a/paths/glossary_terms/create.yaml
+++ b/paths/glossary_terms/create.yaml
@@ -50,6 +50,8 @@ requestBody:
       schema:
         type: object
         title: glossary_term/create/parameters
+        required:
+          - term
         properties:
           term:
             description: Glossary term

--- a/paths/icu/skeleton.yaml
+++ b/paths/icu/skeleton.yaml
@@ -1,6 +1,6 @@
 ---
-summary: Build icu skeletons
-description: Returns icu skeletons for multiple locale codes based on a source content.
+summary: Build ICU skeletons
+description: Returns ICU skeletons for multiple locale codes based on a source content.
 operationId: icu/skeleton
 tags:
 - ICU

--- a/paths/invitations/create.yaml
+++ b/paths/invitations/create.yaml
@@ -54,6 +54,9 @@ requestBody:
       schema:
         type: object
         title: invitation/create/parameters
+        required:
+          - email
+          - role
         properties:
           email:
             description: The email of the invited user. The <code>email</code> can not be updated once created. Create a new invitation for each unique email.

--- a/paths/jobs/create.yaml
+++ b/paths/jobs/create.yaml
@@ -48,6 +48,8 @@ requestBody:
       schema:
         type: object
         title: job/create/parameters
+        required:
+          - name
         properties:
           branch:
             description: specify the branch to use

--- a/paths/key_links/batch_destroy.yaml
+++ b/paths/key_links/batch_destroy.yaml
@@ -7,12 +7,6 @@ parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/project_id"
 - "$ref": "../../parameters.yaml#/key_id_as_id"
-- in: query
-  name: unlink_parent
-  required: false
-  description: Whether to unlink the parent key as well and unmark it as linked-key.
-  schema:
-    type: boolean
 requestBody:
   required: true
   content:
@@ -29,7 +23,10 @@ requestBody:
             example: ["child_key_id1", "child_key_id2"]
             items:
               type: string
-
+          unlink_parent:
+            description: Whether to unlink the parent key as well and unmark it as linked-key.
+            type: boolean
+            default: false
 responses:
   '200':
     description: OK

--- a/paths/key_links/index.yaml
+++ b/paths/key_links/index.yaml
@@ -1,5 +1,5 @@
 ---
-summary: Retrieve all child keys linked to a specific parent key
+summary: List child keys of a parent key
 description: Returns detailed information about a parent key, including its linked child keys.
 operationId: key_links/index
 tags:

--- a/paths/keys/create.yaml
+++ b/paths/keys/create.yaml
@@ -55,6 +55,8 @@ requestBody:
       schema:
         type: object
         title: key/create/parameters
+        required:
+          - name
         properties:
           branch:
             description: specify the branch to use
@@ -129,5 +131,5 @@ requestBody:
             example:
               fruit: Apple
               vegetable: Tomato
-            
+
 x-cli-version: '2.5'

--- a/paths/locales/create.yaml
+++ b/paths/locales/create.yaml
@@ -77,7 +77,7 @@ requestBody:
             type: boolean
             example:
           source_locale_id:
-            description: Source locale. Can be the name or public id of the locale. Preferred is the public id.
+            description: Source locale. Can be the name or id of the locale. Preferred is id.
             type: string
             example: abcd1234abcd1234abcd1234abcd1234
           fallback_locale_id:

--- a/paths/locales/create.yaml
+++ b/paths/locales/create.yaml
@@ -48,6 +48,9 @@ requestBody:
       schema:
         type: object
         title: locale/create/parameters
+        required:
+          - name
+          - code
         properties:
           branch:
             description: specify the branch to use

--- a/paths/locales/download.yaml
+++ b/paths/locales/download.yaml
@@ -100,7 +100,7 @@ parameters:
     in: query
     schema:
       type: boolean
-  - description: If a key has no translation in the locale being downloaded the translation in the fallback locale will be used. Provide the public ID of the locale that should be used as the fallback. Requires include_empty_translations to be set to <code>true</code>.
+  - description: If a key has no translation in the locale being downloaded the translation in the fallback locale will be used. Provide the ID of the locale that should be used as the fallback. Requires include_empty_translations to be set to <code>true</code>.
     example:
     name: fallback_locale_id
     in: query

--- a/paths/locales/update.yaml
+++ b/paths/locales/update.yaml
@@ -76,7 +76,7 @@ requestBody:
             type: boolean
             example:
           source_locale_id:
-            description: Source locale. Can be the name or public id of the locale. Preferred is the public id.
+            description: Source locale. Can be the name or id of the locale. Preferred is id.
             type: string
             example: abcd1234abcd1234abcd1234abcd1234
           fallback_locale_id:

--- a/paths/orders/create.yaml
+++ b/paths/orders/create.yaml
@@ -48,6 +48,9 @@ requestBody:
       schema:
         type: object
         title: order/create/parameters
+        required:
+          - name
+          - lsp
         properties:
           branch:
             description: specify the branch to use

--- a/paths/orders/create.yaml
+++ b/paths/orders/create.yaml
@@ -65,11 +65,11 @@ requestBody:
             type: string
             example: textmaster
           source_locale_id:
-            description: Source locale for the order. Can be the name or public id of the source locale. Preferred is the public id.
+            description: Source locale for the order. Can be the name or id of the source locale. Preferred is id.
             type: string
             example: abcd1234abcd1234abcd1234abcd1234
           target_locale_ids:
-            description: List of target locales you want the source content translate to. Can be the name or public id of the target locales. Preferred is the public id.
+            description: List of target locales you want the source content translate to. Can be the name or id of the target locales. Preferred is id.
             type: array
             items:
               type: string

--- a/paths/projects/create.yaml
+++ b/paths/projects/create.yaml
@@ -47,6 +47,8 @@ requestBody:
       schema:
         type: object
         title: project/create/parameters
+        required:
+          - name
         properties:
           name:
             description: Name of the project

--- a/paths/screenshot_markers/create.yaml
+++ b/paths/screenshot_markers/create.yaml
@@ -50,6 +50,8 @@ requestBody:
       schema:
         type: object
         title: screenshot_marker/create/parameters
+        required:
+          - key_id
         properties:
           branch:
             description: specify the branch to use

--- a/paths/spaces/add_project.yaml
+++ b/paths/spaces/add_project.yaml
@@ -46,6 +46,8 @@ requestBody:
       schema:
         type: object
         title: spaces/projects/create/parameters
+        required:
+         - id
         properties:
           id:
             description: Project ID to add or to the Space

--- a/paths/spaces/create.yaml
+++ b/paths/spaces/create.yaml
@@ -48,6 +48,8 @@ requestBody:
       schema:
         type: object
         title: space/create/parameters
+        required:
+          - name
         properties:
           name:
             description: Name of the space

--- a/paths/styleguides/create.yaml
+++ b/paths/styleguides/create.yaml
@@ -48,6 +48,8 @@ requestBody:
       schema:
         type: object
         title: styleguide/create/parameters
+        required:
+          - title
         properties:
           title:
             description: Style guide title

--- a/paths/tags/create.yaml
+++ b/paths/tags/create.yaml
@@ -48,6 +48,8 @@ requestBody:
       schema:
         type: object
         title: tag/create/parameters
+        required:
+          - name
         properties:
           branch:
             description: specify the branch to use

--- a/paths/teams/add_project.yaml
+++ b/paths/teams/add_project.yaml
@@ -46,6 +46,8 @@ requestBody:
       schema:
         type: object
         title: teams/projects/create/parameters
+        required:
+          - id
         properties:
           id:
             description: Project ID to add to the Team

--- a/paths/teams/add_space.yaml
+++ b/paths/teams/add_space.yaml
@@ -46,6 +46,8 @@ requestBody:
       schema:
         type: object
         title: teams/spaces/create/parameters
+        required:
+          - id
         properties:
           id:
             description: Space ID to add to the Team

--- a/paths/teams/add_user.yaml
+++ b/paths/teams/add_user.yaml
@@ -46,6 +46,8 @@ requestBody:
       schema:
         type: object
         title: teams/users/create/parameters
+        required:
+          - id
         properties:
           id:
             description: User ID to add to the Team

--- a/paths/teams/create.yaml
+++ b/paths/teams/create.yaml
@@ -48,6 +48,8 @@ requestBody:
       schema:
         type: object
         title: team/create/parameters
+        required:
+          - name
         properties:
           name:
             description: Name of the team

--- a/paths/translations/create.yaml
+++ b/paths/translations/create.yaml
@@ -54,7 +54,7 @@ requestBody:
             type: string
             example: my-feature-branch
           locale_id:
-            description: Locale. Can be the name or public id of the locale. Preferred is the public id.
+            description: Locale. Can be the name or id of the locale. Preferred is the id
             type: string
             example: abcd1234cdef1234abcd1234cdef1234
           key_id:

--- a/paths/translations/create.yaml
+++ b/paths/translations/create.yaml
@@ -54,7 +54,7 @@ requestBody:
             type: string
             example: my-feature-branch
           locale_id:
-            description: Locale. Can be the name or id of the locale. Preferred is the id
+            description: Locale. Can be the name or id of the locale. Preferred is id
             type: string
             example: abcd1234cdef1234abcd1234cdef1234
           key_id:

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -59,6 +59,10 @@ requestBody:
       schema:
         type: object
         title: upload/create/parameters
+        required:
+          - file
+          - file_format
+          - locale_id
         properties:
           branch:
             description: specify the branch to use
@@ -107,7 +111,7 @@ requestBody:
             type: string
             example:
           locale_mapping:
-            description: Optional, format specific mapping between locale names and the columns the translations to those locales are contained in.
+            description: Mapping between locale names and translation columns. Required in some formats like CSV or XLSX.
             type: object
             properties: {}
             example: '{"en": "2"}'

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -78,7 +78,7 @@ requestBody:
             type: string
             example: json
           locale_id:
-            description: Locale of the file's content. Can be the name or public id of the locale. Preferred is the public id.
+            description: Locale of the file's content. Can be the name or id of the locale. Preferred is id.
             type: string
             example: abcd1234cdef1234abcd1234cdef1234
           tags:

--- a/paths/variables/create.yaml
+++ b/paths/variables/create.yaml
@@ -48,6 +48,8 @@ requestBody:
       schema:
         type: object
         title: variable/create/parameters
+        required:
+          - name
         properties:
           name:
             description: Name of the variable

--- a/paths/webhooks/create.yaml
+++ b/paths/webhooks/create.yaml
@@ -48,6 +48,8 @@ requestBody:
       schema:
         type: object
         title: webhook/create/parameters
+        required:
+          - callback_url
         properties:
           callback_url:
             description: Callback URL to send requests to

--- a/schemas/key_link.yaml
+++ b/schemas/key_link.yaml
@@ -26,11 +26,3 @@ key_link:
       items:
         $ref: "./key_preview.yaml#/key_preview"
       description: The child translation keys linked to the parent.
-  required:
-    - created_at
-    - updated_at
-    - created_by
-    - updated_by
-    - account
-    - parent
-    - children


### PR DESCRIPTION
Improve documentation of required params. This will be a **breaking** change for some endpoints in the libraries and will be released in a new major version. It's **not** a breaking change for the REST API itself as these param were already required before and returned a 422 in case they were missing

The following endpoints now have additional required parameters:
`authorizations#create` - `note` is required
`blacklisted_keys#create` - `name` is required
`branches#create` - `name` is required
`distributions#create` - `name`, `project_id` are required
`figma_attachements#create` - `url` is required
`glossaries#create` - `name` is required
`glossary_term_translations#create` - `locale_code`, `content` are required
`glossary_terms#create` - `term` is required
`invitations#create` - `email`, `role` are required
`jobs#create` - `name` is required
`keys#create` - `name` is required
`locales#create` - `name`, `code` are required
`orders#create` - `name`, `lsp` are required
`projects#create` - `name` is required
`screenshot_markers#create` - `key_id` is required
`spaces#create` - `name` is required
`styleguides#create` - `title` is required
`tags#create` - `name` is required
`teams#add_project` - `id` is required
`team#add_space` - `id` is required
`teams#add_user` - `id` is required
`teams#create` - `name` is required
`translations#create` - `locale_id`, `key_id` are required
`uploads#create` - `file`, `file_format`, `locale_id` are required
`variables#create` - `name` is required
`webhooks#create` - `callback_url` is required


 

