### PR TITLE
feat(API): Add use_ordinal_rules attribute to request body for create/update Keys endpoints

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -658,6 +658,9 @@
           },
           "plural": {
             "type": "boolean"
+          },
+          "use_ordinal_rules": {
+            "type": "boolean"
           }
         },
         "example": null
@@ -20111,6 +20114,11 @@
                     "type": "boolean",
                     "example": null
                   },
+                  "use_ordinal_rules": {
+                    "description": "Indicates whether key uses ordinal rules for pluralization",
+                    "type": "boolean",
+                    "example": null
+                  },
                   "name_plural": {
                     "description": "Plural name for the key (used in some file formats, e.g. Gettext)",
                     "type": "string",
@@ -20543,6 +20551,11 @@
                   },
                   "plural": {
                     "description": "Indicates whether key supports pluralization",
+                    "type": "boolean",
+                    "example": null
+                  },
+                  "use_ordinal_rules": {
+                    "description": "Indicates whether key uses ordinal rules for pluralization",
                     "type": "boolean",
                     "example": null
                   },

--- a/paths/keys/create.yaml
+++ b/paths/keys/create.yaml
@@ -74,6 +74,10 @@ requestBody:
             description: Indicates whether key supports pluralization
             type: boolean
             example:
+          use_ordinal_rules:
+            description: Indicates whether key uses ordinal rules for pluralization
+            type: boolean
+            example:
           name_plural:
             description: Plural name for the key (used in some file formats, e.g. Gettext)
             type: string

--- a/paths/keys/update.yaml
+++ b/paths/keys/update.yaml
@@ -74,6 +74,10 @@ requestBody:
             description: Indicates whether key supports pluralization
             type: boolean
             example:
+          use_ordinal_rules:
+            description: Indicates whether key uses ordinal rules for pluralization
+            type: boolean
+            example:
           name_plural:
             description: Plural name for the key (used in some file formats, e.g. Gettext)
             type: string

--- a/schemas/key_preview.yaml
+++ b/schemas/key_preview.yaml
@@ -9,4 +9,6 @@ key_preview:
       type: string
     plural:
       type: boolean
+    use_ordinal_rules:
+      type: boolean
   example: 


### PR DESCRIPTION
- Add the `use_ordinal_rules` attribute to create/update keys endpoint request bodies as it was implemented and should be to the documentation.
- Add use_ordinal_rules to key_preview object

<img width="888" height="148" alt="Screenshot 2025-07-14 at 10 56 33" src="https://github.com/user-attachments/assets/ae2c00ed-3882-4e46-a05d-695a93e1aa66" />


Follow-up on PR: https://github.com/phrase/openapi/pull/846