### PR TITLE
fix(cli): CLI do not exit with 0 on pull when branch does not exist

### DIFF
--- a/clients/cli/cmd/internal/pull.go
+++ b/clients/cli/cmd/internal/pull.go
@@ -71,7 +71,7 @@ func (cmd *PullCommand) Run(config *phrase.Config) error {
 		val, ok := localesCache[LocalesCacheKey{target.ProjectID, target.GetBranch()}]
 		if !ok || len(val) == 0 {
 			if cmd.Branch != "" {
-				continue
+				return fmt.Errorf("Branch '%s' does not exist in project '%s'", cmd.Branch, target.ProjectID)
 			}
 			return fmt.Errorf("Could not find any locales for project %q", target.ProjectID)
 		}

--- a/clients/cli/go.mod
+++ b/clients/cli/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/daviddengcn/go-colortext v1.0.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/phrase/phrase-go/v4 v4.0.5 // x-release-please-version
+	github.com/phrase/phrase-go/v4 v4.1.0 // x-release-please-version
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	gopkg.in/yaml.v2 v2.4.0


### PR DESCRIPTION
- When using `pull` command with branch param and the requested branch does not exist, answer with exit-code `1` instead of `0`. 
- Also adds an error message

### Issue
- https://github.com/phrase/phrase-cli/issues/155

### See Screenshot
![image](https://github.com/user-attachments/assets/797dbd26-a989-4db1-86a5-b41d12e1e8d5)
