### PR TITLE
fix(CLI): address additional checks introduced by golang 1.24

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.24.4'
-      - name: Generate CLI
+      - name: Generate CLI and run tests
         env:
           GOPRIVATE: github.com/phrase/phrase-go
         run: |
@@ -27,6 +27,7 @@ jobs:
           go mod edit -replace github.com/phrase/phrase-go/v4=../go
           npm run generate.cli
           go build .
+          go test -v ./...
       - name: License check
         uses: phrase/actions/lawa-ci@v1
         with:

--- a/clients/cli/cmd/internal/init.go
+++ b/clients/cli/cmd/internal/init.go
@@ -308,7 +308,7 @@ func (cmd *InitCommand) configureSources() error {
 
 		err = paths.Validate(pushPath, cmd.FileFormat.ApiName, cmd.FileFormat.Extension)
 		if err != nil {
-			print.Failure(err.Error())
+			print.Failure("%s", err.Error())
 		} else {
 			break
 		}
@@ -339,7 +339,7 @@ func (cmd *InitCommand) configureTargets() error {
 
 		err = paths.Validate(pullPath, cmd.FileFormat.ApiName, cmd.FileFormat.Extension)
 		if err != nil {
-			print.Failure(err.Error())
+			print.Failure("%s", err.Error())
 		} else {
 			break
 		}
@@ -375,12 +375,12 @@ func (cmd *InitCommand) writeConfig() error {
 		return err
 	}
 
-	print.Success("We created the following configuration file for you: " + filename)
+	print.Success("We created the following configuration file for you: %s", filename)
 
 	fmt.Println()
 	fmt.Println(string(yamlBytes))
 
-	print.Success("For advanced configuration options, take a look at the documentation: " + shared.DocsConfigUrl)
+	print.Success("For advanced configuration options, take a look at the documentation: %s", shared.DocsConfigUrl)
 	print.Success("You can now use the push & pull commands in your workflow:")
 	fmt.Println()
 	fmt.Println("$ phrase push")

--- a/clients/cli/cmd/internal/push_source.go
+++ b/clients/cli/cmd/internal/push_source.go
@@ -142,7 +142,7 @@ func (source *Source) CheckPreconditions() error {
 
 	if len(duplicatedPlaceholders) > 0 {
 		dups := strings.Join(duplicatedPlaceholders, ", ")
-		return fmt.Errorf(fmt.Sprintf("%s can only occur once in a file pattern!", dups))
+		return fmt.Errorf("%s can only occur once in a file pattern!", dups)
 	}
 
 	return nil


### PR DESCRIPTION
golang 1.24 introduces some more strict check on format strings sent to printf and alike. this doesn't block the build, but pops up when running the (currently empty) test suite.

This PR addresses these issues.