### PR TITLE
fix(CLI): segfault on pull with branch argument

### DIFF
--- a/clients/cli/cmd/internal/pull.go
+++ b/clients/cli/cmd/internal/pull.go
@@ -66,7 +66,7 @@ func (cmd *PullCommand) Run(config *phrase.Config) error {
 	for _, target := range targets {
 		if cmd.Branch != "" {
 			if target.Params == nil {
-				target.Params = &PullParams{LocaleDownloadOpts: phrase.LocaleDownloadOpts{}}
+				target.Params = &PullParams{}
 			}
 			target.Params.Branch = optional.NewString(cmd.Branch)
 		}


### PR DESCRIPTION
if `target.Params` is not there (missing section in the config), `pull --branch ...` segfaults

https://github.com/phrase/phrase-cli/issues/174