### PR TITLE
chore(docs): remove deprecated smart_suggest params

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -11502,7 +11502,7 @@
             }
           },
           {
-            "description": "ids of keys that should added to the job",
+            "description": "ids of keys that should be removed from the job",
             "example": [
               "abcd1234cdef1234abcd1234cdef1234"
             ],
@@ -16525,7 +16525,7 @@
                     "example": "review"
                   },
                   "machine_translation_enabled": {
-                    "description": "(Optional) Enable machine translation support in the project. Required for Autopilot and Smart Suggest",
+                    "description": "(Optional) Enable machine translation support in the project. Required for Pre-Translation",
                     "type": "boolean",
                     "example": true
                   },
@@ -16586,21 +16586,6 @@
                   },
                   "autotranslate_use_translation_memory": {
                     "description": "(Optional) Requires autotranslate_enabled to be true",
-                    "type": "boolean",
-                    "example": true
-                  },
-                  "smart_suggest_enabled": {
-                    "description": "(Optional) Smart Suggest, requires machine_translation_enabled",
-                    "type": "boolean",
-                    "example": true
-                  },
-                  "smart_suggest_use_glossary": {
-                    "description": "(Optional) Requires smart_suggest_enabled to be true",
-                    "type": "boolean",
-                    "example": true
-                  },
-                  "smart_suggest_use_machine_translation": {
-                    "description": "(Optional) Requires smart_suggest_enabled to be true",
                     "type": "boolean",
                     "example": true
                   }
@@ -16784,7 +16769,7 @@
                     "example": "review"
                   },
                   "machine_translation_enabled": {
-                    "description": "(Optional) Enable machine translation support in the project. Required for Autopilot and Smart Suggest",
+                    "description": "(Optional) Enable machine translation support in the project. Required for Pre-Translation",
                     "type": "boolean",
                     "example": true
                   },
@@ -16845,21 +16830,6 @@
                   },
                   "autotranslate_use_translation_memory": {
                     "description": "(Optional) Requires autotranslate_enabled to be true",
-                    "type": "boolean",
-                    "example": true
-                  },
-                  "smart_suggest_enabled": {
-                    "description": "(Optional) Smart Suggest, requires machine_translation_enabled",
-                    "type": "boolean",
-                    "example": true
-                  },
-                  "smart_suggest_use_glossary": {
-                    "description": "(Optional) Requires smart_suggest_enabled to be true",
-                    "type": "boolean",
-                    "example": true
-                  },
-                  "smart_suggest_use_machine_translation": {
-                    "description": "(Optional) Requires smart_suggest_enabled to be true",
                     "type": "boolean",
                     "example": true
                   }

--- a/paths/jobs/remove_keys.yaml
+++ b/paths/jobs/remove_keys.yaml
@@ -14,7 +14,7 @@ parameters:
   in: query
   schema:
     type: string
-- description: ids of keys that should added to the job
+- description: ids of keys that should be removed from the job
   example:
   - abcd1234cdef1234abcd1234cdef1234
   name: translation_key_ids

--- a/paths/projects/create.yaml
+++ b/paths/projects/create.yaml
@@ -94,7 +94,7 @@ requestBody:
             type: string
             example: review
           machine_translation_enabled:
-            description: "(Optional) Enable machine translation support in the project. Required for Autopilot and Smart Suggest"
+            description: "(Optional) Enable machine translation support in the project. Required for Pre-Translation"
             type: boolean
             example: true
           enable_branching:
@@ -143,18 +143,6 @@ requestBody:
             example: true
           autotranslate_use_translation_memory:
             description: "(Optional) Requires autotranslate_enabled to be true"
-            type: boolean
-            example: true
-          smart_suggest_enabled:
-            description: "(Optional) Smart Suggest, requires machine_translation_enabled"
-            type: boolean
-            example: true
-          smart_suggest_use_glossary:
-            description: "(Optional) Requires smart_suggest_enabled to be true"
-            type: boolean
-            example: true
-          smart_suggest_use_machine_translation:
-            description: "(Optional) Requires smart_suggest_enabled to be true"
             type: boolean
             example: true
 x-cli-version: "2.6.3"

--- a/paths/projects/update.yaml
+++ b/paths/projects/update.yaml
@@ -90,7 +90,7 @@ requestBody:
             type: string
             example: review
           machine_translation_enabled:
-            description: "(Optional) Enable machine translation support in the project. Required for Autopilot and Smart Suggest"
+            description: "(Optional) Enable machine translation support in the project. Required for Pre-Translation"
             type: boolean
             example: true
           enable_branching:
@@ -139,18 +139,6 @@ requestBody:
             example: true
           autotranslate_use_translation_memory:
             description: "(Optional) Requires autotranslate_enabled to be true"
-            type: boolean
-            example: true
-          smart_suggest_enabled:
-            description: "(Optional) Smart Suggest, requires machine_translation_enabled"
-            type: boolean
-            example: true
-          smart_suggest_use_glossary:
-            description: "(Optional) Requires smart_suggest_enabled to be true"
-            type: boolean
-            example: true
-          smart_suggest_use_machine_translation:
-            description: "(Optional) Requires smart_suggest_enabled to be true"
             type: boolean
             example: true
 x-cli-version: "2.6.3"


### PR DESCRIPTION
- Remove smart_suggest params as the feature is no longer supported in editor
- Fix key_ids description for `remove_keys` endpoint