### PR TITLE
chore(STRINGS-2428): Add workflow to automate Strings OpenAPI changes

### DIFF
--- a/.github/workflows/developer-hub.yml
+++ b/.github/workflows/developer-hub.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Send repository_dispatch to repo B
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           repository: phrase/developer-hub
           event-type: trigger-strings-workflow
           client-payload: '{"source": "phrase/openapi", "type": "update"}'

--- a/.github/workflows/developer-hub.yml
+++ b/.github/workflows/developer-hub.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Send repository_dispatch to repo B
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DISPATCH_DEVELOPER_HUB_TOKEN }}
           repository: phrase/developer-hub
           event-type: trigger-strings-workflow
           client-payload: '{"source": "phrase/openapi", "type": "update"}'

--- a/.github/workflows/developer-hub.yml
+++ b/.github/workflows/developer-hub.yml
@@ -4,13 +4,14 @@ on:
   push:
     branches:
       - main
+      - chore/add-dispatch-workflow
 
 jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
       - name: Send repository_dispatch to phrase/developer-hub
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@0eae9e597ebc81bcc8c2220e34ddff4bc7c769b3
         with:
           token: ${{ secrets.DISPATCH_DEVELOPER_HUB_TOKEN }}
           repository: phrase/developer-hub

--- a/.github/workflows/developer-hub.yml
+++ b/.github/workflows/developer-hub.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - chore/add-dispatch-workflow
 
 jobs:
   dispatch:

--- a/.github/workflows/developer-hub.yml
+++ b/.github/workflows/developer-hub.yml
@@ -13,5 +13,5 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           repository: phrase/developer-hub
-          event-type: trigger-workflow
+          event-type: trigger-strings-workflow
           client-payload: '{"source": "phrase/openapi", "type": "update"}'

--- a/.github/workflows/developer-hub.yml
+++ b/.github/workflows/developer-hub.yml
@@ -1,0 +1,17 @@
+name: Dispatch Developer Hub Workflow
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository_dispatch to repo B
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          repository: phrase/developer-hub
+          event-type: trigger-workflow
+          client-payload: '{"source": "phrase/openapi", "type": "update"}'

--- a/.github/workflows/developer-hub.yml
+++ b/.github/workflows/developer-hub.yml
@@ -9,7 +9,7 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - name: Send repository_dispatch to repo B
+      - name: Send repository_dispatch to phrase/developer-hub
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.DISPATCH_DEVELOPER_HUB_TOKEN }}

--- a/.github/workflows/developer-hub.yml
+++ b/.github/workflows/developer-hub.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - chore/add-dispatch-workflow
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/lawa.yml
+++ b/.github/workflows/lawa.yml
@@ -9,4 +9,4 @@ jobs:
       ruby-version: 3.1.3
       decisions-file: config/license-decisions.yml
     secrets:
-      github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+      github-token: ${{ secrets.GH_LAWA_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automatically notifies the `phrase/developer-hub` repository when changes are pushed to the main branch of `phrase/openapi`.

### How it works
- The workflow triggers on every push to main.
- It uses `repository_dispatch` to send a custom event (`trigger-strings-workflow`) to the `phrase/developer-hub` repository.
- The payload includes context about the source repository and event type:
```
{
  "source": "phrase/openapi",
  "type": "update"
}
```
- The event is then listened here: https://github.com/phrase/developer-hub/pull/9

### Related issue
- [STRINGS-2428: Set up GH Actions to automate OpenAPI specs updates](https://phrase.atlassian.net/browse/STRINGS-2428)