### PR TITLE
fix(PHP): Fix query param serialization of nested objects [TSI-2593]

### DIFF
--- a/clients/php/test/Api/LocalesApiTest.php
+++ b/clients/php/test/Api/LocalesApiTest.php
@@ -134,7 +134,40 @@ class LocalesApiTest extends TestCase
 
         $projectId = "project_id_example";
         $id = "locale_id";
-        $result = $this->apiInstance->localeDownload($projectId, $id);
+        $file_format = "csv";
+        $format_options = array(
+            "key" => "value",
+            "nested" => array(
+                "nested_key" => "nested_value"
+            )
+        );
+        $custom_metadata_filters = array('key' => 'value');
+
+        $result = $this->apiInstance-> localeDownload(
+            $projectId,
+            $id,
+            null,
+            null,
+            null,
+            null,
+            $file_format,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            $format_options,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            $custom_metadata_filters
+        );
+        
 
         $this->assertNotNull($result);
         $this->assertEquals('foo', $result);
@@ -142,6 +175,7 @@ class LocalesApiTest extends TestCase
         $lastRequest = $this->history[count($this->history)-1]['request'];
         $this->assertEquals('GET', $lastRequest->getMethod());
         $this->assertEquals('/v2/projects/'.$projectId.'/locales/'.$id.'/download', $lastRequest->getUri()->getPath());
+        $this->assertEquals('file_format=csv&format_options%5Bkey%5D=value&format_options%5Bnested%5D%5Bnested_key%5D=nested_value&custom_metadata_filters%5Bkey%5D=value', $lastRequest->getUri()->getQuery());
     }
 
     /**

--- a/openapi-generator/templates/php/api.mustache
+++ b/openapi-generator/templates/php/api.mustache
@@ -637,7 +637,7 @@ use {{invokerPackage}}\ObjectSerializer;
         $operationHost = $operationHosts[$this->hostIndex];
 
         {{/servers.0}}
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = http_build_query($queryParams);
         return new Request(
             '{{httpMethod}}',
             {{^servers.0}}$this->config->getHost(){{/servers.0}}{{#servers.0}}$operationHost{{/servers.0}} . $resourcePath . ($query ? "?{$query}" : ''),


### PR DESCRIPTION
Fix query param serialization of nested fields such as `format_options` and `custom_metadata_filters` for locale download in PHP SDK. It seems Guzzle's query builder can't properly handle nested arrays, using the built-in `http_build_query` function seems to fix the issue.

https://phrase.atlassian.net/browse/TSI-2593