### PR TITLE
feat(PHP): Address PHP 8.4 deprecations #STRINGS-1764

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -11,12 +11,12 @@ jobs:
           npm run generate.php
       - uses: php-actions/composer@v6
         with:
-          php_version: '7.4'
+          php_version: '8.3'
           working_dir: ./clients/php
       - uses: php-actions/phpunit@v3
         with:
-          php_version: '7.4'
-          version: '7.4'
+          php_version: '8.3'
+          version: '8.3'
           configuration: ./clients/php/phpunit.xml.dist
       - name: License check
         uses: phrase/actions/lawa-ci@v1

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: php-actions/phpunit@v3
         with:
           php_version: '8.3'
-          version: '8.3'
+          version: '12.1'
           configuration: ./clients/php/phpunit.xml.dist
       - name: License check
         uses: phrase/actions/lawa-ci@v1

--- a/clients/php/test/Api/KeysApiTest.php
+++ b/clients/php/test/Api/KeysApiTest.php
@@ -54,16 +54,9 @@ class KeysApiTest extends TestCase
     private $history = [];
 
     /**
-     * Setup before running any test cases
-     */
-    public static function setUpBeforeClass()
-    {
-    }
-
-    /**
      * Setup before running each test case
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->mock = new MockHandler();
         $history = Middleware::history($this->history);
@@ -75,20 +68,6 @@ class KeysApiTest extends TestCase
         $config = Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'token');
 
         $this->apiInstance = new Api($client, $config);
-    }
-
-    /**
-     * Clean up after running each test case
-     */
-    public function tearDown()
-    {
-    }
-
-    /**
-     * Clean up after running all test cases
-     */
-    public static function tearDownAfterClass()
-    {
     }
 
     /**

--- a/clients/php/test/Api/LocalesApiTest.php
+++ b/clients/php/test/Api/LocalesApiTest.php
@@ -55,16 +55,9 @@ class LocalesApiTest extends TestCase
     private $history = [];
 
     /**
-     * Setup before running any test cases
-     */
-    public static function setUpBeforeClass()
-    {
-    }
-
-    /**
      * Setup before running each test case
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->mock = new MockHandler();
         $history = Middleware::history($this->history);
@@ -76,20 +69,6 @@ class LocalesApiTest extends TestCase
         $config = Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'token');
 
         $this->apiInstance = new Api($client, $config);
-    }
-
-    /**
-     * Clean up after running each test case
-     */
-    public function tearDown()
-    {
-    }
-
-    /**
-     * Clean up after running all test cases
-     */
-    public static function tearDownAfterClass()
-    {
     }
 
     /**
@@ -169,7 +148,7 @@ class LocalesApiTest extends TestCase
             null,
             $custom_metadata_filters
         );
-        
+
 
         $this->assertNotNull($result);
         $this->assertEquals('foo', $result);

--- a/clients/php/test/Api/UploadsApiTest.php
+++ b/clients/php/test/Api/UploadsApiTest.php
@@ -56,16 +56,9 @@ class UploadsApiTest extends TestCase
     private $history = [];
 
     /**
-     * Setup before running any test cases
-     */
-    public static function setUpBeforeClass()
-    {
-    }
-
-    /**
      * Setup before running each test case
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->mock = new MockHandler();
         $history = Middleware::history($this->history);
@@ -77,20 +70,6 @@ class UploadsApiTest extends TestCase
         $config = Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'token');
 
         $this->apiInstance = new Api($client, $config);
-    }
-
-    /**
-     * Clean up after running each test case
-     */
-    public function tearDown()
-    {
-    }
-
-    /**
-     * Clean up after running all test cases
-     */
-    public static function tearDownAfterClass()
-    {
     }
 
     /**
@@ -138,8 +117,8 @@ class UploadsApiTest extends TestCase
         $lastRequest = $this->history[count($this->history) - 1]['request'];
         $this->assertEquals('POST', $lastRequest->getMethod());
         $this->assertEquals('/v2/projects/'.$projectId.'/uploads', $lastRequest->getUri()->getPath());
-        $this->assertContains('multipart/form-data', $lastRequest->getHeader('Content-Type')[0]);
-        $this->assertContains("Content-Disposition: form-data; name=\"locale_mapping[en][bar]\"\r\nContent-Length: 3\r\n\r\nbaz\r\n", $lastRequest->getBody()->getContents());
+        $this->assertStringContainsString('multipart/form-data', $lastRequest->getHeader('Content-Type')[0]);
+        $this->assertStringContainsString("Content-Disposition: form-data; name=\"locale_mapping[en][bar]\"\r\nContent-Length: 3\r\n\r\nbaz\r\n", $lastRequest->getBody()->getContents());
     }
 
     /**

--- a/openapi-generator/templates/php/api.mustache
+++ b/openapi-generator/templates/php/api.mustache
@@ -66,9 +66,9 @@ use {{invokerPackage}}\ObjectSerializer;
      * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null,
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null,
         $host_index = 0
     ) {
         $this->client = $client ?: new Client();

--- a/openapi-generator/templates/php/api_test.mustache
+++ b/openapi-generator/templates/php/api_test.mustache
@@ -37,28 +37,28 @@ use PHPUnit\Framework\TestCase;
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp()
+    public function setUp(): void
     {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
     }
     {{#operation}}

--- a/openapi-generator/templates/php/composer.mustache
+++ b/openapi-generator/templates/php/composer.mustache
@@ -27,10 +27,10 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^7.3"
+        "guzzlehttp/guzzle": "^7.9"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.4",
+        "phpunit/phpunit": "^12.1",
         "squizlabs/php_codesniffer": "~2.6",
         "friendsofphp/php-cs-fixer": "~2.12"
     },

--- a/openapi-generator/templates/php/model_generic.mustache
+++ b/openapi-generator/templates/php/model_generic.mustache
@@ -154,7 +154,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         {{#parentSchema}}
         parent::__construct($data);

--- a/openapi-generator/templates/php/model_test.mustache
+++ b/openapi-generator/templates/php/model_test.mustache
@@ -38,28 +38,28 @@ class {{classname}}Test extends TestCase
     /**
      * Setup before running any test case
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp()
+    public function setUp(): void
     {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
     }
 


### PR DESCRIPTION
PHP 8.4 deprecated some language features which results with some warnings, both from our code and some dependencies. This PR addresses this and bumps PHP, and phpunit and guzzlehttp libraries.

https://github.com/phrase/phrase-php/issues/4