### PR TITLE
chore(cli): skip directories in CLI release

### DIFF
--- a/clients/cli/build/release.sh
+++ b/clients/cli/build/release.sh
@@ -56,10 +56,12 @@ fi
 # Upload artifacts
 DIST_DIR="./dist"
 for file in "$DIST_DIR"/*; do
-  echo "Uploading ${file}"
-  asset="https://uploads.github.com/repos/phrase/phrase-cli/releases/${release_id}/assets?name=$(basename "$file")"
-  curl -sS --data-binary @"$file" -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/octet-stream" $asset > /dev/null
-  echo Hash: $(sha256sum $file)
+  if [ -f "$file" ]; then
+    echo "Uploading ${file}"
+    asset="https://uploads.github.com/repos/phrase/phrase-cli/releases/${release_id}/assets?name=$(basename "$file")"
+    curl -sS --data-binary @"$file" -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/octet-stream" $asset > /dev/null
+    echo Hash: $(sha256sum $file)
+  fi
 done
 
 echo "Publishing release"


### PR DESCRIPTION
Since the latest release cURL no longer seems to skip uploads of directories and raises an error instead.

Previous log output:

```
Uploading ./dist/linux
sha256sum: ./dist/linux: Is a directory
```

Latest cURL in the release image:
```
Uploading ./dist/linux
curl: option --data-binary: error encountered when reading a file
```