### PR TITLE
feat(API): autotranslate param in key creation [STRINGS-786]

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -21257,6 +21257,11 @@
                     "type": "string",
                     "example": "Default translation content"
                   },
+                  "autotranslate": {
+                    "description": "Indicates whether the key should be autotranslated to other locales based on the copy provided in `default_translation_content`.",
+                    "type": "boolean",
+                    "example": null
+                  },
                   "xml_space_preserve": {
                     "description": "Indicates whether the key should be exported with \"xml:space=preserve\". Supported by several XML-based formats.",
                     "type": "boolean",

--- a/paths/keys/create.yaml
+++ b/paths/keys/create.yaml
@@ -109,6 +109,10 @@ requestBody:
             description: Creates a translation in the default locale with the specified content
             type: string
             example: Default translation content
+          autotranslate:
+            description: Indicates whether the key should be autotranslated to other locales based on the copy provided in `default_translation_content`.
+            type: boolean
+            example:
           xml_space_preserve:
             description: Indicates whether the key should be exported with "xml:space=preserve". Supported by several XML-based formats.
             type: boolean


### PR DESCRIPTION
Seems that this parameter was undocumented.

https://memsource.slack.com/archives/C02QV9K8EP5/p1731599023473799
- https://phrase.atlassian.net/browse/STRINGS-786