### PR TITLE
chore(docs): README title clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenAPI specification for Phrase
+# OpenAPI specification for Phrase Strings
 
 ## Commands
 


### PR DESCRIPTION
This repo only contains documentation for Phrase Strings.