### PR TITLE
fix(python): pin urllib3 version to <2.6 #SCD-642

### DIFF
--- a/openapi-generator/templates/python/README_onlypackage.mustache
+++ b/openapi-generator/templates/python/README_onlypackage.mustache
@@ -24,7 +24,7 @@ This python library package is generated without supporting files like setup.py 
 
 To be able to use it, you will need these dependencies in your own package that uses this library:
 
-* urllib3 >= 1.15
+* urllib3 >= 1.15, < 2.6
 * six >= 1.10
 * certifi
 * python-dateutil

--- a/openapi-generator/templates/python/python-experimental/README_onlypackage.mustache
+++ b/openapi-generator/templates/python/python-experimental/README_onlypackage.mustache
@@ -25,7 +25,7 @@ This python library package is generated without supporting files like setup.py 
 
 To be able to use it, you will need these dependencies in your own package that uses this library:
 
-* urllib3 >= 1.15
+* urllib3 >= 1.15, < 2.6
 * six >= 1.10
 * certifi
 * python-dateutil

--- a/openapi-generator/templates/python/python-experimental/requirements.mustache
+++ b/openapi-generator/templates/python/python-experimental/requirements.mustache
@@ -4,4 +4,4 @@ future; python_version<="2.7"
 six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.15.1
+urllib3 >= 1.15.1, < 2.6

--- a/openapi-generator/templates/python/python-experimental/setup.mustache
+++ b/openapi-generator/templates/python/python-experimental/setup.mustache
@@ -17,7 +17,7 @@ VERSION = "{{packageVersion}}"
 # http://pypi.python.org/pypi/setuptools
 
 REQUIRES = [
-  "urllib3 >= 1.15",
+  "urllib3>=1.15,<2.6",
   "six >= 1.10",
   "certifi",
   "python-dateutil",

--- a/openapi-generator/templates/python/requirements.mustache
+++ b/openapi-generator/templates/python/requirements.mustache
@@ -3,4 +3,4 @@ future; python_version<="2.7"
 six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.15.1
+urllib3 >= 1.15.1, < 2.6

--- a/openapi-generator/templates/python/setup.mustache
+++ b/openapi-generator/templates/python/setup.mustache
@@ -16,7 +16,7 @@ VERSION = "{{packageVersion}}"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+REQUIRES = ["urllib3>=1.15,<2.6", "six >= 1.10", "certifi", "python-dateutil"]
 {{#asyncio}}
 REQUIRES.append("aiohttp >= 3.0.0")
 {{/asyncio}}


### PR DESCRIPTION
https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#260-2025-12-05 introduces a breaking change which causes errors with the client (presumably `getheaders` removal). Pinning the version to 2.5 until we adapt the library.