### PR TITLE
feat(API): Add use_ordinal_rules boolean [STRINGS-2273]

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -1488,6 +1488,12 @@
               "type": "string"
             }
           },
+          "ordinal_plural_forms": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "source_locale": {
             "$ref": "#/components/schemas/locale_preview"
           },
@@ -2242,7 +2248,8 @@
           "key": {
             "id": "abcd1234cdef1234abcd1234cdef1234",
             "name": "home.index.headline",
-            "plural": false
+            "plural": false,
+            "use_ordinal_rules": false
           },
           "locale": {
             "id": "abcd1234cdef1234abcd1234cdef1234",
@@ -2317,6 +2324,9 @@
             "type": "string"
           },
           "plural": {
+            "type": "boolean"
+          },
+          "use_ordinal_rules": {
             "type": "boolean"
           },
           "tags": {

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -1521,6 +1521,10 @@
             "one",
             "other"
           ],
+          "plural_ordinal_forms": [
+            "zero",
+            "other"
+          ],
           "source_locale": {
             "id": "abcd1234cdef1234abcd1234cdef1234",
             "name": "en",
@@ -2353,6 +2357,7 @@
           "description": "My description for this key...",
           "name_hash": "1b31d2580ce324f246f66b3be00ed399",
           "plural": false,
+          "use_ordinal_rules": false,
           "tags": [
             "awesome-feature",
             "needs-proofreading"

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -1521,7 +1521,7 @@
             "one",
             "other"
           ],
-          "plural_ordinal_forms": [
+          "ordinal_plural_forms": [
             "zero",
             "other"
           ],

--- a/schemas/locale.yaml
+++ b/schemas/locale.yaml
@@ -44,6 +44,9 @@ locale:
     - zero
     - one
     - other
+    plural_ordinal_forms:
+      - zero
+      - other
     source_locale:
       id: abcd1234cdef1234abcd1234cdef1234
       name: en

--- a/schemas/locale.yaml
+++ b/schemas/locale.yaml
@@ -44,7 +44,7 @@ locale:
     - zero
     - one
     - other
-    plural_ordinal_forms:
+    ordinal_plural_forms:
       - zero
       - other
     source_locale:

--- a/schemas/locale.yaml
+++ b/schemas/locale.yaml
@@ -19,6 +19,10 @@ locale:
       type: array
       items:
         type: string
+    ordinal_plural_forms:
+      type: array
+      items:
+        type: string
     source_locale:
       "$ref": "./locale_preview.yaml#/locale_preview"
     fallback_locale:

--- a/schemas/translation.yaml
+++ b/schemas/translation.yaml
@@ -40,6 +40,7 @@ translation:
       id: abcd1234cdef1234abcd1234cdef1234
       name: home.index.headline
       plural: false
+      use_ordinal_rules: false
     locale:
       id: abcd1234cdef1234abcd1234cdef1234
       name: de

--- a/schemas/translation_key.yaml
+++ b/schemas/translation_key.yaml
@@ -13,6 +13,8 @@ translation_key:
       type: string
     plural:
       type: boolean
+    use_ordinal_rules:
+      type: boolean
     tags:
       type: array
       items:

--- a/schemas/translation_key.yaml
+++ b/schemas/translation_key.yaml
@@ -33,6 +33,7 @@ translation_key:
     description: My description for this key...
     name_hash: 1b31d2580ce324f246f66b3be00ed399
     plural: false
+    use_ordinal_rules: false
     tags:
     - awesome-feature
     - needs-proofreading


### PR DESCRIPTION
`use_ordinal_rules` boolean is used to define whether is using ORDINAL or CARDINAL pluralization rules.

Add `ordinal_plural_forms` to locales endpoint.