### PR TITLE
feat: Add update_translations_on_source_match

### DIFF
--- a/clients/java/src/test/java/com/phrase/client/api/UploadsApiTest.java
+++ b/clients/java/src/test/java/com/phrase/client/api/UploadsApiTest.java
@@ -97,6 +97,7 @@ public class UploadsApiTest {
         String tags = null;
         Boolean updateTranslations = null;
         Boolean updateTranslationKeys = true;
+        Boolean updateTranslationsOnSourceMatch = null;
         Boolean updateDescriptions = null;
         Boolean convertEmoji = null;
         Boolean skipUploadTags = null;
@@ -107,7 +108,7 @@ public class UploadsApiTest {
         Boolean autotranslate = null;
         Boolean markReviewed = null;
         Boolean tagOnlyAffectedKeys = null;
-        Upload response = api.uploadCreate(projectId, file, fileFormat, localeId, xPhraseAppOTP, branch, tags, updateTranslations, updateTranslationKeys, updateDescriptions, convertEmoji, skipUploadTags, skipUnverification, fileEncoding, localeMapping, formatOptions, autotranslate, markReviewed, tagOnlyAffectedKeys);
+        Upload response = api.uploadCreate(projectId, file, fileFormat, localeId, xPhraseAppOTP, branch, tags, updateTranslations, updateTranslationKeys, updateTranslationsOnSourceMatch, updateDescriptions, convertEmoji, skipUploadTags, skipUnverification, fileEncoding, localeMapping, formatOptions, autotranslate, markReviewed, tagOnlyAffectedKeys);
 
         Assert.assertEquals("valid id returned", "id_example", response.getId());
         Assert.assertEquals("valid creation date returned", OffsetDateTime.parse("2015-01-28T09:52:53Z"), response.getCreatedAt());

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -14990,7 +14990,7 @@
                     "example": null
                   },
                   "update_translations_on_source_match": {
-                    "description": "Update target translations only if the source translations of the uploaded multilingual file match the stored translations",
+                    "description": "Update target translations only if the source translations of the uploaded multilingual file match the stored translations.",
                     "type": "boolean",
                     "default": false,
                     "example": null

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -14990,7 +14990,7 @@
                     "example": null
                   },
                   "update_translations_on_source_match": {
-                    "description": "Pass `true` to update target translations only if the source translations match the uploaded multilingual file",
+                    "description": "Update target translations only if the source translations of the uploaded multilingual file match the stored translations",
                     "type": "boolean",
                     "default": false,
                     "example": null

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -14989,6 +14989,12 @@
                     "default": true,
                     "example": null
                   },
+                  "update_translations_on_source_match": {
+                    "description": "Pass `true` to update target translations only if the source translations match the uploaded multilingual file",
+                    "type": "boolean",
+                    "default": false,
+                    "example": null
+                  },
                   "update_descriptions": {
                     "description": "Existing key descriptions will be updated with the file content. Empty descriptions overwrite existing descriptions.",
                     "type": "boolean",

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -95,7 +95,7 @@ requestBody:
             default: true
             example:
           update_translations_on_source_match:
-            description: Pass `true` to update target translations only if the source translations match the uploaded multilingual file
+            description: Update target translations only if the source translations of the uploaded multilingual file match the stored translations
             type: boolean
             default: false
             example:

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -95,7 +95,7 @@ requestBody:
             default: true
             example:
           update_translations_on_source_match:
-            description: Update target translations only if the source translations of the uploaded multilingual file match the stored translations
+            description: Update target translations only if the source translations of the uploaded multilingual file match the stored translations.
             type: boolean
             default: false
             example:

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -94,6 +94,11 @@ requestBody:
             type: boolean
             default: true
             example:
+          update_translations_on_source_match:
+            description: Pass `true` to update target translations only if the source translations match the uploaded multilingual file
+            type: boolean
+            default: false
+            example:
           update_descriptions:
             description: Existing key descriptions will be updated with the file content. Empty descriptions overwrite existing descriptions.
             type: boolean


### PR DESCRIPTION
Add `update_translations_on_source_match` to update target translations only if the source translations match the uploaded multilingual file.