### PR TITLE
chore: fix go module version

### DIFF
--- a/clients/go/test/api_uploads_test.go
+++ b/clients/go/test/api_uploads_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	"github.com/antihax/optional"
-	"github.com/phrase/phrase-go/v2"
+	"github.com/phrase/phrase-go/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/openapi-generator/templates/go/README.mustache
+++ b/openapi-generator/templates/go/README.mustache
@@ -17,7 +17,7 @@ import (
 	"context"
 	"fmt"
 
-	phrase "github.com/phrase/phrase-go/v2" // x-release-please-major
+	phrase "github.com/phrase/phrase-go/v3"
 )
 
 func main() {

--- a/openapi-generator/templates/go/go.mod.mustache
+++ b/openapi-generator/templates/go/go.mod.mustache
@@ -1,4 +1,4 @@
-module {{gitHost}}/{{gitUserId}}/{{gitRepoId}}{{#isGoSubmodule}}/{{packageName}}{{/isGoSubmodule}}/v2 // x-release-please-major
+module {{gitHost}}/{{gitUserId}}/{{gitRepoId}}{{#isGoSubmodule}}/{{packageName}}{{/isGoSubmodule}}/v3
 
 go 1.14
 


### PR DESCRIPTION
Bumping the major version for phrase-go unfortunately didn't work automatically