### PR TITLE
build(typescript): bump dev TS version to 5.9

### DIFF
--- a/openapi-generator/templates/typescript-fetch/package.mustache
+++ b/openapi-generator/templates/typescript-fetch/package.mustache
@@ -16,7 +16,7 @@
     "form-data": "^4.0.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.9"
   }{{#npmRepository}},{{/npmRepository}}
 {{#npmRepository}}
   "publishConfig": {


### PR DESCRIPTION
Fix TS test suite (broken since https://github.com/phrase/openapi/pull/872) by bumping the TS version.