### PR TITLE
fix(CLI): use id instead of repo_sync_id as param

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -4471,15 +4471,6 @@
           "type": "string"
         }
       },
-      "repo_sync_id": {
-        "in": "path",
-        "name": "repo_sync_id",
-        "description": "Repo Sync ID",
-        "required": true,
-        "schema": {
-          "type": "string"
-        }
-      },
       "space_id": {
         "in": "path",
         "name": "space_id",
@@ -22007,7 +21998,7 @@
         "x-cli-version": "2.24"
       }
     },
-    "/accounts/{account_id}/repo_syncs/{repo_sync_id}": {
+    "/accounts/{account_id}/repo_syncs/{id}": {
       "get": {
         "summary": "Get a single Repo Sync",
         "description": "Shows a single Repo Sync setting.",
@@ -22023,7 +22014,7 @@
             "$ref": "#/components/parameters/account_id"
           },
           {
-            "$ref": "#/components/parameters/repo_sync_id"
+            "$ref": "#/components/parameters/id"
           }
         ],
         "responses": {
@@ -22071,7 +22062,7 @@
         "x-cli-version": "2.24"
       }
     },
-    "/accounts/{account_id}/repo_syncs/{repo_sync_id}/export": {
+    "/accounts/{account_id}/repo_syncs/{id}/export": {
       "post": {
         "summary": "Export to code repository",
         "description": "> Beta: this feature will change in the future.\n\nExport translations from Phrase Strings to repository provider according to the\n.phrase.yml file within the code repository.\n\n*Export is done asynchronously and may take several seconds depending on the project size.*",
@@ -22087,7 +22078,7 @@
             "$ref": "#/components/parameters/account_id"
           },
           {
-            "$ref": "#/components/parameters/repo_sync_id"
+            "$ref": "#/components/parameters/id"
           }
         ],
         "responses": {
@@ -22136,13 +22127,13 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase repo_sync export \\\n--repo_sync_id <repo_sync_id> \\\n--access_token <token>"
+            "source": "phrase repo_sync export \\\n--id <repo_sync_id> \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.24"
       }
     },
-    "/accounts/{account_id}/repo_syncs/{repo_sync_id}/import": {
+    "/accounts/{account_id}/repo_syncs/{id}/import": {
       "post": {
         "summary": "Import from code repository",
         "description": "> Beta: this feature will change in the future.\n\nImport translations from repository provider to Phrase Strings according to the .phrase.yml file\nwithin the code repository.\n\n_Import is done asynchronously and may take several seconds depending on the project size._",
@@ -22158,7 +22149,7 @@
             "$ref": "#/components/parameters/account_id"
           },
           {
-            "$ref": "#/components/parameters/repo_sync_id"
+            "$ref": "#/components/parameters/id"
           }
         ],
         "responses": {
@@ -22207,13 +22198,13 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase repo_sync import \\\n--repo_sync_id <repo_sync_id> \\\n--access_token <token>"
+            "source": "phrase repo_sync import \\\n--id <repo_sync_id> \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.24"
       }
     },
-    "/accounts/{account_id}/repo_syncs/{repo_sync_id}/events": {
+    "/accounts/{account_id}/repo_syncs/{id}/events": {
       "get": {
         "summary": "Repository Syncs History",
         "description": "Get the history of a single Repo Sync. The history includes all imports and exports\nperformed by the Repo Sync.",
@@ -22229,7 +22220,7 @@
             "$ref": "#/components/parameters/account_id"
           },
           {
-            "$ref": "#/components/parameters/repo_sync_id"
+            "$ref": "#/components/parameters/id"
           }
         ],
         "responses": {
@@ -22286,7 +22277,7 @@
         "x-cli-version": "2.24"
       }
     },
-    "/accounts/{account_id}/repo_syncs/{repo_sync_id}/deactivate": {
+    "/accounts/{account_id}/repo_syncs/{id}/deactivate": {
       "post": {
         "summary": "Deactivate a Repo Sync",
         "description": "Deactivate an active Repo Sync. Import and export can't be performed on deactivated syncs\nand the pushes to the repository won't trigger the import to Phrase.",
@@ -22302,7 +22293,7 @@
             "$ref": "#/components/parameters/account_id"
           },
           {
-            "$ref": "#/components/parameters/repo_sync_id"
+            "$ref": "#/components/parameters/id"
           }
         ],
         "responses": {
@@ -22344,13 +22335,13 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase repo_sync deactivate \\\n--repo_sync_id <repo_sync_id> \\\n--access_token <token>"
+            "source": "phrase repo_sync deactivate \\\n--id <repo_sync_id> \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.24"
       }
     },
