### PR TITLE
build(CLI): Run test workflow only for CLI releases

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -1,7 +1,10 @@
 # Currently this does not contain any tests, only a license check
 # Once we add tests, we should add a step here to run them
 name: Run CLI Tests
-on: [push]
+on:
+  push:
+    paths:
+      - openapi-generator/cli_lang.yaml
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths:
       - openapi-generator/cli_lang.yaml
+      - clients/cli/cmd/internal/*
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,6 @@ cli:
 	openapi-generator-cli generate -i tmp/compiled.yaml -g go -o tmp/cli -c ./openapi-generator/cli_lang.yaml -e handlebars
 	cp tmp/cli/api_* clients/cli/cmd/
 	cp tmp/cli/README.md clients/cli/
-	go install golang.org/x/tools/cmd/goimports@latest
+	go install golang.org/x/tools/cmd/goimports@v0.24.0
 	goimports -w clients/cli
 	cd clients/cli && go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ruby:
 	openapi-generator-cli generate -i tmp/compiled.yaml -g ruby -o clients/ruby -c ./openapi-generator/ruby_lang.yaml
 go:
 	openapi-generator-cli generate -i tmp/compiled.yaml -g go -o clients/go -c ./openapi-generator/go_lang.yaml --global-property apiTests=false,modelTests=false
-	go install golang.org/x/tools/cmd/goimports@latest
+	go install golang.org/x/tools/cmd/goimports@v0.24.0
 	goimports -w clients/go
 	cd clients/go && go mod tidy
 typescript:


### PR DESCRIPTION
Run the CLI tests only when there are related changes, otherwise it fails due to missing Go package version.