### PR TITLE
chore: Modify workflow to add PR's author and URL to the event payload

### DIFF
--- a/.github/workflows/developer-hub.yml
+++ b/.github/workflows/developer-hub.yml
@@ -1,12 +1,13 @@
-name: Dispatch Developer Hub Workflow
+name: Dispatch Developer Hub on PR merge
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [closed]
 
 jobs:
   dispatch:
+    # Only run this job if the pull request was merged into the main branch
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Send repository_dispatch to phrase/developer-hub
@@ -15,4 +16,10 @@ jobs:
           token: ${{ secrets.DISPATCH_DEVELOPER_HUB_TOKEN }}
           repository: phrase/developer-hub
           event-type: trigger-strings-workflow
-          client-payload: '{"source": "phrase/openapi", "type": "update"}'
+          client-payload: >-
+            {
+              "source": "phrase/openapi",
+              "type": "update",
+              "pr_author": "${{ github.event.pull_request.user.login }}",
+              "pr_url": "${{ github.event.pull_request.html_url }}"
+            }


### PR DESCRIPTION
Changed the workflow in `.github/workflows/developer-hub.yml` to let the `phrase/developer-hub` repository mention and assign the author of the original merged PR.

Relates to:
https://github.com/phrase/developer-hub/pull/99