### PR TITLE
fix(API): add app_min_version and app_max_version param to releases

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -9370,6 +9370,16 @@
                       "feature1"
                     ]
                   },
+                  "app_min_version": {
+                    "description": "Minimum version of the app that the release supports in semver format",
+                    "type": "string",
+                    "example": "2.5.0"
+                  },
+                  "app_max_version": {
+                    "description": "Maximum version of the app that the release supports in semver format",
+                    "type": "string",
+                    "example": "3.0.0"
+                  },
                   "branch": {
                     "description": "Branch used for release",
                     "type": "string",
@@ -9535,6 +9545,16 @@
                       "android",
                       "ios"
                     ]
+                  },
+                  "app_min_version": {
+                    "description": "Minimum version of the app that the release supports in semver format",
+                    "type": "string",
+                    "example": "2.5.0"
+                  },
+                  "app_max_version": {
+                    "description": "Maximum version of the app that the release supports in semver format",
+                    "type": "string",
+                    "example": "3.0.0"
                   },
                   "branch": {
                     "description": "Branch used for release",

--- a/paths/releases/create.yaml
+++ b/paths/releases/create.yaml
@@ -79,6 +79,14 @@ requestBody:
             example:
               - android
               - feature1
+          app_min_version:
+            description: Minimum version of the app that the release supports in semver format
+            type: string
+            example: 2.5.0
+          app_max_version:
+            description: Maximum version of the app that the release supports in semver format
+            type: string
+            example: 3.0.0
           branch:
             description: Branch used for release
             type: string

--- a/paths/releases/update.yaml
+++ b/paths/releases/update.yaml
@@ -65,6 +65,14 @@ requestBody:
             example:
             - android
             - ios
+          app_min_version:
+            description: Minimum version of the app that the release supports in semver format
+            type: string
+            example: 2.5.0
+          app_max_version:
+            description: Maximum version of the app that the release supports in semver format
+            type: string
+            example: 3.0.0
           branch:
             description: Branch used for release
             type: string


### PR DESCRIPTION
Add missing `app_min_version` and `app_max_version` params to the release endpoints