### PR TITLE
build(python): Adjust test dependencies for Python versions >= 3.7 [TSI-2469]

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -18,4 +18,4 @@ jobs:
         run: |
           cd ./clients/python
           pip install -r requirements.txt -r test-requirements.txt
-          python -m unittest
+          pytest

--- a/clients/python/test/test_locales_api.py
+++ b/clients/python/test/test_locales_api.py
@@ -12,7 +12,12 @@
 from __future__ import absolute_import
 
 import unittest
-from unittest.mock import Mock, patch
+import sys
+
+if sys.version_info[:2] <= (3, 7):
+    from mock import Mock, patch 
+else:
+    from unittest.mock import Mock, patch
 
 
 import phrase_api

--- a/clients/python/test/test_uploads_api.py
+++ b/clients/python/test/test_uploads_api.py
@@ -12,7 +12,12 @@
 from __future__ import absolute_import
 
 import unittest
-from unittest.mock import Mock, patch
+import sys
+
+if sys.version_info[:2] <= (3, 7):
+    from mock import Mock, patch 
+else:
+    from unittest.mock import Mock, patch
 
 import phrase_api
 from phrase_api.api.uploads_api import UploadsApi  # noqa: E501

--- a/openapi-generator/templates/python/test-requirements.mustache
+++ b/openapi-generator/templates/python/test-requirements.mustache
@@ -6,7 +6,9 @@ py>=1.4.31
 randomize>=0.13
 {{/useNose}}
 {{^useNose}}
-pytest~=4.6.7 # needed for python 2.7+3.4
 pytest-cov>=2.8.1
 pytest-randomly==1.2.3 # needed for python 2.7+3.4
+
+pytest~=4.6.7; python_version < "3.7"
+pytest~=7.1; python_version >= "3.7"
 {{/useNose}}

--- a/openapi-generator/templates/python/test-requirements.mustache
+++ b/openapi-generator/templates/python/test-requirements.mustache
@@ -11,4 +11,5 @@ pytest-randomly==1.2.3 # needed for python 2.7+3.4
 
 pytest~=4.6.7; python_version < "3.7"
 pytest~=7.1; python_version >= "3.7"
+mock; python_version <= "3.7"
 {{/useNose}}


### PR DESCRIPTION
Introduce separate `pytest` version for Python versions newer than `3.7`, as it caused the build to fail. 

Also adjust the `test-python` workflow to use `pytest` as well for consistency.

**ℹ️ This will be merged after the issue with PyPI is resolved.**

https://phrase.atlassian.net/browse/TSI-2469