### PR TITLE
fix(API): Match repo_sync events to the correct response

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -4337,7 +4337,7 @@
           "id": {
             "type": "string"
           },
-          "event_type": {
+          "type": {
             "type": "string",
             "enum": [
               "import",
@@ -4380,7 +4380,7 @@
           }
         },
         "example": {
-          "event_type": "import",
+          "type": "import",
           "created_at": "2015-01-28T09:52:53Z",
           "status": "failure",
           "auto_import": true,
@@ -22071,7 +22071,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase repo_sync_event show \\\n--id <id> \\\n--repo_sync_id <repo_sync_id> \\\n--account_id abcd1234 \\\n--access_token <token>"
+            "source": "phrase repo_syncs show \\\n--id <id> \\\n--repo_sync_id <repo_sync_id> \\\n--account_id abcd1234 \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.24"

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -22014,7 +22014,7 @@
       "get": {
         "summary": "Get a single Repo Sync Event",
         "description": "Shows a single Repo Sync event.",
-        "operationId": "repo_sync_event/show",
+        "operationId": "repo_sync/events_show",
         "tags": [
           "Repo Syncs"
         ],

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -21739,7 +21739,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase repo_sync list \\\n--account_id abcd1234 \\\n--access_token <token>"
+            "source": "phrase repo_syncs list \\\n--account_id abcd1234 \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.24"
@@ -21803,7 +21803,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase repo_sync show \\\n--id <id> \\\n--account_id abcd1234 \\\n--access_token <token>"
+            "source": "phrase repo_syncs show \\\n--id <id> \\\n--account_id abcd1234 \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.24"
@@ -21867,7 +21867,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase repo_sync export \\\n--id <repo_sync_id> \\\n--access_token <token>"
+            "source": "phrase repo_syncs export \\\n--id <repo_sync_id> \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.24"
@@ -21931,7 +21931,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase repo_sync import \\\n--id <repo_sync_id> \\\n--access_token <token>"
+            "source": "phrase repo_syncs import \\\n--id <repo_sync_id> \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.24"
@@ -22004,7 +22004,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase repo_sync events \\\n--id <id> \\\n--account_id abcd1234 \\\n--access_token <token>"
+            "source": "phrase repo_syncs events \\\n--id <id> \\\n--account_id abcd1234 \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.24"
@@ -22135,7 +22135,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase repo_sync deactivate \\\n--id <repo_sync_id> \\\n--access_token <token>"
+            "source": "phrase repo_syncs deactivate \\\n--id <repo_sync_id> \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.24"
@@ -22199,7 +22199,7 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase repo_sync activate \\\n--id <repo_sync_id> \\\n--access_token <token>"
+            "source": "phrase repo_syncs activate \\\n--id <repo_sync_id> \\\n--access_token <token>"
           }
         ],
         "x-cli-version": "2.24"

--- a/paths/repo_sync_events/index.yaml
+++ b/paths/repo_sync_events/index.yaml
@@ -42,7 +42,7 @@ x-code-samples:
       -u USERNAME_OR_ACCESS_TOKEN
 - lang: CLI v2
   source: |-
-    phrase repo_sync events \
+    phrase repo_syncs events \
     --id <id> \
     --account_id abcd1234 \
     --access_token <token>

--- a/paths/repo_sync_events/show.yaml
+++ b/paths/repo_sync_events/show.yaml
@@ -1,7 +1,7 @@
 ---
 summary: Get a single Repo Sync Event
 description: Shows a single Repo Sync event.
-operationId: repo_sync_event/show
+operationId: repo_sync/events_show
 tags:
 - Repo Syncs
 parameters:
@@ -36,7 +36,7 @@ x-code-samples:
       -u USERNAME_OR_ACCESS_TOKEN
 - lang: CLI v2
   source: |-
-    phrase repo_syncs show \
+    phrase repo_syncs events_show \
     --id <id> \
     --repo_sync_id <repo_sync_id> \
     --account_id abcd1234 \

--- a/paths/repo_sync_events/show.yaml
+++ b/paths/repo_sync_events/show.yaml
@@ -36,7 +36,7 @@ x-code-samples:
       -u USERNAME_OR_ACCESS_TOKEN
 - lang: CLI v2
   source: |-
-    phrase repo_sync_event show \
+    phrase repo_syncs show \
     --id <id> \
     --repo_sync_id <repo_sync_id> \
     --account_id abcd1234 \

--- a/paths/repo_syncs/activate.yaml
+++ b/paths/repo_syncs/activate.yaml
@@ -39,7 +39,7 @@ x-code-samples:
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
-    phrase repo_sync activate \
+    phrase repo_syncs activate \
     --id <repo_sync_id> \
     --access_token <token>
 x-cli-version: '2.24'

--- a/paths/repo_syncs/deactivate.yaml
+++ b/paths/repo_syncs/deactivate.yaml
@@ -39,7 +39,7 @@ x-code-samples:
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
-    phrase repo_sync deactivate \
+    phrase repo_syncs deactivate \
     --id <repo_sync_id> \
     --access_token <token>
 x-cli-version: '2.24'

--- a/paths/repo_syncs/export.yaml
+++ b/paths/repo_syncs/export.yaml
@@ -41,7 +41,7 @@ x-code-samples:
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
-    phrase repo_sync export \
+    phrase repo_syncs export \
     --id <repo_sync_id> \
     --access_token <token>
 x-cli-version: '2.24'

--- a/paths/repo_syncs/import.yaml
+++ b/paths/repo_syncs/import.yaml
@@ -41,7 +41,7 @@ x-code-samples:
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-
-    phrase repo_sync import \
+    phrase repo_syncs import \
     --id <repo_sync_id> \
     --access_token <token>
 x-cli-version: '2.24'

--- a/paths/repo_syncs/index.yaml
+++ b/paths/repo_syncs/index.yaml
@@ -40,7 +40,7 @@ x-code-samples:
       -u USERNAME_OR_ACCESS_TOKEN
 - lang: CLI v2
   source: |-
-    phrase repo_sync list \
+    phrase repo_syncs list \
     --account_id abcd1234 \
     --access_token <token>
 x-cli-version: '2.24'

--- a/paths/repo_syncs/show.yaml
+++ b/paths/repo_syncs/show.yaml
@@ -35,7 +35,7 @@ x-code-samples:
       -u USERNAME_OR_ACCESS_TOKEN
 - lang: CLI v2
   source: |-
-    phrase repo_sync show \
+    phrase repo_syncs show \
     --id <id> \
     --account_id abcd1234 \
     --access_token <token>

--- a/schemas/repo_sync_event.yaml
+++ b/schemas/repo_sync_event.yaml
@@ -5,7 +5,7 @@ repo_sync_event:
   properties:
     id:
       type: string
-    event_type:
+    type:
       type: string
       enum: [import, export]
     created_at:
@@ -28,7 +28,7 @@ repo_sync_event:
         - type: string
         - type: object
   example:
-    event_type: import
+    type: import
     created_at: '2015-01-28T09:52:53Z'
     status: failure
     auto_import: true


### PR DESCRIPTION
We use `phrase-cli` in our CI/CD pipeline to automate merges to our repositories. However, the recent changes introduced in #735 have broken our process.  
While upgrading our pipeline to use `repo_sync`, I encountered the following issues with `phrase-cli`:  


### Issues Description 

---

#### **Missing `event_type` and `pull_request_url`**  
- The `phrase-cli` does not provide the `event_type` of the sync event or the `pull_request_url`. These details are critical for avoiding multiple merge requests in our CI/CD.  
- The API returns `type` instead of `event_type`, which caused discrepancies in the schemas. I’ve updated the schemas in this PR to match the API response.  

##### Reproduction  
Example with `phrase-cli`:  
```bash
$ phrase repo_syncs show --id $SYNC_EVENT_ID --repo_sync_id $GITLAB_SYNC_ID --account_id $ACCOUNT_ID
{
  "id": "<REDACTED>",
  "created_at": "2024-12-19T17:35:52Z",
  "status": "success",
  "auto_import": false
}
```

Example with curl (fetching type but missing pull_request_url):

```bash
 curl -X GET "https://api.phrase.com/v2/accounts/ $ACCOUNT_ID/repo_syncs/$GITLAB_SYNC_ID/events/$SYNC_EVENT_ID?access_token=$PHRASE_ACCESS_TOKEN"  -H "Accept: application/json"
{
     "id": "<REDACTED>",
     "type":"export",
     "created_at":"2024-12-19T17:35:52Z",
     "status":"success",
     "auto_import":false
}
```

I’ve updated the schemas in this PR to match the API response.

--- 

#### **Command Parsing conflicts:**:

- When parsing the commands in [api_repo_syncs.go#L169](https://github.com/phrase/phrase-cli/blob/master/cmd/api_repo_syncs.go#L169) and [api_repo_syncs.go#L499](https://github.com/phrase/phrase-cli/blob/master/cmd/api_repo_syncs.go#L499), a conflict arises as shown in (this snippet)[https://go.dev/play/p/DoeBHQOf-oI]

- For instance, the output of the help command demonstrates duplicate show commands:
```bash
> $ phrase repo_syncs --help                                                                                 ⬡ 20.12.1
RepoSyncs API

Usage:
  phrase repo_syncs [command]

Available Commands:
  activate    Activate a Repo Sync
  deactivate  Deactivate a Repo Sync
  events      Repository Syncs History
  export      Export to code repository
  import      Import from code repository
  list        Get Repo Syncs
  show        Get a single Repo Sync Event <----- TWO SHOW COMMAND
  show        Get a single Repo Sync <----- TWO SHOW COMMAND

```

I changed the `operationId` to be `repo_sync/events_show` so it will create a new command `events_show` avoiding the conflict 

---

### Extra fixes:

**Documentation Discrepancy:**
Some API references use repo_sync where they should use repo_syncs.

The API documentation for [Get a Single Repo Sync Event](https://developers.phrase.com/api/#get-/accounts/-account_id-/repo_syncs/-repo_sync_id-/events/-id-) incorrectly references the command as repo_sync_event. So I  took the opportunity to correct this in the documentation.



### Request for Additional Fix

API does not return the `pull_request_url`. This seems to be in a private repository. It would be great if this could be addressed as it’s essential for our CI/CD workflow.


