### PR TITLE
ci(release.sh): add link to changelog to release body

### DIFF
--- a/clients/cli/build/release.sh
+++ b/clients/cli/build/release.sh
@@ -33,7 +33,8 @@ function create_release_data()
   "tag_name": "${VERSION}",
   "name": "${VERSION}",
   "draft": true,
-  "prerelease": false
+  "prerelease": false,
+  "body": "https://github.com/phrase/phrase-cli/blob/master/CHANGELOG.md"
 }
 EOF
 }


### PR DESCRIPTION
Adds a link to https://github.com/phrase/openapi/blob/master/clients/cli/CHANGELOG.md to the body of the release, so that the changelog can easily be found by users that are subscribed to new releases.

Docs: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release

PR created as per request in https://github.com/phrase/phrase-cli/pull/146#discussion_r1599902539