### PR TITLE
feat(API): Adjust job_template_locale properties

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -3505,7 +3505,9 @@
         "title": "job_template_locale",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "nullable": true,
+            "description": "The ID of the job template locale. Will return `null` if the related `job_template` is global."
           },
           "job_template": {
             "type": "object",

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -1472,6 +1472,28 @@
           "code": "en-GB"
         }
       },
+      "locale_preview_global": {
+        "type": "object",
+        "title": "locale_preview_global",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true,
+            "description": "The ID of the locale. Global Job Templates will return `null` here."
+          },
+          "name": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "id": "abcd1234cdef1234abcd1234cdef1234",
+          "name": "English",
+          "code": "en-GB"
+        }
+      },
       "locale": {
         "type": "object",
         "title": "locale",
@@ -3523,7 +3545,7 @@
             "example": null
           },
           "locale": {
-            "$ref": "#/components/schemas/locale_preview"
+            "$ref": "#/components/schemas/locale_preview_global"
           },
           "users": {
             "type": "array",

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -3527,9 +3527,7 @@
         "title": "job_template_locale",
         "properties": {
           "id": {
-            "type": "string",
-            "nullable": true,
-            "description": "The ID of the job template locale. Will return `null` if the related `job_template` is global."
+            "type": "string"
           },
           "job_template": {
             "type": "object",

--- a/schemas.yaml
+++ b/schemas.yaml
@@ -44,6 +44,8 @@ schemas:
     "$ref": schemas/project_report.yaml#/project_report
   locale_preview:
     "$ref": schemas/locale_preview.yaml#/locale_preview
+  locale_preview_global:
+    "$ref": schemas/locale_preview_global.yaml#/locale_preview_global    
   locale:
     "$ref": schemas/locale.yaml#/locale
   locale_download:

--- a/schemas/job_template_locale.yaml
+++ b/schemas/job_template_locale.yaml
@@ -5,6 +5,8 @@ job_template_locale:
   properties:
     id:
       type: string
+      nullable: true
+      description: The ID of the job template locale. Will return `null` if the related `job_template` is global.
     job_template:
       "$ref": "./job_template_preview.yaml#/job_template_preview"
     locale:

--- a/schemas/job_template_locale.yaml
+++ b/schemas/job_template_locale.yaml
@@ -10,7 +10,7 @@ job_template_locale:
     job_template:
       "$ref": "./job_template_preview.yaml#/job_template_preview"
     locale:
-      "$ref": "./locale_preview.yaml#/locale_preview"
+      "$ref": "./locale_preview_global.yaml#/locale_preview_global"
     users:
       type: array
       items:

--- a/schemas/job_template_locale.yaml
+++ b/schemas/job_template_locale.yaml
@@ -5,8 +5,6 @@ job_template_locale:
   properties:
     id:
       type: string
-      nullable: true
-      description: The ID of the job template locale. Will return `null` if the related `job_template` is global.
     job_template:
       "$ref": "./job_template_preview.yaml#/job_template_preview"
     locale:

--- a/schemas/locale_preview_global.yaml
+++ b/schemas/locale_preview_global.yaml
@@ -1,0 +1,17 @@
+---
+locale_preview_global:
+  type: object
+  title: locale_preview_global
+  properties:
+    id:
+      type: string
+      nullable: true
+      description: The ID of the locale. Global Job Templates will return `null` here.
+    name:
+      type: string
+    code:
+      type: string
+  example:
+    id: abcd1234cdef1234abcd1234cdef1234
+    name: English
+    code: en-GB


### PR DESCRIPTION
Global job templates are not tied to a specific locale, so the locale `id` in the `job_template_locale` response can be `null`. Rather than modifying the existing `locale_preview` schema, this adds a new `locale_preview_global` schema with a nullable `id` field and uses it for the `locale` property in `job_template_locale`.


See:
- https://github.com/phrase/phrase/pull/14638
- https://phrase.atlassian.net/browse/STRINGS-1270