### PR TITLE
fix(API): pass translation_key_ids when removing keys from job

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -11322,7 +11322,7 @@
                 "type": "object",
                 "title": "job/keys/delete/parameters",
                 "required": [
-                  "name"
+                  "translation_key_ids"
                 ],
                 "properties": {
                   "branch": {

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -11288,29 +11288,6 @@
           },
           {
             "$ref": "#/components/parameters/id"
-          },
-          {
-            "description": "specify the branch to use",
-            "example": "my-feature-branch",
-            "name": "branch",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "ids of keys that should be removed from the job",
-            "example": [
-              "abcd1234cdef1234abcd1234cdef1234"
-            ],
-            "name": "translation_key_ids",
-            "in": "query",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
           }
         ],
         "responses": {
@@ -11334,10 +11311,40 @@
           },
           {
             "lang": "CLI v2",
-            "source": "phrase jobs keys_delete \\\n--project_id <project_id> \\\n--id <id> \\\n--branch my-feature-branch \\\n--translation_key_ids \"abcd1234cdef1234abcd1234cdef1234\" \\\n--access_token <token>"
+            "source": "phrase jobs keys_delete \\\n--project_id <project_id> \\\n--id <id> \\\n--branch my-feature-branch \\\n--data '{\"branch\": \"my-feature-branch\", \"translation_key_ids\": [\"abcd1234cdef1234abcd1234cdef1234\"]}' \\\n--access_token <token>"
           }
         ],
-        "x-cli-version": "2.5"
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "title": "job/keys/delete/parameters",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "branch": {
+                    "description": "specify the branch to use",
+                    "type": "string",
+                    "example": "my-feature-branch"
+                  },
+                  "translation_key_ids": {
+                    "description": "ids of keys that should be deleted from the job",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "abcd1234cdef1234abcd1234cdef1234"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/projects/{project_id}/job_templates": {

--- a/paths/jobs/remove_keys.yaml
+++ b/paths/jobs/remove_keys.yaml
@@ -41,7 +41,7 @@ requestBody:
         type: object
         title: job/keys/delete/parameters
         required:
-          - name
+          - translation_key_ids
         properties:
           branch:
             description: specify the branch to use

--- a/paths/jobs/remove_keys.yaml
+++ b/paths/jobs/remove_keys.yaml
@@ -8,21 +8,6 @@ parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/project_id"
 - "$ref": "../../parameters.yaml#/id"
-- description: specify the branch to use
-  example: my-feature-branch
-  name: branch
-  in: query
-  schema:
-    type: string
-- description: ids of keys that should be removed from the job
-  example:
-  - abcd1234cdef1234abcd1234cdef1234
-  name: translation_key_ids
-  in: query
-  schema:
-    type: array
-    items:
-      type: string
 responses:
   '204':
     "$ref": "../../responses.yaml#/204"
@@ -46,6 +31,26 @@ x-code-samples:
     --project_id <project_id> \
     --id <id> \
     --branch my-feature-branch \
-    --translation_key_ids "abcd1234cdef1234abcd1234cdef1234" \
+    --data '{"branch": "my-feature-branch", "translation_key_ids": ["abcd1234cdef1234abcd1234cdef1234"]}' \
     --access_token <token>
-x-cli-version: '2.5'
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        title: job/keys/delete/parameters
+        required:
+          - name
+        properties:
+          branch:
+            description: specify the branch to use
+            type: string
+            example: my-feature-branch
+          translation_key_ids:
+            description: ids of keys that should be deleted from the job
+            type: array
+            items:
+              type: string
+            example:
+            - abcd1234cdef1234abcd1234cdef1234


### PR DESCRIPTION
Fix passing the `translation_key_ids` as arrays in query params are not properly supported by the generated client and move the param to the body. Also move the branch param to the request body to align it with keys_create`

https://github.com/phrase/phrase-cli/issues/158