### PR TITLE
fix(Java): fix maven build

### DIFF
--- a/openapi-generator/templates/java/libraries/okhttp-gson/pom.mustache
+++ b/openapi-generator/templates/java/libraries/okhttp-gson/pom.mustache
@@ -322,6 +322,11 @@
             <version>3.14.7</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.2.6</version>
+        </dependency>
     </dependencies>
     <properties>
         <java.version>{{#supportJava6}}1.6{{/supportJava6}}{{^supportJava6}}{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}{{/supportJava6}}</java.version>

--- a/openapi-generator/templates/java/pom.mustache
+++ b/openapi-generator/templates/java/pom.mustache
@@ -363,11 +363,6 @@
             <version>${junit-version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.openapitools</groupId>
-            <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.6</version>
-        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Seems like in the last merged PR #593 , I may have made changes in the wrong pom template. I realised we use `okhttp-gson` Java client/template.... If this still doesn't work, will add a ticket to fix the issue and investigate it further,.