### PR TITLE
fix(typescript): Fix github release creation

### DIFF
--- a/clients/typescript/.github/workflows/release.yml
+++ b/clients/typescript/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
     tags:
       - '*'
 permissions:
-  id-token: write
-  contents: read
+  id-token: write # needed to publish to npm
+  contents: write # needed to create a release
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
apparently creating a github release requires `content: write` permission

https://github.com/orgs/community/discussions/68252