### PR TITLE
feat(API): Add processed & upload total translations on upload summary

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -1808,6 +1808,12 @@
               },
               "translation_keys_ignored": {
                 "type": "integer"
+              },
+              "processed_translations": {
+                "type": "integer"
+              },
+              "upload_total_translations": {
+                "type": "integer"
               }
             }
           },

--- a/schemas/upload.yaml
+++ b/schemas/upload.yaml
@@ -44,6 +44,10 @@ upload:
           type: integer
         translation_keys_ignored:
           type: integer
+        processed_translations:
+          type: integer
+        upload_total_translations:
+          type: integer
     created_at:
       type: string
       format: date-time


### PR DESCRIPTION
Add `processed_translations` and `upload_total_translations` to `upload.summary` schema

![image](https://github.com/user-attachments/assets/257c8996-7712-40c3-ab6e-bfe03c60cf16)

- https://phrase.atlassian.net/browse/STRINGS-1976