### PR TITLE
fix(API): Repo Sync Event errors field type #STRINGS-1074

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -152,6 +152,9 @@
       "description": "The Repo Syncs API allows you to synchronize your Phrase projects with your code repositories.\nYou can import translations from your repository to Phrase and export translations from Phrase to your repository.\n"
     },
     {
+      "name": "Repo Sync Events"
+    },
+    {
       "name": "Reports"
     },
     {

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -4368,14 +4368,7 @@
             "description": "List of error messages, in case of failure",
             "type": "array",
             "items": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "object"
-                }
-              ]
+              "type": "string"
             }
           }
         },
@@ -4385,8 +4378,8 @@
           "status": "failure",
           "auto_import": true,
           "errors": [
-            "Error message",
-            "Error message"
+            "Error message 1",
+            "Error message 2"
           ]
         }
       }

--- a/main.yaml
+++ b/main.yaml
@@ -199,6 +199,7 @@ tags:
     description: |
       The Repo Syncs API allows you to synchronize your Phrase projects with your code repositories.
       You can import translations from your repository to Phrase and export translations from Phrase to your repository.
+  - name: Repo Sync Events
   - name: Reports
   - name: Search
   - name: Screenshot Markers

--- a/schemas/repo_sync_event.yaml
+++ b/schemas/repo_sync_event.yaml
@@ -24,14 +24,12 @@ repo_sync_event:
       description: List of error messages, in case of failure
       type: array
       items:
-        anyOf:
-        - type: string
-        - type: object
+        type: string
   example:
     type: import
     created_at: '2015-01-28T09:52:53Z'
     status: failure
     auto_import: true
     errors:
-      - "Error message"
-      - "Error message"
+      - "Error message 1"
+      - "Error message 2"


### PR DESCRIPTION
unfortunately, it seems that `anyOf` is not handled properly by our client builders.

```
ERROR: json: cannot unmarshal string into Go struct field RepoSyncEvent.errors of type phrase.RepoSyncEventErrorsInner
```

so, I simplified this part of schema to always expect just an array of strings. We'll make sure that the server also always sends simple strings.