### PR TITLE
docs(go): API documentation fixes

### DIFF
--- a/openapi-generator/go_lang.yaml
+++ b/openapi-generator/go_lang.yaml
@@ -8,3 +8,4 @@ gitRepoId: phrase-go
 httpUserAgent: Phrase Strings go
 templateDir: openapi-generator/templates/go
 apiNameSuffix: Api
+invokerPackage: phrase

--- a/openapi-generator/templates/go/api_doc.mustache
+++ b/openapi-generator/templates/go/api_doc.mustache
@@ -1,4 +1,4 @@
-# {{invokerPackage}}\{{classname}}{{#description}}
+# {{invokerPackage}}.{{classname}}{{#description}}
 
 {{description}}{{/description}}
 


### PR DESCRIPTION
Noticed small glitches on golang documentation:
* Class prefix was missing and separator was wrong (probably copied from PHP)
* Optional parameters table was broken

https://github.com/phrase/phrase-go/blob/352ba6cfa3ec52df4a6c42e29e4581596145003b/docs/TranslationsApi.md