### PR TITLE
feat(CLI): Do not save token to config file by default #STRINGS-999

### DIFF
--- a/clients/cli/cmd/internal/init.go
+++ b/clients/cli/cmd/internal/init.go
@@ -143,9 +143,9 @@ func (cmd *InitCommand) askForToken() error {
 }
 
 func (cmd *InitCommand) setToken(token string) {
-	pushNow := ""
-	_ = prompt.WithDefault("Do you want to save the token to the config file? Otherwise you will have to provide it every time you run the command either through a command argument or through an environment variable (y/n)", &pushNow, "n")
-	if pushNow == "y" {
+	saveTokenToConfig := ""
+	_ = prompt.WithDefault("Do you want to save the token to the config file? Otherwise you will have to provide it every time you run the command either through a command argument or through an environment variable (y/n)", &saveTokenToConfig, "n")
+	if saveTokenToConfig == "y" {
 		cmd.YAML.AccessToken = token
 	}
 	cmd.Credentials.Token = token

--- a/clients/cli/cmd/internal/init.go
+++ b/clients/cli/cmd/internal/init.go
@@ -144,8 +144,8 @@ func (cmd *InitCommand) askForToken() error {
 
 func (cmd *InitCommand) setToken(token string) {
 	saveTokenToConfig := ""
-	_ = prompt.WithDefault("Do you want to save the token to the config file? Otherwise you will have to provide it every time you run the command either through a command argument or through an environment variable (y/n)", &saveTokenToConfig, "n")
-	if saveTokenToConfig == "y" {
+	_ = prompt.WithDefault("You can choose to save the token to the configuration file. Otherwise you will have to provide it every time you run the command either through a command argument (\"phrase -t YOUR_TOKEN\") or through an environment variable (PHRASE_ACCESS_TOKEN=\"YOUR_TOKEN\").\nDo you want to save the token to the config file? (y/n)", &saveTokenToConfig, "n")
+	if trimAndLower(saveTokenToConfig) == "y" {
 		cmd.YAML.AccessToken = token
 	}
 	cmd.Credentials.Token = token
@@ -389,7 +389,7 @@ func (cmd *InitCommand) writeConfig() error {
 
 	pushNow := ""
 	_ = prompt.WithDefault("Do you want to upload your locales now for the first time? (y/n)", &pushNow, "y")
-	if pushNow == "y" {
+	if trimAndLower(pushNow) == "y" {
 		err = firstPush()
 		if err != nil {
 			return err
@@ -409,4 +409,8 @@ func firstPush() error {
 	}
 	cmd := &PushCommand{Config: *config}
 	return cmd.Run()
+}
+
+func trimAndLower(s string) string {
+	return strings.TrimSpace(strings.ToLower(s))
 }

--- a/clients/cli/cmd/internal/init.go
+++ b/clients/cli/cmd/internal/init.go
@@ -143,7 +143,11 @@ func (cmd *InitCommand) askForToken() error {
 }
 
 func (cmd *InitCommand) setToken(token string) {
-	cmd.YAML.AccessToken = token
+	pushNow := ""
+	_ = prompt.WithDefault("Do you want to save the token to the config file? Otherwise you will have to provide it every time you run the command either through a command argument or through an environment variable (y/n)", &pushNow, "n")
+	if pushNow == "y" {
+		cmd.YAML.AccessToken = token
+	}
 	cmd.Credentials.Token = token
 	Config = &cmd.Config
 	client := newClient()


### PR DESCRIPTION
When running `phrase init`, we should not save the token to the configuration file by default, as that's not safe from security perspective (tokens should not be committed to the repository).

Instead, we ask the user explicitly if they want to save it, otherwise we don't.

Addresses https://github.com/phrase/phrase-cli/issues/18