### PR TITLE
fix(PHP): Fix serializing nested form parameters #STRINGS-730

### DIFF
--- a/clients/php/test/Api/UploadsApiTest.php
+++ b/clients/php/test/Api/UploadsApiTest.php
@@ -138,8 +138,8 @@ class UploadsApiTest extends TestCase
         $lastRequest = $this->history[count($this->history) - 1]['request'];
         $this->assertEquals('POST', $lastRequest->getMethod());
         $this->assertEquals('/v2/projects/'.$projectId.'/uploads', $lastRequest->getUri()->getPath());
-        $this->assertStringContainsString('multipart/form-data', $lastRequest->getHeader('Content-Type')[0]);
-        $this->assertStringContainsString("Content-Disposition: form-data; name=\"locale_mapping[en][bar]\"\r\nContent-Length: 3\r\n\r\nbaz\r\n", $lastRequest->getBody()->getContents());
+        $this->assertContains('multipart/form-data', $lastRequest->getHeader('Content-Type')[0]);
+        $this->assertContains("Content-Disposition: form-data; name=\"locale_mapping[en][bar]\"\r\nContent-Length: 3\r\n\r\nbaz\r\n", $lastRequest->getBody()->getContents());
     }
 
     /**

--- a/clients/php/test/Api/UploadsApiTest.php
+++ b/clients/php/test/Api/UploadsApiTest.php
@@ -107,7 +107,24 @@ class UploadsApiTest extends TestCase
         $file = new \SplFileObject($fileName, 'w+');
         $file->fwrite('test');
 
-        $result = $this->apiInstance->uploadCreate($projectId, $file, "yml", "en", null, null);
+        $result = $this->apiInstance->uploadCreate(
+            $projectId,
+            $file,
+            "yml",
+            "en",
+            null, # x_phrase_app_otp
+            null, # branch
+            null, # tags
+            null, # update_translations
+            null, # update_translation_keys
+            null, # update_translations_on_source_match
+            null, # update_descriptions
+            null, # convert_emoji
+            null, # skip_upload_tags
+            null, # skip_unverification
+            null, # file_encoding
+            ['en' => ['foo' => 3, 'bar' => 'baz']] # locale_mapping
+        );
         $file = null;
         unlink($fileName);
 
@@ -121,7 +138,8 @@ class UploadsApiTest extends TestCase
         $lastRequest = $this->history[count($this->history) - 1]['request'];
         $this->assertEquals('POST', $lastRequest->getMethod());
         $this->assertEquals('/v2/projects/'.$projectId.'/uploads', $lastRequest->getUri()->getPath());
-        $this->assertContains('multipart/form-data', $lastRequest->getHeader('Content-Type')[0]);
+        $this->assertStringContainsString('multipart/form-data', $lastRequest->getHeader('Content-Type')[0]);
+        $this->assertStringContainsString("Content-Disposition: form-data; name=\"locale_mapping[en][bar]\"\r\nContent-Length: 3\r\n\r\nbaz\r\n", $lastRequest->getBody()->getContents());
     }
 
     /**

--- a/openapi-generator/templates/php/ObjectSerializer.mustache
+++ b/openapi-generator/templates/php/ObjectSerializer.mustache
@@ -165,16 +165,24 @@ class ObjectSerializer
      * the http body (form parameter). If it's a string, pass through unchanged
      * If it's a datetime object, format it in ISO8601
      *
-     * @param string|\SplFileObject $value the value of the form parameter
+     * @param string $name the name of the form parameter
+     * @param string|\SplFileObject|array|object $value the value of the form parameter
      *
-     * @return string the form string
+     * @return array the key-value pairs of the form parameters
      */
-    public static function toFormValue($value)
+    public static function toFormValues($name, $value)
     {
-        if ($value instanceof \SplFileObject) {
-            return $value->getRealPath();
+        if (is_array($value) || is_object($value)) {
+            $query = http_build_query([$name => $value]);
+            $params = explode("&", $query);
+            $result = [];
+            foreach ($params as $param) {
+                $kv = explode("=", $param);
+                $result[urldecode($kv[0])] = urldecode($kv[1]);
+            }
+            return $result;
         } else {
-            return self::toString($value);
+            return [$name => self::toString($value)];
         }
     }
 

--- a/openapi-generator/templates/php/api.mustache
+++ b/openapi-generator/templates/php/api.mustache
@@ -533,7 +533,7 @@ use {{invokerPackage}}\ObjectSerializer;
         if (${{paramName}} !== null) {
             {{#isFile}}
             $multipart = true;
-            $formParams['{{baseName}}'] = \GuzzleHttp\Psr7\Utils::tryFopen(ObjectSerializer::toFormValue(${{paramName}}), 'rb');
+            $formParams['{{baseName}}'] = \GuzzleHttp\Psr7\Utils::tryFopen(${{paramName}}->getRealPath(), 'rb');
             {{/isFile}}
             {{^isFile}}
             $this->formParamsAppend($formParams, '{{baseName}}', ${{paramName}});
@@ -670,15 +670,10 @@ use {{invokerPackage}}\ObjectSerializer;
      */
     protected function formParamsAppend(&$formParams, $name, $value)
     {
-        if (is_object($value)) {
-            foreach ((array) $value as $k => $v) {
-                $formParams[$name.'['.$k.']'] = ObjectSerializer::toFormValue($v);
-            }
-
-            return;
+        $formValues = ObjectSerializer::toFormValues($name, $value);
+        foreach ($formValues as $k => $v) {
+            $formParams[$k] = $v;
         }
-
-        $formParams[$name] = ObjectSerializer::toFormValue($value);
     }
 }
 {{/operations}}


### PR DESCRIPTION
Related to https://github.com/phrase/openapi/pull/130

This PR adds better support for serializing form parameters (e.g. when uploading file through API):
* passing in arrays and objects
* support nested structures