### PR TITLE
build(go): Update deprecated --rm-dist argument

### DIFF
--- a/clients/go/.github/workflows/release.yml
+++ b/clients/go/.github/workflows/release.yml
@@ -20,6 +20,6 @@ jobs:
         uses: goreleaser/goreleaser-action@ac067437f516133269923265894e77920c3dce18 # pin@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Addresses https://github.com/phrase/phrase-go/actions/runs/9480403418/job/26120994452

https://goreleaser.com/deprecations/#-rm-dist