-    "/accounts/{account_id}/repo_syncs/{repo_sync_id}/activate": {
+    "/accounts/{account_id}/repo_syncs/{id}/activate": {
       "post": {
         "summary": "Activate a Repo Sync",
         "description": "Activate a deactivated Repo Sync. Active syncs can be used to import and export translations,\nand imports to Phrase are automatically triggered by pushes to the repository, if configured.",
@@ -22366,7 +22357,7 @@
             "$ref": "#/components/parameters/account_id"
           },
           {
-            "$ref": "#/components/parameters/repo_sync_id"
+            "$ref": "#/components/parameters/id"
           }
         ],
         "responses": {
@@ -22408,7 +22399,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase repo_sync activate \\\n--repo_sync_id <repo_sync_id> \\\n--access_token <token>"
+            "source": "phrase repo_sync activate \\\n--id <repo_sync_id> \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.24"

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -46,13 +46,6 @@ query_account_id:
   required: false
   schema:
     type: string
-repo_sync_id:
-  in: path
-  name: repo_sync_id
-  description: Repo Sync ID
-  required: true
-  schema:
-    type: string
 space_id:
   in: path
   name: space_id

--- a/paths.yaml
+++ b/paths.yaml
@@ -513,22 +513,22 @@
 "/accounts/{account_id}/repo_syncs":
   get:
     "$ref": "./paths/repo_syncs/index.yaml"
-"/accounts/{account_id}/repo_syncs/{repo_sync_id}":
+"/accounts/{account_id}/repo_syncs/{id}":
   get:
     "$ref": "./paths/repo_syncs/show.yaml"
-"/accounts/{account_id}/repo_syncs/{repo_sync_id}/export":
+"/accounts/{account_id}/repo_syncs/{id}/export":
   post:
     "$ref": "./paths/repo_syncs/export.yaml"
-"/accounts/{account_id}/repo_syncs/{repo_sync_id}/import":
+"/accounts/{account_id}/repo_syncs/{id}/import":
   post:
     "$ref": "./paths/repo_syncs/import.yaml"
-"/accounts/{account_id}/repo_syncs/{repo_sync_id}/events":
+"/accounts/{account_id}/repo_syncs/{id}/events":
   get:
     "$ref": "./paths/repo_syncs/events.yaml"
-"/accounts/{account_id}/repo_syncs/{repo_sync_id}/deactivate":
+"/accounts/{account_id}/repo_syncs/{id}/deactivate":
   post:
     "$ref": "./paths/repo_syncs/deactivate.yaml"
-"/accounts/{account_id}/repo_syncs/{repo_sync_id}/activate":
+"/accounts/{account_id}/repo_syncs/{id}/activate":
   post:
     "$ref": "./paths/repo_syncs/activate.yaml"
 "/accounts/{account_id}/spaces":

--- a/paths/repo_syncs/activate.yaml
+++ b/paths/repo_syncs/activate.yaml
@@ -9,7 +9,7 @@ tags:
 parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/account_id"
-- "$ref": "../../parameters.yaml#/repo_sync_id"
+- "$ref": "../../parameters.yaml#/id"
 responses:
   '200':
     description: OK
@@ -40,6 +40,6 @@ x-code-samples:
 - lang: CLI v2
   source: |-
     phrase repo_sync activate \
-    --repo_sync_id <repo_sync_id> \
+    --id <repo_sync_id> \
     --access_token <token>
 x-cli-version: '2.24'

--- a/paths/repo_syncs/deactivate.yaml
+++ b/paths/repo_syncs/deactivate.yaml
@@ -9,7 +9,7 @@ tags:
 parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/account_id"
-- "$ref": "../../parameters.yaml#/repo_sync_id"
+- "$ref": "../../parameters.yaml#/id"
 responses:
   '200':
     description: OK
@@ -40,6 +40,6 @@ x-code-samples:
 - lang: CLI v2
   source: |-
     phrase repo_sync deactivate \
-    --repo_sync_id <repo_sync_id> \
+    --id <repo_sync_id> \
     --access_token <token>
 x-cli-version: '2.24'

--- a/paths/repo_syncs/events.yaml
+++ b/paths/repo_syncs/events.yaml
@@ -8,7 +8,7 @@ tags:
 parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/account_id"
-- "$ref": "../../parameters.yaml#/repo_sync_id"
+- "$ref": "../../parameters.yaml#/id"
 responses:
   '200':
     description: Successful response

--- a/paths/repo_syncs/export.yaml
+++ b/paths/repo_syncs/export.yaml
@@ -13,7 +13,7 @@ tags:
 parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/account_id"
-- "$ref": "../../parameters.yaml#/repo_sync_id"
+- "$ref": "../../parameters.yaml#/id"
 responses:
   '200':
     description: OK
@@ -49,6 +49,6 @@ x-code-samples:
 - lang: CLI v2
   source: |-
     phrase repo_sync export \
-    --repo_sync_id <repo_sync_id> \
+    --id <repo_sync_id> \
     --access_token <token>
 x-cli-version: '2.24'

--- a/paths/repo_syncs/import.yaml
+++ b/paths/repo_syncs/import.yaml
@@ -13,7 +13,7 @@ tags:
 parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/account_id"
-- "$ref": "../../parameters.yaml#/repo_sync_id"
+- "$ref": "../../parameters.yaml#/id"
 responses:
   '200':
     description: OK
@@ -49,6 +49,6 @@ x-code-samples:
 - lang: CLI v2
   source: |-
     phrase repo_sync import \
-    --repo_sync_id <repo_sync_id> \
+    --id <repo_sync_id> \
     --access_token <token>
 x-cli-version: '2.24'

--- a/paths/repo_syncs/show.yaml
+++ b/paths/repo_syncs/show.yaml
@@ -7,7 +7,7 @@ tags:
 parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/account_id"
-- "$ref": "../../parameters.yaml#/repo_sync_id"
+- "$ref": "../../parameters.yaml#/id"
 responses:
   '200':
     description: OK


### PR DESCRIPTION
The param to work with a resource should be called simply `id`