### PR TITLE
build: Ignore .gitignore changes by release-please

### DIFF
--- a/release-please/config-cli.json
+++ b/release-please/config-cli.json
@@ -4,6 +4,7 @@
     "README.md",
     "*.json",
     ".github",
+    ".gitignore",
     "doc",
     "docs",
     "output",

--- a/release-please/config-go.json
+++ b/release-please/config-go.json
@@ -4,6 +4,7 @@
     "README.md",
     "*.json",
     ".github",
+    ".gitignore",
     "doc",
     "docs",
     "output",

--- a/release-please/config-java.json
+++ b/release-please/config-java.json
@@ -4,6 +4,7 @@
     "README.md",
     "*.json",
     ".github",
+    ".gitignore",
     "doc",
     "docs",
     "output",

--- a/release-please/config-php.json
+++ b/release-please/config-php.json
@@ -4,6 +4,7 @@
     "README.md",
     "*.json",
     ".github",
+    ".gitignore",
     "doc",
     "docs",
     "output",

--- a/release-please/config-python.json
+++ b/release-please/config-python.json
@@ -4,6 +4,7 @@
     "README.md",
     "*.json",
     ".github",
+    ".gitignore",
     "doc",
     "docs",
     "output",

--- a/release-please/config-ruby.json
+++ b/release-please/config-ruby.json
@@ -4,6 +4,7 @@
     "README.md",
     "*.json",
     ".github",
+    ".gitignore",
     "doc",
     "docs",
     "output",

--- a/release-please/config-typescript.json
+++ b/release-please/config-typescript.json
@@ -4,6 +4,7 @@
     "README.md",
     "*.json",
     ".github",
+    ".gitignore",
     "doc",
     "docs",
     "output",


### PR DESCRIPTION
Seems that an innocent change in https://github.com/phrase/openapi/pull/607 has triggered a release version bump for all libs. I guess it was caused by a change in `.gitignore`. We should... ignore them!