### PR TITLE
chore: disable golang proxy for phrase-go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,12 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.6
+          go-version: 1.21.9
       - name: Build and Deploy 🚀
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOPRIVATE: github.com/phrase/phrase-go
         run: |
           npm install
           npm run generate.go
@@ -50,11 +51,12 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.6
+          go-version: 1.21.9
       - name: Build and Deploy 🚀
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOPRIVATE: github.com/phrase/phrase-go
         run: |
           npm install
           npm run generate.cli

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.6
+          go-version: 1.21.9
       - name: Build
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
@@ -53,7 +53,7 @@ jobs:
   #     - name: Set up Go
   #       uses: actions/setup-go@v2
   #       with:
-  #         go-version: 1.19.6
+  #         go-version: 1.21.9
   #     - name: Build
   #       env:
   #         API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -15,8 +15,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.19.6'
+          go-version: '1.21.9'
       - name: Generate CLI
+        env:
+          GOPRIVATE: github.com/phrase/phrase-go
         run: |
           npm install
           npm run generate.cli

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.19.6'
+          go-version: '1.21.9'
       - name: Run Tests
         run: |
           npm install

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.19.1
+golang 1.21.9
 nodejs 20.11.0
 maven 3.9.1


### PR DESCRIPTION
Requests are cached for 30 minutes when a non existing version is requested. This is causing lots of build failures during the time when a new phrase-go version is published and used. By setting `GOPRIVATE` the proxy should be skipped and the package directly fetched from GitHub