### PR TITLE
fix(Java): fix maven build

### DIFF
--- a/openapi-generator/templates/java/pom.mustache
+++ b/openapi-generator/templates/java/pom.mustache
@@ -363,6 +363,11 @@
             <version>${junit-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.2.6</version>
+        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
In an earlier PR #534 to allow nullable values, a dependency in Java client was introduced, ever since it being merged, build on `java-client` repo has been failing complaining about missing dependency.

Possible reason can be, we use `gradle` within OpenApi whereas `java-client` uses `maven` and the said dependency had to be included in the `pom.xml` file as well. For now have added the dependency to `pom.mustache` with the latest release version.

[Link to failed builds on java-client](https://github.com/phrase/phrase-java/actions/runs/7781883827/job/21217194464#step:4:136)