### PR TITLE
fix(typescript): use trusted publishing for typescript client

### DIFF
--- a/clients/typescript/.github/workflows/release.yml
+++ b/clients/typescript/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - '*'
+permissions:
+  id-token: write
+  contents: read
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -19,5 +22,3 @@ jobs:
         registry-url: 'https://registry.npmjs.org/'
     - run: npm install
     - run: npm publish --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Use trusted publishing for typescript client following documentation: https://docs.npmjs.com/trusted-publishers