### PR TITLE
fix(CLI): Fix async download parameters creation #STRINGS-2712

### DIFF
--- a/clients/cli/cmd/internal/pull.go
+++ b/clients/cli/cmd/internal/pull.go
@@ -277,7 +277,7 @@ func asyncDownloadParams(localVarOptionals phrase.LocaleDownloadOpts) phrase.Loc
 				sourceValue := reflect.ValueOf(localVarOptionals).FieldByName(sourceField.Name)
 				targetValue := reflect.ValueOf(&localeDownloadCreateParams).Elem().Field(i)
 				// handle slices
-				if sourceValue.Kind() == reflect.Slice && targetValue.Kind() == reflect.Slice {
+				if sourceValue.Kind() == reflect.Slice {
 					if sourceValue.Len() > 0 {
 						targetValue.Set(reflect.MakeSlice(targetValue.Type(), sourceValue.Len(), sourceValue.Len()))
 						for j := 0; j < sourceValue.Len(); j++ {


### PR DESCRIPTION
As async download and standard locale download use different style of parameters (json payload vs query), we are copying latter into the former when user wants async download, using golang reflection. Previously we had only simple parameters and recently an array (`locale_ids`) is introduced, which our code was choking upon. This extend the copy to golang slices.

https://phrase.atlassian.net/browse/STRINGS-2712