### PR TITLE
feat(API): document tags attribute of an upload #STRINGS-1221

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -1758,7 +1758,15 @@
             "type": "string"
           },
           "tag": {
-            "type": "string"
+            "type": "string",
+            "description": "Unique tag of the upload\n"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of tags that were assigned to the uploaded keys\n"
           },
           "url": {
             "type": "string",

--- a/schemas/upload.yaml
+++ b/schemas/upload.yaml
@@ -13,6 +13,14 @@ upload:
       type: string
     tag:
       type: string
+      description: |
+        Unique tag of the upload
+    tags:
+      type: array
+      items:
+        type: string
+      description: |
+        List of tags that were assigned to the uploaded keys
     url:
       type: string
       description: |


### PR DESCRIPTION
Attribute `tags` of an Upload resource was previously undocumented. Also, added some description to show the difference between `tag` and `tags`. 

https://phrase.atlassian.net/browse/STRINGS-1221