### PR TITLE
fix(go): Fix query param serialization of nested objects [TSI-2594]

### DIFF
--- a/clients/go/test/api_locales_test.go
+++ b/clients/go/test/api_locales_test.go
@@ -41,6 +41,9 @@ func Test_phrase_LocalesApiService(t *testing.T) {
 		formatOptions := optional.NewInterface(map[string]interface{}{
 			"foo": "bar",
 			"baz": "bazz",
+			"custom_metadata_columns": map[string]interface{}{
+				"foo": 100,
+			},
 		})
 		localeDownloadOpts := phrase.LocaleDownloadOpts{FormatOptions: formatOptions}
 
@@ -50,7 +53,7 @@ func Test_phrase_LocalesApiService(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, resp)
 		assert.Equal(t, 200, httpRes.StatusCode)
-		assert.Equal(t, "format_options%5Bbaz%5D=bazz&format_options%5Bfoo%5D=bar", requestUrl.RawQuery)
+		assert.Equal(t, "format_options%5Bbaz%5D=bazz&format_options%5Bcustom_metadata_columns%5D%5Bfoo%5D=100&format_options%5Bfoo%5D=bar", requestUrl.RawQuery)
 		assert.Equal(t, "/projects/project_id_example/locales/locale_id/download", requestUrl.Path)
 		assert.Equal(t, "GET", httpRes.Request.Method)
 	})

--- a/openapi-generator/templates/go/api.mustache
+++ b/openapi-generator/templates/go/api.mustache
@@ -168,7 +168,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 	{{/isCollectionFormatMulti}}
 	{{^isCollectionFormatMulti}}
 		{{#isPrimitiveType}}localVarQueryParams.Add("{{baseName}}", parameterToString(localVarOptionals.{{vendorExtensions.x-export-param-name}}.Value(), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")){{/isPrimitiveType}}{{^isPrimitiveType}}for key, value := range localVarOptionals.{{vendorExtensions.x-export-param-name}}.Value().(map[string]interface{}) {
-			localVarQueryParams.Add(fmt.Sprintf("{{baseName}}[%s]", key), parameterToString(value, ""))
+			localVarQueryParams = serializeMapParams(fmt.Sprintf("{{baseName}}[%s]", key), value, localVarQueryParams)
 		}{{/isPrimitiveType}}
 	{{/isCollectionFormatMulti}}
 	}

--- a/openapi-generator/templates/go/client.mustache
+++ b/openapi-generator/templates/go/client.mustache
@@ -165,12 +165,18 @@ func parameterToJson(obj interface{}) (string, error) {
 
 // helper for serializing and setting mapped parameters request body
 func serializeMapParams(key string, value interface{}, localParams url.Values) url.Values {
-	if reflect.TypeOf(value).Kind() == reflect.Map {
-		for k, v := range value.(map[interface{}]interface{}) {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		for k, v := range v {
 			paramKeyName := fmt.Sprintf("%s[%s]", key, k)
 			serializeMapParams(paramKeyName, v, localParams)
 		}
-	} else {
+	case map[interface{}]interface{}:
+		for k, v := range v {
+			paramKeyName := fmt.Sprintf("%s[%v]", key, k)
+			serializeMapParams(paramKeyName, v, localParams)
+		}
+	default:
 		localParams.Add(key, parameterToString(value, ""))
 	}
 	return localParams


### PR DESCRIPTION
Fix serializing format_options when downloading locales. We're using a nested structure for `custom_metadata_columns` which were being wrongfully sent as `{"custom_metadata_columns"=>"map[foo:5]"}`.

Similar to the issue we fixed for uploads in https://github.com/phrase/openapi/pull/498

https://phrase.atlassian.net/browse/TSI-2594