### PR TITLE
fix(CLI): crash when target/params section is empty #STRINGS-921

### DIFF
--- a/clients/cli/cmd/internal/pull.go
+++ b/clients/cli/cmd/internal/pull.go
@@ -68,7 +68,7 @@ func (cmd *PullCommand) Run(config *phrase.Config) error {
 			target.Params.Branch = optional.NewString(cmd.Branch)
 		}
 
-		val, ok := localesCache[LocalesCacheKey{target.ProjectID, target.Params.Branch.Value()}]
+		val, ok := localesCache[LocalesCacheKey{target.ProjectID, target.GetBranch()}]
 		if !ok || len(val) == 0 {
 			if cmd.Branch != "" {
 				continue

--- a/clients/cli/cmd/internal/pull_target.go
+++ b/clients/cli/cmd/internal/pull_target.go
@@ -18,7 +18,7 @@ type Targets []*Target
 func (targets Targets) GetAllLocalesCacheKeys() []LocalesCacheKey {
 	localesCacheKeys := []LocalesCacheKey{}
 	for _, target := range targets {
-		localesCacheKeys = append(localesCacheKeys, LocalesCacheKey{target.ProjectID, target.Params.Branch.Value()})
+		localesCacheKeys = append(localesCacheKeys, LocalesCacheKey{target.ProjectID, target.GetBranch()})
 	}
 	return localesCacheKeys
 }
@@ -30,6 +30,13 @@ type Target struct {
 	FileFormat    string      `json:"file_format"`
 	Params        *PullParams `json:"params" mapstructure:"omittable-nested,omitempty"`
 	RemoteLocales []*phrase.Locale
+}
+
+func (target *Target) GetBranch() string {
+	if target.Params != nil {
+		return target.Params.Branch.Value()
+	}
+	return ""
 }
 
 func (target *Target) CheckPreconditions() error {


### PR DESCRIPTION
addresses https://github.com/phrase/phrase-cli/issues/157