### PR TITLE
feat(API): Add support for  option on upload

### DIFF
--- a/clients/cli/go.mod
+++ b/clients/cli/go.mod
@@ -32,6 +32,8 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
 
+require github.com/phrase/phrase-go/v3 v3.7.1
+
 require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect

--- a/clients/cli/go.sum
+++ b/clients/cli/go.sum
@@ -215,6 +215,8 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/phrase/phrase-go/v3 v3.7.1 h1:zrGntbiuOTjOpVcG7jkUpQLq570s+RPRYxWIRSfNiTs=
+github.com/phrase/phrase-go/v3 v3.7.1/go.mod h1:s0uOYiXLxKAYlaIS6TbKv3efkKFUlY4OB6OL+VgvK90=
 github.com/phrase/phrase-go/v4 v4.9.0 h1:V+MWmNrxwrYNtmoY41dgrdWT902Er2hcohtQcpVvWmw=
 github.com/phrase/phrase-go/v4 v4.9.0/go.mod h1:4XplKvrbHS2LDaXfFp9xrVDtO5xk2WHFm0htutwwd8c=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/clients/java/src/test/java/com/phrase/client/api/UploadsApiTest.java
+++ b/clients/java/src/test/java/com/phrase/client/api/UploadsApiTest.java
@@ -99,6 +99,7 @@ public class UploadsApiTest {
         String tags = null;
         Boolean updateTranslations = null;
         Boolean updateCustomMetadata = null;
+        Boolean clearCustomMetadata = null;
         Boolean updateTranslationKeys = true;
         Boolean updateTranslationsOnSourceMatch = null;
         Boolean updateDescriptions = null;
@@ -122,7 +123,7 @@ public class UploadsApiTest {
         formatOptionsMap.put("more_options", nestedFormatOptionsMap);
 
         Upload response = api.uploadCreate(projectId, file, fileFormat, localeId, xPhraseAppOTP, branch,
-            tags, updateTranslations, updateCustomMetadata, updateTranslationKeys, updateTranslationsOnSourceMatch,
+            tags, updateTranslations, updateCustomMetadata, clearCustomMetadata, updateTranslationKeys, updateTranslationsOnSourceMatch,
             updateDescriptions, convertEmoji, skipUploadTags, skipUnverification, fileEncoding,
             localeMapping, formatOptionsMap, autotranslate, verifyMentionedTranslations, markReviewed, tagOnlyAffectedKeys,
             translationKeyPrefix);

--- a/clients/php/test/Api/UploadsApiTest.php
+++ b/clients/php/test/Api/UploadsApiTest.php
@@ -97,6 +97,7 @@ class UploadsApiTest extends TestCase
             null, # update_translations
             null, # update_custom_metadata
             null, # update_translation_keys
+            null, # clear_custom_metadata
             null, # update_translations_on_source_match
             null, # update_descriptions
             null, # convert_emoji

--- a/clients/php/test/Api/UploadsApiTest.php
+++ b/clients/php/test/Api/UploadsApiTest.php
@@ -96,8 +96,8 @@ class UploadsApiTest extends TestCase
             null, # tags
             null, # update_translations
             null, # update_custom_metadata
-            null, # update_translation_keys
             null, # clear_custom_metadata
+            null, # update_translation_keys
             null, # update_translations_on_source_match
             null, # update_descriptions
             null, # convert_emoji

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -14665,7 +14665,7 @@
                     "example": true
                   },
                   "clear_custom_metadata": {
-                    "description": "Determines whether to clear custom metadata values when uploading a file. If set to true, existing metadata can be removed. Passing an empty value deletes the corresponding metadata property. The default is `false`",
+                    "description": "Determines whether to clear custom metadata values when uploading a file. If set to true, existing metadata can be removed. Passing an empty value in upload for key metadata deletes the corresponding metadata property. The default is `false`",
                     "type": "boolean",
                     "default": false,
                     "example": true

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -14659,9 +14659,15 @@
                     "example": true
                   },
                   "update_custom_metadata": {
-                    "description": "Determines whether to update custom metadata values when uploading a file. If set to true, existing metadata can be changed or removed. Passing an empty value deletes the corresponding metadata property.",
+                    "description": "Determines whether to update custom metadata values when uploading a file. If set to true, existing metadata can be changed.",
                     "type": "boolean",
                     "default": true,
+                    "example": true
+                  },
+                  "clear_custom_metadata": {
+                    "description": "Determines whether to clear custom metadata values when uploading a file. If set to true, existing metadata can be removed. Passing an empty value deletes the corresponding metadata property. The default is `false`",
+                    "type": "boolean",
+                    "default": false,
                     "example": true
                   },
                   "update_translation_keys": {

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -94,7 +94,7 @@ requestBody:
             default: true
             example: true
           clear_custom_metadata:
-            description: Determines whether to clear custom metadata values when uploading a file. If set to true, existing metadata can be removed. Passing an empty value deletes the corresponding metadata property. The default is `false`
+            description: Determines whether to clear custom metadata values when uploading a file. If set to true, existing metadata can be removed. Passing an empty value in upload for key metadata deletes the corresponding metadata property. The default is `false`
             type: boolean
             default: false
             example: true

--- a/paths/uploads/create.yaml
+++ b/paths/uploads/create.yaml
@@ -89,9 +89,14 @@ requestBody:
             type: boolean
             example: true
           update_custom_metadata:
-            description: Determines whether to update custom metadata values when uploading a file. If set to true, existing metadata can be changed or removed. Passing an empty value deletes the corresponding metadata property.
+            description: Determines whether to update custom metadata values when uploading a file. If set to true, existing metadata can be changed.
             type: boolean
             default: true
+            example: true
+          clear_custom_metadata:
+            description: Determines whether to clear custom metadata values when uploading a file. If set to true, existing metadata can be removed. Passing an empty value deletes the corresponding metadata property. The default is `false`
+            type: boolean
+            default: false
             example: true
           update_translation_keys:
             description: Pass `false` here to prevent new keys from being created and existing keys updated.


### PR DESCRIPTION
Add support for `update_custom_metadata` option on upload
<img width="1889" height="270" alt="Screenshot 2025-08-06 at 17 04 31" src="https://github.com/user-attachments/assets/33aacbf7-52b1-43b0-b7c7-5c72ccbff8a7" />


## Effected Ticket
https://phrase.atlassian.net/browse/SCM-619

## Related PR
https://github.com/phrase/phrase/pull/15791