### PR TITLE
chore: rename repo to strings-openapi

### DIFF
--- a/clients/cli/CHANGELOG.md
+++ b/clients/cli/CHANGELOG.md
@@ -7,564 +7,564 @@
 
 * **API:** Add linked_translation to translation type ([#1005](https://github.com/phrase/strings-openapi/issues/1005)) ([b18e64c](https://github.com/phrase/strings-openapi/commit/b18e64c948d40a9e5f996e8fdf6dee07d1812b02))
 
-## [2.53.1](https://github.com/phrase/openapi/compare/cli-v2.53.0...cli-v2.53.1) (2026-01-13)
+## [2.53.1](https://github.com/phrase/strings-openapi/compare/cli-v2.53.0...cli-v2.53.1) (2026-01-13)
 
 
 ### Bug Fixes
 
-* **CLI:** Stuck waiting when using push -w -B ([#1003](https://github.com/phrase/openapi/issues/1003)) ([8a1b0f8](https://github.com/phrase/openapi/commit/8a1b0f865bc8e0437fbb2f00aa5a4a7b487aa7d7))
+* **CLI:** Stuck waiting when using push -w -B ([#1003](https://github.com/phrase/strings-openapi/issues/1003)) ([8a1b0f8](https://github.com/phrase/strings-openapi/commit/8a1b0f865bc8e0437fbb2f00aa5a4a7b487aa7d7))
 
-## [2.53.0](https://github.com/phrase/openapi/compare/cli-v2.52.0...cli-v2.53.0) (2026-01-09)
+## [2.53.0](https://github.com/phrase/strings-openapi/compare/cli-v2.52.0...cli-v2.53.0) (2026-01-09)
 
 
 ### Features
 
-* **API:** Add missing project flags to project details schema #SCD-141 ([#993](https://github.com/phrase/openapi/issues/993)) ([93fbdd7](https://github.com/phrase/openapi/commit/93fbdd76150ed94374ef888ac92c0c9b626de7c8))
+* **API:** Add missing project flags to project details schema #SCD-141 ([#993](https://github.com/phrase/strings-openapi/issues/993)) ([93fbdd7](https://github.com/phrase/strings-openapi/commit/93fbdd76150ed94374ef888ac92c0c9b626de7c8))
 
 
 ### Bug Fixes
 
-* **API:** drop invalid account locale params ([#992](https://github.com/phrase/openapi/issues/992)) ([87af83c](https://github.com/phrase/openapi/commit/87af83c94fd7e47340b5393847e93a31127abbe8))
+* **API:** drop invalid account locale params ([#992](https://github.com/phrase/strings-openapi/issues/992)) ([87af83c](https://github.com/phrase/strings-openapi/commit/87af83c94fd7e47340b5393847e93a31127abbe8))
 
-## [2.52.0](https://github.com/phrase/openapi/compare/cli-v2.51.0...cli-v2.52.0) (2025-12-11)
-
-
-### Features
-
-* **API:** Add create comparison endpoint for branches [SCD-549] ([#966](https://github.com/phrase/openapi/issues/966)) ([4099e32](https://github.com/phrase/openapi/commit/4099e32d42744f9d73346077ef30b0f4bd5c849e))
-
-## [2.51.0](https://github.com/phrase/openapi/compare/cli-v2.50.2...cli-v2.51.0) (2025-12-02)
+## [2.52.0](https://github.com/phrase/strings-openapi/compare/cli-v2.51.0...cli-v2.52.0) (2025-12-11)
 
 
 ### Features
 
-* **API:** add manual triggering of automations #SCM-953 ([#968](https://github.com/phrase/openapi/issues/968)) ([ebe1c68](https://github.com/phrase/openapi/commit/ebe1c68e472d87ea6c6cd2f76bb421406c30a274))
-* **API:** add use_locale_fallback option to download #SCD-620 ([#976](https://github.com/phrase/openapi/issues/976)) ([9266c68](https://github.com/phrase/openapi/commit/9266c680d8717bb736aed83625858f0b3419da54))
+* **API:** Add create comparison endpoint for branches [SCD-549] ([#966](https://github.com/phrase/strings-openapi/issues/966)) ([4099e32](https://github.com/phrase/strings-openapi/commit/4099e32d42744f9d73346077ef30b0f4bd5c849e))
 
-## [2.50.2](https://github.com/phrase/openapi/compare/cli-v2.50.1...cli-v2.50.2) (2025-11-10)
+## [2.51.0](https://github.com/phrase/strings-openapi/compare/cli-v2.50.2...cli-v2.51.0) (2025-12-02)
+
+
+### Features
+
+* **API:** add manual triggering of automations #SCM-953 ([#968](https://github.com/phrase/strings-openapi/issues/968)) ([ebe1c68](https://github.com/phrase/strings-openapi/commit/ebe1c68e472d87ea6c6cd2f76bb421406c30a274))
+* **API:** add use_locale_fallback option to download #SCD-620 ([#976](https://github.com/phrase/strings-openapi/issues/976)) ([9266c68](https://github.com/phrase/strings-openapi/commit/9266c680d8717bb736aed83625858f0b3419da54))
+
+## [2.50.2](https://github.com/phrase/strings-openapi/compare/cli-v2.50.1...cli-v2.50.2) (2025-11-10)
 
 
 ### Bug Fixes
 
-* **API:** Add omit_translation_keys to Jobs#show endpoint ([#957](https://github.com/phrase/openapi/issues/957)) ([23ece66](https://github.com/phrase/openapi/commit/23ece66b05fc748a4598ce876cb2954ed1a385cc))
+* **API:** Add omit_translation_keys to Jobs#show endpoint ([#957](https://github.com/phrase/strings-openapi/issues/957)) ([23ece66](https://github.com/phrase/strings-openapi/commit/23ece66b05fc748a4598ce876cb2954ed1a385cc))
 
-## [2.50.1](https://github.com/phrase/openapi/compare/cli-v2.50.0...cli-v2.50.1) (2025-11-04)
-
-
-### Bug Fixes
-
-* **CLI:** segfault on pull with branch argument ([#955](https://github.com/phrase/openapi/issues/955)) ([2f33f92](https://github.com/phrase/openapi/commit/2f33f927e1c5bc07a5746802d077295c25c83dee))
-
-## [2.50.0](https://github.com/phrase/openapi/compare/cli-v2.49.0...cli-v2.50.0) (2025-10-27)
-
-
-### Features
-
-* **API:** Support omit_translation_keys param in Jobs#show ([#944](https://github.com/phrase/openapi/issues/944)) ([690a2ce](https://github.com/phrase/openapi/commit/690a2ce992359e7920367699145d2d4ff3a206fa))
-
-## [2.49.0](https://github.com/phrase/openapi/compare/cli-v2.48.0...cli-v2.49.0) (2025-10-23)
-
-
-### Features
-
-* **API:** Support source_locale_id param in uploads ([#935](https://github.com/phrase/openapi/issues/935)) ([304a406](https://github.com/phrase/openapi/commit/304a4061aaac8001a3a9e10c5cf985b04c31dab2))
-
-## [2.48.0](https://github.com/phrase/openapi/compare/cli-v2.47.0...cli-v2.48.0) (2025-10-16)
-
-
-### Features
-
-* List child branches ([#926](https://github.com/phrase/openapi/issues/926)) ([31d3b57](https://github.com/phrase/openapi/commit/31d3b57e0d1381149409b77c3e236b226cde22a1))
-
-## [2.47.0](https://github.com/phrase/openapi/compare/cli-v2.46.0...cli-v2.47.0) (2025-10-01)
-
-
-### Features
-
-* add branch sync endpoint ([#912](https://github.com/phrase/openapi/issues/912)) ([3293917](https://github.com/phrase/openapi/commit/329391757b3f81574448b1b87506b85bfdeb6761))
-
-## [2.46.0](https://github.com/phrase/openapi/compare/cli-v2.45.0...cli-v2.46.0) (2025-09-30)
-
-
-### Features
-
-* **API:** Add "reviewed" param for tanslations#update ([#891](https://github.com/phrase/openapi/issues/891)) ([3f77286](https://github.com/phrase/openapi/commit/3f7728669fa68d5911dfca39a9e39c24cd20c0a4))
-* **SCM-732:** expose Automation API ([#910](https://github.com/phrase/openapi/issues/910)) ([6eea53d](https://github.com/phrase/openapi/commit/6eea53d06aca8f43623ba90e2e0a8cd6761c9a13))
-
-## [2.45.0](https://github.com/phrase/openapi/compare/cli-v2.44.0...cli-v2.45.0) (2025-08-01)
-
-
-### Features
-
-* **API:** Add support for `update_custom_metadata` option on upload ([#882](https://github.com/phrase/openapi/issues/882)) ([5b486ea](https://github.com/phrase/openapi/commit/5b486eabf30c84402a8e31911a5ba6fe3b343a89))
-
-## [2.44.0](https://github.com/phrase/openapi/compare/cli-v2.43.0...cli-v2.44.0) (2025-07-24)
-
-
-### Features
-
-* **API:** Job and job locale annotations #SCD-145 ([#867](https://github.com/phrase/openapi/issues/867)) ([95b6c2a](https://github.com/phrase/openapi/commit/95b6c2a2ab798d01f9bc0d53a22dbf817a5eb0ee))
-
-## [2.43.0](https://github.com/phrase/openapi/compare/cli-v2.42.2...cli-v2.43.0) (2025-07-18)
-
-
-### Features
-
-* **API:** add updated_since param for downloads ([#858](https://github.com/phrase/openapi/issues/858)) ([db4196b](https://github.com/phrase/openapi/commit/db4196bfb1a45f628577bebb99aad7da1179c241))
-* **API:** Add use_ordinal_rules attribute to request body for create/update Keys endpoints ([#868](https://github.com/phrase/openapi/issues/868)) ([29410b5](https://github.com/phrase/openapi/commit/29410b5d4edee9645f449d2d7de53fb953c1f0c2))
-* **API:** Add use_ordinal_rules boolean [STRINGS-2273] ([#846](https://github.com/phrase/openapi/issues/846)) ([450ce0c](https://github.com/phrase/openapi/commit/450ce0cce6bb2064758c44b130b39dd5539c2681))
-
-## [2.42.2](https://github.com/phrase/openapi/compare/cli-v2.42.1...cli-v2.42.2) (2025-06-30)
+## [2.50.1](https://github.com/phrase/strings-openapi/compare/cli-v2.50.0...cli-v2.50.1) (2025-11-04)
 
 
 ### Bug Fixes
 
-* **CLI:** address additional checks introduced by golang 1.24 ([#856](https://github.com/phrase/openapi/issues/856)) ([6f6e1f5](https://github.com/phrase/openapi/commit/6f6e1f5af5287c92fde059645519af9837cf8e19))
+* **CLI:** segfault on pull with branch argument ([#955](https://github.com/phrase/strings-openapi/issues/955)) ([2f33f92](https://github.com/phrase/strings-openapi/commit/2f33f927e1c5bc07a5746802d077295c25c83dee))
 
-## [2.42.1](https://github.com/phrase/openapi/compare/cli-v2.42.0...cli-v2.42.1) (2025-06-30)
-
-
-### Bug Fixes
-
-* **CLI:** Fix async download parameters creation #STRINGS-2712 ([#854](https://github.com/phrase/openapi/issues/854)) ([3a264d4](https://github.com/phrase/openapi/commit/3a264d49cf9d09f550b0cc45e6a97a782b7b0adb))
-
-## [2.42.0](https://github.com/phrase/openapi/compare/cli-v2.41.0...cli-v2.42.0) (2025-05-23)
+## [2.50.0](https://github.com/phrase/strings-openapi/compare/cli-v2.49.0...cli-v2.50.0) (2025-10-27)
 
 
 ### Features
 
-* **API:** Add omit_statistics param to tags#show ([#834](https://github.com/phrase/openapi/issues/834)) ([2058b18](https://github.com/phrase/openapi/commit/2058b18297133075885ac99770aee2e171811cd6))
+* **API:** Support omit_translation_keys param in Jobs#show ([#944](https://github.com/phrase/strings-openapi/issues/944)) ([690a2ce](https://github.com/phrase/strings-openapi/commit/690a2ce992359e7920367699145d2d4ff3a206fa))
 
-## [2.41.0](https://github.com/phrase/openapi/compare/cli-v2.40.0...cli-v2.41.0) (2025-05-16)
-
-
-### Features
-
-* **API:** Add "verify_mentioned_translations" parameter to uploads ([#830](https://github.com/phrase/openapi/issues/830)) ([f2fdf60](https://github.com/phrase/openapi/commit/f2fdf60dd97c3908293cd457a765dafde603bd9b))
-* **API:** Add processed & upload total translations on upload summary ([#824](https://github.com/phrase/openapi/issues/824)) ([081db68](https://github.com/phrase/openapi/commit/081db68d2ffcf5d66a81e07eec0a9572a1f9d633))
-* **API:** Translations unreview & batch unreview ([#831](https://github.com/phrase/openapi/issues/831)) ([6a696db](https://github.com/phrase/openapi/commit/6a696db00d80d8acaf5887a08a7a97997566eb8f))
-
-## [2.40.0](https://github.com/phrase/openapi/compare/cli-v2.39.0...cli-v2.40.0) (2025-04-08)
+## [2.49.0](https://github.com/phrase/strings-openapi/compare/cli-v2.48.0...cli-v2.49.0) (2025-10-23)
 
 
 ### Features
 
-* **CLI:** Do not save token to config file by default #STRINGS-999 ([#822](https://github.com/phrase/openapi/issues/822)) ([7836701](https://github.com/phrase/openapi/commit/783670117c84357da9157b4e5cdb80fc3d96c820))
+* **API:** Support source_locale_id param in uploads ([#935](https://github.com/phrase/strings-openapi/issues/935)) ([304a406](https://github.com/phrase/strings-openapi/commit/304a4061aaac8001a3a9e10c5cf985b04c31dab2))
 
-
-### Bug Fixes
-
-* **API:** Remove request body from GET comments ([#817](https://github.com/phrase/openapi/issues/817)) ([2646001](https://github.com/phrase/openapi/commit/264600132e80ac03983e0ae86e99db3d6fb9080d))
-
-## [2.39.0](https://github.com/phrase/openapi/compare/cli-v2.38.0...cli-v2.39.0) (2025-03-06)
+## [2.48.0](https://github.com/phrase/strings-openapi/compare/cli-v2.47.0...cli-v2.48.0) (2025-10-16)
 
 
 ### Features
 
-* **CLI:** Support cleanup over multiple sources #STRINGS-1378 ([#810](https://github.com/phrase/openapi/issues/810)) ([e78ab70](https://github.com/phrase/openapi/commit/e78ab704ef451b1be161011204f6d402201408a1))
+* List child branches ([#926](https://github.com/phrase/strings-openapi/issues/926)) ([31d3b57](https://github.com/phrase/strings-openapi/commit/31d3b57e0d1381149409b77c3e236b226cde22a1))
 
-## [2.38.0](https://github.com/phrase/openapi/compare/cli-v2.37.0...cli-v2.38.0) (2025-03-05)
-
-
-### Features
-
-* **API:** Include roles in account response ([#811](https://github.com/phrase/openapi/issues/811)) ([dc27ee5](https://github.com/phrase/openapi/commit/dc27ee5117762222b6e1e6abb639f8e00c6a9101))
-
-## [2.37.0](https://github.com/phrase/openapi/compare/cli-v2.36.0...cli-v2.37.0) (2025-02-25)
+## [2.47.0](https://github.com/phrase/strings-openapi/compare/cli-v2.46.0...cli-v2.47.0) (2025-10-01)
 
 
 ### Features
 
-* **API:** add updated_since filter to job list #STRINGS-1555 ([#799](https://github.com/phrase/openapi/issues/799)) ([dc9b6ed](https://github.com/phrase/openapi/commit/dc9b6ed12e013231d397820449086c87fea2f8ba))
+* add branch sync endpoint ([#912](https://github.com/phrase/strings-openapi/issues/912)) ([3293917](https://github.com/phrase/strings-openapi/commit/329391757b3f81574448b1b87506b85bfdeb6761))
 
-
-### Bug Fixes
-
-* **CLI:** Revert viper library version #STRINGS-1487 ([#809](https://github.com/phrase/openapi/issues/809)) ([8b68918](https://github.com/phrase/openapi/commit/8b689182b5e23bf7fee447db9229c5aba0417c7d))
-
-## [2.36.0](https://github.com/phrase/openapi/compare/cli-v2.35.6...cli-v2.36.0) (2025-02-17)
+## [2.46.0](https://github.com/phrase/strings-openapi/compare/cli-v2.45.0...cli-v2.46.0) (2025-09-30)
 
 
 ### Features
 
-* **API:** Add locale_ids param to synchronous download endpoint [STRINGS-1492] ([#780](https://github.com/phrase/openapi/issues/780)) ([47186a4](https://github.com/phrase/openapi/commit/47186a44fc8c0b8e466636acf3d49413b1f29f30))
-* **API:** Add source last updated at information on job details ([#777](https://github.com/phrase/openapi/issues/777)) ([c9b8423](https://github.com/phrase/openapi/commit/c9b8423766b4138980d0553502b3e18ca524f34e))
-* **API:** document tags attribute of an upload #STRINGS-1221 ([#790](https://github.com/phrase/openapi/issues/790)) ([fff505b](https://github.com/phrase/openapi/commit/fff505bdff35a0033fee06e505c42fe794c88562))
+* **API:** Add "reviewed" param for tanslations#update ([#891](https://github.com/phrase/strings-openapi/issues/891)) ([3f77286](https://github.com/phrase/strings-openapi/commit/3f7728669fa68d5911dfca39a9e39c24cd20c0a4))
+* **SCM-732:** expose Automation API ([#910](https://github.com/phrase/strings-openapi/issues/910)) ([6eea53d](https://github.com/phrase/strings-openapi/commit/6eea53d06aca8f43623ba90e2e0a8cd6761c9a13))
 
-## [2.35.6](https://github.com/phrase/openapi/compare/cli-v2.35.5...cli-v2.35.6) (2025-01-29)
-
-
-### Bug Fixes
-
-* **API:** pass translation_key_ids when removing keys from job ([#771](https://github.com/phrase/openapi/issues/771)) ([f670e27](https://github.com/phrase/openapi/commit/f670e2763b1112fefd1812109b3c09def42b7bd2))
-* **cli:** CLI do not exit with 0 on pull when branch does not exist ([#768](https://github.com/phrase/openapi/issues/768)) ([e7d8c43](https://github.com/phrase/openapi/commit/e7d8c435dafec065ed8fb657e8879bf843ee3a48))
-* **CLI:** Undo version bump ([#770](https://github.com/phrase/openapi/issues/770)) ([643aba1](https://github.com/phrase/openapi/commit/643aba13c79c6350f7416af3f5a78837bc937055))
-
-## [2.35.5](https://github.com/phrase/openapi/compare/cli-v2.35.4...cli-v2.35.5) (2025-01-06)
+## [2.45.0](https://github.com/phrase/strings-openapi/compare/cli-v2.44.0...cli-v2.45.0) (2025-08-01)
 
 
-### Bug Fixes
+### Features
 
-* **CLI:** Adjust operationId for quality_performance_score #STRINGS-1104 ([#721](https://github.com/phrase/openapi/issues/721)) ([7aa3b9b](https://github.com/phrase/openapi/commit/7aa3b9b508d1d24a4af7f4977b1a2fead8bfda78))
+* **API:** Add support for `update_custom_metadata` option on upload ([#882](https://github.com/phrase/strings-openapi/issues/882)) ([5b486ea](https://github.com/phrase/strings-openapi/commit/5b486eabf30c84402a8e31911a5ba6fe3b343a89))
 
-## [2.35.4](https://github.com/phrase/openapi/compare/cli-v2.35.3...cli-v2.35.4) (2024-12-20)
-
-
-### Bug Fixes
-
-* **API:** Repo Sync Event errors field type #STRINGS-1074 ([#756](https://github.com/phrase/openapi/issues/756)) ([c7670e0](https://github.com/phrase/openapi/commit/c7670e04810f95359d72ba6346b5f626bfb77b6f))
-
-## [2.35.3](https://github.com/phrase/openapi/compare/cli-v2.35.2...cli-v2.35.3) (2024-12-20)
+## [2.44.0](https://github.com/phrase/strings-openapi/compare/cli-v2.43.0...cli-v2.44.0) (2025-07-24)
 
 
-### Bug Fixes
+### Features
 
-* **API:** Repo Sync schema fixes #STRINGS-1074 ([#748](https://github.com/phrase/openapi/issues/748)) ([033be10](https://github.com/phrase/openapi/commit/033be1003fe01b5115de1f8ba2336d32b4862bfd))
+* **API:** Job and job locale annotations #SCD-145 ([#867](https://github.com/phrase/strings-openapi/issues/867)) ([95b6c2a](https://github.com/phrase/strings-openapi/commit/95b6c2a2ab798d01f9bc0d53a22dbf817a5eb0ee))
 
-## [2.35.2](https://github.com/phrase/openapi/compare/cli-v2.35.1...cli-v2.35.2) (2024-12-19)
+## [2.43.0](https://github.com/phrase/strings-openapi/compare/cli-v2.42.2...cli-v2.43.0) (2025-07-18)
+
+
+### Features
+
+* **API:** add updated_since param for downloads ([#858](https://github.com/phrase/strings-openapi/issues/858)) ([db4196b](https://github.com/phrase/strings-openapi/commit/db4196bfb1a45f628577bebb99aad7da1179c241))
+* **API:** Add use_ordinal_rules attribute to request body for create/update Keys endpoints ([#868](https://github.com/phrase/strings-openapi/issues/868)) ([29410b5](https://github.com/phrase/strings-openapi/commit/29410b5d4edee9645f449d2d7de53fb953c1f0c2))
+* **API:** Add use_ordinal_rules boolean [STRINGS-2273] ([#846](https://github.com/phrase/strings-openapi/issues/846)) ([450ce0c](https://github.com/phrase/strings-openapi/commit/450ce0cce6bb2064758c44b130b39dd5539c2681))
+
+## [2.42.2](https://github.com/phrase/strings-openapi/compare/cli-v2.42.1...cli-v2.42.2) (2025-06-30)
 
 
 ### Bug Fixes
 
-* **CLI:** Bump go version ([#745](https://github.com/phrase/openapi/issues/745)) ([7210e8a](https://github.com/phrase/openapi/commit/7210e8ae8f9f8cb04bca535658f65e30d1ca4831))
+* **CLI:** address additional checks introduced by golang 1.24 ([#856](https://github.com/phrase/strings-openapi/issues/856)) ([6f6e1f5](https://github.com/phrase/strings-openapi/commit/6f6e1f5af5287c92fde059645519af9837cf8e19))
 
-## [2.35.1](https://github.com/phrase/openapi/compare/cli-v2.35.0...cli-v2.35.1) (2024-12-19)
+## [2.42.1](https://github.com/phrase/strings-openapi/compare/cli-v2.42.0...cli-v2.42.1) (2025-06-30)
 
 
 ### Bug Fixes
 
-* **CLI:** Bump dependencies' versions ([#742](https://github.com/phrase/openapi/issues/742)) ([d78d620](https://github.com/phrase/openapi/commit/d78d6209eed6bddda05260d81567fcaffd9d637b))
+* **CLI:** Fix async download parameters creation #STRINGS-2712 ([#854](https://github.com/phrase/strings-openapi/issues/854)) ([3a264d4](https://github.com/phrase/strings-openapi/commit/3a264d49cf9d09f550b0cc45e6a97a782b7b0adb))
 
-## [2.35.0](https://github.com/phrase/openapi/compare/cli-v2.34.1...cli-2.25.0) (2024-12-18)
+## [2.42.0](https://github.com/phrase/strings-openapi/compare/cli-v2.41.0...cli-v2.42.0) (2025-05-23)
+
+
+### Features
+
+* **API:** Add omit_statistics param to tags#show ([#834](https://github.com/phrase/strings-openapi/issues/834)) ([2058b18](https://github.com/phrase/strings-openapi/commit/2058b18297133075885ac99770aee2e171811cd6))
+
+## [2.41.0](https://github.com/phrase/strings-openapi/compare/cli-v2.40.0...cli-v2.41.0) (2025-05-16)
+
+
+### Features
+
+* **API:** Add "verify_mentioned_translations" parameter to uploads ([#830](https://github.com/phrase/strings-openapi/issues/830)) ([f2fdf60](https://github.com/phrase/strings-openapi/commit/f2fdf60dd97c3908293cd457a765dafde603bd9b))
+* **API:** Add processed & upload total translations on upload summary ([#824](https://github.com/phrase/strings-openapi/issues/824)) ([081db68](https://github.com/phrase/strings-openapi/commit/081db68d2ffcf5d66a81e07eec0a9572a1f9d633))
+* **API:** Translations unreview & batch unreview ([#831](https://github.com/phrase/strings-openapi/issues/831)) ([6a696db](https://github.com/phrase/strings-openapi/commit/6a696db00d80d8acaf5887a08a7a97997566eb8f))
+
+## [2.40.0](https://github.com/phrase/strings-openapi/compare/cli-v2.39.0...cli-v2.40.0) (2025-04-08)
+
+
+### Features
+
+* **CLI:** Do not save token to config file by default #STRINGS-999 ([#822](https://github.com/phrase/strings-openapi/issues/822)) ([7836701](https://github.com/phrase/strings-openapi/commit/783670117c84357da9157b4e5cdb80fc3d96c820))
+
+
+### Bug Fixes
+
+* **API:** Remove request body from GET comments ([#817](https://github.com/phrase/strings-openapi/issues/817)) ([2646001](https://github.com/phrase/strings-openapi/commit/264600132e80ac03983e0ae86e99db3d6fb9080d))
+
+## [2.39.0](https://github.com/phrase/strings-openapi/compare/cli-v2.38.0...cli-v2.39.0) (2025-03-06)
+
+
+### Features
+
+* **CLI:** Support cleanup over multiple sources #STRINGS-1378 ([#810](https://github.com/phrase/strings-openapi/issues/810)) ([e78ab70](https://github.com/phrase/strings-openapi/commit/e78ab704ef451b1be161011204f6d402201408a1))
+
+## [2.38.0](https://github.com/phrase/strings-openapi/compare/cli-v2.37.0...cli-v2.38.0) (2025-03-05)
+
+
+### Features
+
+* **API:** Include roles in account response ([#811](https://github.com/phrase/strings-openapi/issues/811)) ([dc27ee5](https://github.com/phrase/strings-openapi/commit/dc27ee5117762222b6e1e6abb639f8e00c6a9101))
+
+## [2.37.0](https://github.com/phrase/strings-openapi/compare/cli-v2.36.0...cli-v2.37.0) (2025-02-25)
+
+
+### Features
+
+* **API:** add updated_since filter to job list #STRINGS-1555 ([#799](https://github.com/phrase/strings-openapi/issues/799)) ([dc9b6ed](https://github.com/phrase/strings-openapi/commit/dc9b6ed12e013231d397820449086c87fea2f8ba))
+
+
+### Bug Fixes
+
+* **CLI:** Revert viper library version #STRINGS-1487 ([#809](https://github.com/phrase/strings-openapi/issues/809)) ([8b68918](https://github.com/phrase/strings-openapi/commit/8b689182b5e23bf7fee447db9229c5aba0417c7d))
+
+## [2.36.0](https://github.com/phrase/strings-openapi/compare/cli-v2.35.6...cli-v2.36.0) (2025-02-17)
+
+
+### Features
+
+* **API:** Add locale_ids param to synchronous download endpoint [STRINGS-1492] ([#780](https://github.com/phrase/strings-openapi/issues/780)) ([47186a4](https://github.com/phrase/strings-openapi/commit/47186a44fc8c0b8e466636acf3d49413b1f29f30))
+* **API:** Add source last updated at information on job details ([#777](https://github.com/phrase/strings-openapi/issues/777)) ([c9b8423](https://github.com/phrase/strings-openapi/commit/c9b8423766b4138980d0553502b3e18ca524f34e))
+* **API:** document tags attribute of an upload #STRINGS-1221 ([#790](https://github.com/phrase/strings-openapi/issues/790)) ([fff505b](https://github.com/phrase/strings-openapi/commit/fff505bdff35a0033fee06e505c42fe794c88562))
+
+## [2.35.6](https://github.com/phrase/strings-openapi/compare/cli-v2.35.5...cli-v2.35.6) (2025-01-29)
+
+
+### Bug Fixes
+
+* **API:** pass translation_key_ids when removing keys from job ([#771](https://github.com/phrase/strings-openapi/issues/771)) ([f670e27](https://github.com/phrase/strings-openapi/commit/f670e2763b1112fefd1812109b3c09def42b7bd2))
+* **cli:** CLI do not exit with 0 on pull when branch does not exist ([#768](https://github.com/phrase/strings-openapi/issues/768)) ([e7d8c43](https://github.com/phrase/strings-openapi/commit/e7d8c435dafec065ed8fb657e8879bf843ee3a48))
+* **CLI:** Undo version bump ([#770](https://github.com/phrase/strings-openapi/issues/770)) ([643aba1](https://github.com/phrase/strings-openapi/commit/643aba13c79c6350f7416af3f5a78837bc937055))
+
+## [2.35.5](https://github.com/phrase/strings-openapi/compare/cli-v2.35.4...cli-v2.35.5) (2025-01-06)
+
+
+### Bug Fixes
+
+* **CLI:** Adjust operationId for quality_performance_score #STRINGS-1104 ([#721](https://github.com/phrase/strings-openapi/issues/721)) ([7aa3b9b](https://github.com/phrase/strings-openapi/commit/7aa3b9b508d1d24a4af7f4977b1a2fead8bfda78))
+
+## [2.35.4](https://github.com/phrase/strings-openapi/compare/cli-v2.35.3...cli-v2.35.4) (2024-12-20)
+
+
+### Bug Fixes
+
+* **API:** Repo Sync Event errors field type #STRINGS-1074 ([#756](https://github.com/phrase/strings-openapi/issues/756)) ([c7670e0](https://github.com/phrase/strings-openapi/commit/c7670e04810f95359d72ba6346b5f626bfb77b6f))
+
+## [2.35.3](https://github.com/phrase/strings-openapi/compare/cli-v2.35.2...cli-v2.35.3) (2024-12-20)
+
+
+### Bug Fixes
+
+* **API:** Repo Sync schema fixes #STRINGS-1074 ([#748](https://github.com/phrase/strings-openapi/issues/748)) ([033be10](https://github.com/phrase/strings-openapi/commit/033be1003fe01b5115de1f8ba2336d32b4862bfd))
+
+## [2.35.2](https://github.com/phrase/strings-openapi/compare/cli-v2.35.1...cli-v2.35.2) (2024-12-19)
+
+
+### Bug Fixes
+
+* **CLI:** Bump go version ([#745](https://github.com/phrase/strings-openapi/issues/745)) ([7210e8a](https://github.com/phrase/strings-openapi/commit/7210e8ae8f9f8cb04bca535658f65e30d1ca4831))
+
+## [2.35.1](https://github.com/phrase/strings-openapi/compare/cli-v2.35.0...cli-v2.35.1) (2024-12-19)
+
+
+### Bug Fixes
+
+* **CLI:** Bump dependencies' versions ([#742](https://github.com/phrase/strings-openapi/issues/742)) ([d78d620](https://github.com/phrase/strings-openapi/commit/d78d6209eed6bddda05260d81567fcaffd9d637b))
+
+## [2.35.0](https://github.com/phrase/strings-openapi/compare/cli-v2.34.1...cli-2.25.0) (2024-12-18)
 
 
 ### ⚠ BREAKING CHANGES
 
-* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/openapi/issues/735))
+* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/strings-openapi/issues/735))
 
 ### Features
 
-* **API:** Add 'default_encoding' documentation ([#733](https://github.com/phrase/openapi/issues/733)) ([0139c51](https://github.com/phrase/openapi/commit/0139c51da747fbe7bc9929bcf3534aad7f22f39a))
-* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/openapi/issues/735)) ([c3bd8ec](https://github.com/phrase/openapi/commit/c3bd8eccaabcfa1b1066ea4438971ac59833af46))
+* **API:** Add 'default_encoding' documentation ([#733](https://github.com/phrase/strings-openapi/issues/733)) ([0139c51](https://github.com/phrase/strings-openapi/commit/0139c51da747fbe7bc9929bcf3534aad7f22f39a))
+* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/strings-openapi/issues/735)) ([c3bd8ec](https://github.com/phrase/strings-openapi/commit/c3bd8eccaabcfa1b1066ea4438971ac59833af46))
 
 
 ### Bug Fixes
 
-* **API:** Add missing branch parameter to job comment endpoints #STRINGS-988 ([#724](https://github.com/phrase/openapi/issues/724)) ([64d399c](https://github.com/phrase/openapi/commit/64d399ced0980ac2a48366f91110047287a0c590))
+* **API:** Add missing branch parameter to job comment endpoints #STRINGS-988 ([#724](https://github.com/phrase/strings-openapi/issues/724)) ([64d399c](https://github.com/phrase/strings-openapi/commit/64d399ced0980ac2a48366f91110047287a0c590))
 
-## [2.34.1](https://github.com/phrase/openapi/compare/cli-v2.34.0...cli-v2.34.1) (2024-11-27)
-
-
-### Bug Fixes
-
-* **CLI:** crash when target/params section is empty #STRINGS-921 ([#722](https://github.com/phrase/openapi/issues/722)) ([03032c4](https://github.com/phrase/openapi/commit/03032c43be427a948f7e49cb7b7ff257bcf41821))
-
-## [2.34.0](https://github.com/phrase/openapi/compare/cli-v2.33.1...cli-v2.34.0) (2024-11-25)
-
-
-### Features
-
-* **API:** Add Pagination header to POST search endpoints [[#457](https://github.com/phrase/openapi/issues/457)] ([#706](https://github.com/phrase/openapi/issues/706)) ([9a79fa3](https://github.com/phrase/openapi/commit/9a79fa31bb3b9d58272fa2f4e82d72d0d44a93a0))
-* **API:** autotranslate param in key creation [STRINGS-786] ([#713](https://github.com/phrase/openapi/issues/713)) ([581d0ff](https://github.com/phrase/openapi/commit/581d0ff5f1d06757e5ddd9603b78fc8d435d68ee))
-* **CLI:** Support branch in pull config #STRINGS-538 ([#701](https://github.com/phrase/openapi/issues/701)) ([30ae809](https://github.com/phrase/openapi/commit/30ae809b38ead0d0d019362b67a8b604ac15fe5f))
+## [2.34.1](https://github.com/phrase/strings-openapi/compare/cli-v2.34.0...cli-v2.34.1) (2024-11-27)
 
 
 ### Bug Fixes
 
-* **API:** Comment creation schema fix #STRINGS-866 ([#718](https://github.com/phrase/openapi/issues/718)) ([e201d13](https://github.com/phrase/openapi/commit/e201d1360c89698dd8d3642cc28f89dd0e50a1fb))
+* **CLI:** crash when target/params section is empty #STRINGS-921 ([#722](https://github.com/phrase/strings-openapi/issues/722)) ([03032c4](https://github.com/phrase/strings-openapi/commit/03032c43be427a948f7e49cb7b7ff257bcf41821))
 
-## [2.33.1](https://github.com/phrase/openapi/compare/cli-v2.33.0...cli-v2.33.1) (2024-10-10)
+## [2.34.0](https://github.com/phrase/strings-openapi/compare/cli-v2.33.1...cli-v2.34.0) (2024-11-25)
+
+
+### Features
+
+* **API:** Add Pagination header to POST search endpoints [[#457](https://github.com/phrase/strings-openapi/issues/457)] ([#706](https://github.com/phrase/strings-openapi/issues/706)) ([9a79fa3](https://github.com/phrase/strings-openapi/commit/9a79fa31bb3b9d58272fa2f4e82d72d0d44a93a0))
+* **API:** autotranslate param in key creation [STRINGS-786] ([#713](https://github.com/phrase/strings-openapi/issues/713)) ([581d0ff](https://github.com/phrase/strings-openapi/commit/581d0ff5f1d06757e5ddd9603b78fc8d435d68ee))
+* **CLI:** Support branch in pull config #STRINGS-538 ([#701](https://github.com/phrase/strings-openapi/issues/701)) ([30ae809](https://github.com/phrase/strings-openapi/commit/30ae809b38ead0d0d019362b67a8b604ac15fe5f))
 
 
 ### Bug Fixes
 
-* **cli:** Adapt to formats API fix ([#699](https://github.com/phrase/openapi/issues/699)) ([3363de7](https://github.com/phrase/openapi/commit/3363de7b1f9564dad363932c3964a24b87887e7d))
+* **API:** Comment creation schema fix #STRINGS-866 ([#718](https://github.com/phrase/strings-openapi/issues/718)) ([e201d13](https://github.com/phrase/strings-openapi/commit/e201d1360c89698dd8d3642cc28f89dd0e50a1fb))
 
-## [2.33.0](https://github.com/phrase/openapi/compare/cli-v2.32.0...cli-v2.33.0) (2024-10-02)
-
-
-### Features
-
-* Add translation key prefixes for upload and download ([#687](https://github.com/phrase/openapi/issues/687)) ([9c9c959](https://github.com/phrase/openapi/commit/9c9c959830631bcac8beaf1de30ab31755ac1ee5))
+## [2.33.1](https://github.com/phrase/strings-openapi/compare/cli-v2.33.0...cli-v2.33.1) (2024-10-10)
 
 
 ### Bug Fixes
 
-* **API:** Format list is not paginated and authenticated #STRINGS-458 ([#690](https://github.com/phrase/openapi/issues/690)) ([25e90f4](https://github.com/phrase/openapi/commit/25e90f46513e70cf328be80c36ae785cead05851))
+* **cli:** Adapt to formats API fix ([#699](https://github.com/phrase/strings-openapi/issues/699)) ([3363de7](https://github.com/phrase/strings-openapi/commit/3363de7b1f9564dad363932c3964a24b87887e7d))
 
-## [2.32.0](https://github.com/phrase/openapi/compare/cli-v2.31.1...cli-v2.32.0) (2024-09-09)
+## [2.33.0](https://github.com/phrase/strings-openapi/compare/cli-v2.32.0...cli-v2.33.0) (2024-10-02)
 
 
 ### Features
 
-* Add update_translations_on_source_match ([#670](https://github.com/phrase/openapi/issues/670)) ([11003ac](https://github.com/phrase/openapi/commit/11003ace7353bf99893482ca4aa32214abf3e581))
-
-## [2.31.1](https://github.com/phrase/openapi/compare/cli-v2.31.0...cli-v2.31.1) (2024-07-15)
+* Add translation key prefixes for upload and download ([#687](https://github.com/phrase/strings-openapi/issues/687)) ([9c9c959](https://github.com/phrase/strings-openapi/commit/9c9c959830631bcac8beaf1de30ab31755ac1ee5))
 
 
 ### Bug Fixes
 
-* **CLI:** Pull should not crash on empty files ([#655](https://github.com/phrase/openapi/issues/655)) ([3e3b33c](https://github.com/phrase/openapi/commit/3e3b33cf0e5dd173c2596b23f5a815692f9ee865))
+* **API:** Format list is not paginated and authenticated #STRINGS-458 ([#690](https://github.com/phrase/strings-openapi/issues/690)) ([25e90f4](https://github.com/phrase/strings-openapi/commit/25e90f46513e70cf328be80c36ae785cead05851))
 
-## [2.31.0](https://github.com/phrase/openapi/compare/cli-v2.30.0...cli-v2.31.0) (2024-07-03)
-
-
-### Features
-
-* **CLI:** Add option for async download [TSI-2515] ([#649](https://github.com/phrase/openapi/issues/649)) ([976353a](https://github.com/phrase/openapi/commit/976353aa639310dd8bad45cc090aff4768b520f1))
-
-## [2.30.0](https://github.com/phrase/openapi/compare/cli-v2.29.0...cli-v2.30.0) (2024-07-02)
+## [2.32.0](https://github.com/phrase/strings-openapi/compare/cli-v2.31.1...cli-v2.32.0) (2024-09-09)
 
 
 ### Features
 
-* add repo sync events show endpoint ([#641](https://github.com/phrase/openapi/issues/641)) ([e1d9cfb](https://github.com/phrase/openapi/commit/e1d9cfb23e079fea2d9e5475dff9a4137f1f0154))
+* Add update_translations_on_source_match ([#670](https://github.com/phrase/strings-openapi/issues/670)) ([11003ac](https://github.com/phrase/strings-openapi/commit/11003ace7353bf99893482ca4aa32214abf3e581))
 
-## [2.29.0](https://github.com/phrase/openapi/compare/cli-v2.28.1...cli-v2.29.0) (2024-06-25)
-
-
-### Features
-
-* **API:** Async downloads [TSI-2515] ([#642](https://github.com/phrase/openapi/issues/642)) ([6fcab5d](https://github.com/phrase/openapi/commit/6fcab5d4719f64e8e5dd49c327dc9348b384de4c))
-
-## [2.28.1](https://github.com/phrase/openapi/compare/cli-v2.28.0...cli-v2.28.1) (2024-06-18)
+## [2.31.1](https://github.com/phrase/strings-openapi/compare/cli-v2.31.0...cli-v2.31.1) (2024-07-15)
 
 
 ### Bug Fixes
 
-* add app_min_version and app_max_version param to releases ([#633](https://github.com/phrase/openapi/issues/633)) ([b384301](https://github.com/phrase/openapi/commit/b3843012460ace4c1d34c4373e5158595466adcb))
+* **CLI:** Pull should not crash on empty files ([#655](https://github.com/phrase/strings-openapi/issues/655)) ([3e3b33c](https://github.com/phrase/strings-openapi/commit/3e3b33cf0e5dd173c2596b23f5a815692f9ee865))
 
-## [2.28.0](https://github.com/phrase/openapi/compare/cli-v2.27.1...cli-v2.28.0) (2024-06-12)
-
-
-### Features
-
-* **API:** Add OTA Release Triggers API [TSI-2485] ([#622](https://github.com/phrase/openapi/issues/622)) ([8cb91dc](https://github.com/phrase/openapi/commit/8cb91dcce2c19ca700cf9d0713fa74f28ad59434))
-
-## [2.27.1](https://github.com/phrase/openapi/compare/cli-v2.27.0...cli-v2.27.1) (2024-05-31)
-
-
-### Bug Fixes
-
-* **CLI:** use id instead of repo_sync_id as param ([#618](https://github.com/phrase/openapi/issues/618)) ([7a1a0d9](https://github.com/phrase/openapi/commit/7a1a0d9115262dc7fa3065ee7cc76bec7a381ddb))
-* **PHP:** Fix deserializing custom metadata values in key response ([#607](https://github.com/phrase/openapi/issues/607)) ([b6eeeba](https://github.com/phrase/openapi/commit/b6eeeba223e3eabec268a8f3d372afcb6abd09dd))
-
-## [2.27.0](https://github.com/phrase/openapi/compare/cli-v2.26.0...cli-v2.27.0) (2024-04-29)
+## [2.31.0](https://github.com/phrase/strings-openapi/compare/cli-v2.30.0...cli-v2.31.0) (2024-07-03)
 
 
 ### Features
 
-* **API:** Add 'update_translation_keys' for Uploads [TSI-2292] ([#578](https://github.com/phrase/openapi/issues/578)) ([4492ec0](https://github.com/phrase/openapi/commit/4492ec0a7c62f9de9ab1c1125071615bddcc26ce))
+* **CLI:** Add option for async download [TSI-2515] ([#649](https://github.com/phrase/strings-openapi/issues/649)) ([976353a](https://github.com/phrase/strings-openapi/commit/976353aa639310dd8bad45cc090aff4768b520f1))
 
-## [2.26.0](https://github.com/phrase/openapi/compare/cli-v2.25.0...cli-v2.26.0) (2024-04-23)
+## [2.30.0](https://github.com/phrase/strings-openapi/compare/cli-v2.29.0...cli-v2.30.0) (2024-07-02)
+
+
+### Features
+
+* add repo sync events show endpoint ([#641](https://github.com/phrase/strings-openapi/issues/641)) ([e1d9cfb](https://github.com/phrase/strings-openapi/commit/e1d9cfb23e079fea2d9e5475dff9a4137f1f0154))
+
+## [2.29.0](https://github.com/phrase/strings-openapi/compare/cli-v2.28.1...cli-v2.29.0) (2024-06-25)
+
+
+### Features
+
+* **API:** Async downloads [TSI-2515] ([#642](https://github.com/phrase/strings-openapi/issues/642)) ([6fcab5d](https://github.com/phrase/strings-openapi/commit/6fcab5d4719f64e8e5dd49c327dc9348b384de4c))
+
+## [2.28.1](https://github.com/phrase/strings-openapi/compare/cli-v2.28.0...cli-v2.28.1) (2024-06-18)
 
 
 ### Bug Fixes
 
-* add missing required params ([#571](https://github.com/phrase/openapi/issues/571))
+* add app_min_version and app_max_version param to releases ([#633](https://github.com/phrase/strings-openapi/issues/633)) ([b384301](https://github.com/phrase/strings-openapi/commit/b3843012460ace4c1d34c4373e5158595466adcb))
+
+## [2.28.0](https://github.com/phrase/strings-openapi/compare/cli-v2.27.1...cli-v2.28.0) (2024-06-12)
+
+
+### Features
+
+* **API:** Add OTA Release Triggers API [TSI-2485] ([#622](https://github.com/phrase/strings-openapi/issues/622)) ([8cb91dc](https://github.com/phrase/strings-openapi/commit/8cb91dcce2c19ca700cf9d0713fa74f28ad59434))
+
+## [2.27.1](https://github.com/phrase/strings-openapi/compare/cli-v2.27.0...cli-v2.27.1) (2024-05-31)
+
+
+### Bug Fixes
+
+* **CLI:** use id instead of repo_sync_id as param ([#618](https://github.com/phrase/strings-openapi/issues/618)) ([7a1a0d9](https://github.com/phrase/strings-openapi/commit/7a1a0d9115262dc7fa3065ee7cc76bec7a381ddb))
+* **PHP:** Fix deserializing custom metadata values in key response ([#607](https://github.com/phrase/strings-openapi/issues/607)) ([b6eeeba](https://github.com/phrase/strings-openapi/commit/b6eeeba223e3eabec268a8f3d372afcb6abd09dd))
+
+## [2.27.0](https://github.com/phrase/strings-openapi/compare/cli-v2.26.0...cli-v2.27.0) (2024-04-29)
+
+
+### Features
+
+* **API:** Add 'update_translation_keys' for Uploads [TSI-2292] ([#578](https://github.com/phrase/strings-openapi/issues/578)) ([4492ec0](https://github.com/phrase/strings-openapi/commit/4492ec0a7c62f9de9ab1c1125071615bddcc26ce))
+
+## [2.26.0](https://github.com/phrase/strings-openapi/compare/cli-v2.25.0...cli-v2.26.0) (2024-04-23)
+
+
+### Bug Fixes
+
+* add missing required params ([#571](https://github.com/phrase/strings-openapi/issues/571))
 
 ### Code Refactoring
 
-* add missing required params ([#571](https://github.com/phrase/openapi/issues/571)) ([d810e9e](https://github.com/phrase/openapi/commit/d810e9ebc767e14ba9e56106de8c5774d9d6d178))
+* add missing required params ([#571](https://github.com/phrase/strings-openapi/issues/571)) ([d810e9e](https://github.com/phrase/strings-openapi/commit/d810e9ebc767e14ba9e56106de8c5774d9d6d178))
 
-## [2.25.0](https://github.com/phrase/openapi/compare/cli-v2.24.0...cli-v2.25.0) (2024-04-22)
-
-
-### Features
-
-* Add linked-parent to translation details ([#570](https://github.com/phrase/openapi/issues/570)) ([2c6f432](https://github.com/phrase/openapi/commit/2c6f43253e24b670b71ac810c85dce0759c29403))
-
-## [2.24.0](https://github.com/phrase/openapi/compare/cli-v2.23.2...cli-v2.24.0) (2024-04-17)
+## [2.25.0](https://github.com/phrase/strings-openapi/compare/cli-v2.24.0...cli-v2.25.0) (2024-04-22)
 
 
 ### Features
 
-* **API:** Add Repo Sync [TSI-1923] ([#569](https://github.com/phrase/openapi/issues/569)) ([0bd1756](https://github.com/phrase/openapi/commit/0bd17562018cb045ff41cc1ff5008b9419a0ed12))
+* Add linked-parent to translation details ([#570](https://github.com/phrase/strings-openapi/issues/570)) ([2c6f432](https://github.com/phrase/strings-openapi/commit/2c6f43253e24b670b71ac810c85dce0759c29403))
 
-## [2.23.2](https://github.com/phrase/openapi/compare/cli-v2.23.1...cli-v2.23.2) (2024-04-10)
+## [2.24.0](https://github.com/phrase/strings-openapi/compare/cli-v2.23.2...cli-v2.24.0) (2024-04-17)
+
+
+### Features
+
+* **API:** Add Repo Sync [TSI-1923] ([#569](https://github.com/phrase/strings-openapi/issues/569)) ([0bd1756](https://github.com/phrase/strings-openapi/commit/0bd17562018cb045ff41cc1ff5008b9419a0ed12))
+
+## [2.23.2](https://github.com/phrase/strings-openapi/compare/cli-v2.23.1...cli-v2.23.2) (2024-04-10)
 
 
 ### Bug Fixes
 
-* **CLI:** Update protobuf library ([#567](https://github.com/phrase/openapi/issues/567)) ([a19bb4b](https://github.com/phrase/openapi/commit/a19bb4ba90a994d32e55206bcde4eba72d2eec6a))
+* **CLI:** Update protobuf library ([#567](https://github.com/phrase/strings-openapi/issues/567)) ([a19bb4b](https://github.com/phrase/strings-openapi/commit/a19bb4ba90a994d32e55206bcde4eba72d2eec6a))
 
-## [2.23.1](https://github.com/phrase/openapi/compare/cli-v2.23.0...cli-v2.23.1) (2024-04-04)
-
-
-### Bug Fixes
-
-* (API) Add mandatory params to linked keys endpoints ([#564](https://github.com/phrase/openapi/issues/564)) ([08d9846](https://github.com/phrase/openapi/commit/08d9846bc224d349e2ade9abf28d733afb1e8be3))
-
-## [2.23.0](https://github.com/phrase/openapi/compare/cli-v2.22.0...cli-v2.23.0) (2024-04-03)
-
-
-### Features
-
-* **API:** add Linked Keys endpoints ([#555](https://github.com/phrase/openapi/issues/555)) ([4935dac](https://github.com/phrase/openapi/commit/4935dac58c787eaade2f1f65ce649f466b5e3a60))
-
-## [2.22.0](https://github.com/phrase/openapi/compare/cli-v2.21.2...cli-v2.22.0) (2024-02-08)
-
-
-### Features
-
-* add query param for properties ([#542](https://github.com/phrase/openapi/issues/542)) ([b4e12d0](https://github.com/phrase/openapi/commit/b4e12d04fd2916351f9201e1e6de504143ecc9aa))
-
-## [2.21.2](https://github.com/phrase/openapi/compare/cli-v2.21.1...cli-v2.21.2) (2024-02-05)
+## [2.23.1](https://github.com/phrase/strings-openapi/compare/cli-v2.23.0...cli-v2.23.1) (2024-04-04)
 
 
 ### Bug Fixes
 
-* **API:** allow nullable value for job's due_date ([#534](https://github.com/phrase/openapi/issues/534)) ([38b51b5](https://github.com/phrase/openapi/commit/38b51b51095394f8ce769873140038abba628514))
+* (API) Add mandatory params to linked keys endpoints ([#564](https://github.com/phrase/strings-openapi/issues/564)) ([08d9846](https://github.com/phrase/strings-openapi/commit/08d9846bc224d349e2ade9abf28d733afb1e8be3))
 
-## [2.21.1](https://github.com/phrase/openapi/compare/cli-v2.21.0...cli-v2.21.1) (2024-02-01)
+## [2.23.0](https://github.com/phrase/strings-openapi/compare/cli-v2.22.0...cli-v2.23.0) (2024-04-03)
+
+
+### Features
+
+* **API:** add Linked Keys endpoints ([#555](https://github.com/phrase/strings-openapi/issues/555)) ([4935dac](https://github.com/phrase/strings-openapi/commit/4935dac58c787eaade2f1f65ce649f466b5e3a60))
+
+## [2.22.0](https://github.com/phrase/strings-openapi/compare/cli-v2.21.2...cli-v2.22.0) (2024-02-08)
+
+
+### Features
+
+* add query param for properties ([#542](https://github.com/phrase/strings-openapi/issues/542)) ([b4e12d0](https://github.com/phrase/strings-openapi/commit/b4e12d04fd2916351f9201e1e6de504143ecc9aa))
+
+## [2.21.2](https://github.com/phrase/strings-openapi/compare/cli-v2.21.1...cli-v2.21.2) (2024-02-05)
 
 
 ### Bug Fixes
 
-* **API:** Adjust documentation of QPS endpoint ([#525](https://github.com/phrase/openapi/issues/525)) ([4b4f1ac](https://github.com/phrase/openapi/commit/4b4f1acf28fbd13b3d16c37162cdccfa05c38ffa))
+* **API:** allow nullable value for job's due_date ([#534](https://github.com/phrase/strings-openapi/issues/534)) ([38b51b5](https://github.com/phrase/strings-openapi/commit/38b51b51095394f8ce769873140038abba628514))
 
-## [2.21.0](https://github.com/phrase/openapi/compare/cli-v2.20.0...cli-v2.21.0) (2024-01-17)
-
-
-### Features
-
-* **api:** Add QPS endpoint and documentation ([#521](https://github.com/phrase/openapi/issues/521)) ([d22c558](https://github.com/phrase/openapi/commit/d22c558adfbb7fcd13759e388c038744914e42fa))
-
-## [2.20.0](https://github.com/phrase/openapi/compare/cli-v2.19.3...cli-v2.20.0) (2024-01-10)
-
-
-### Features
-
-* **CLI:** Optional cleanup after push [TSI-2234] ([#518](https://github.com/phrase/openapi/issues/518)) ([f3730a1](https://github.com/phrase/openapi/commit/f3730a1ab8e1377aa5f4f2793b0bd72c3dab1664))
-
-## [2.19.3](https://github.com/phrase/openapi/compare/cli-v2.19.2...cli-v2.19.3) (2024-01-02)
+## [2.21.1](https://github.com/phrase/strings-openapi/compare/cli-v2.21.0...cli-v2.21.1) (2024-02-01)
 
 
 ### Bug Fixes
 
-* **CLI:** retrigger release for GO ([fca7edb](https://github.com/phrase/openapi/commit/fca7edb2bfecaeb2ed92c5f50acb8d820ef94cb0))
-* **GO:** fix type mismatch error ([fca7edb](https://github.com/phrase/openapi/commit/fca7edb2bfecaeb2ed92c5f50acb8d820ef94cb0))
-* **GO:** fix type mismatch for nested args ([#515](https://github.com/phrase/openapi/issues/515)) ([fca7edb](https://github.com/phrase/openapi/commit/fca7edb2bfecaeb2ed92c5f50acb8d820ef94cb0))
+* **API:** Adjust documentation of QPS endpoint ([#525](https://github.com/phrase/strings-openapi/issues/525)) ([4b4f1ac](https://github.com/phrase/strings-openapi/commit/4b4f1acf28fbd13b3d16c37162cdccfa05c38ffa))
 
-## [2.19.2](https://github.com/phrase/openapi/compare/cli-v2.19.1...cli-v2.19.2) (2024-01-02)
+## [2.21.0](https://github.com/phrase/strings-openapi/compare/cli-v2.20.0...cli-v2.21.0) (2024-01-17)
+
+
+### Features
+
+* **api:** Add QPS endpoint and documentation ([#521](https://github.com/phrase/strings-openapi/issues/521)) ([d22c558](https://github.com/phrase/strings-openapi/commit/d22c558adfbb7fcd13759e388c038744914e42fa))
+
+## [2.20.0](https://github.com/phrase/strings-openapi/compare/cli-v2.19.3...cli-v2.20.0) (2024-01-10)
+
+
+### Features
+
+* **CLI:** Optional cleanup after push [TSI-2234] ([#518](https://github.com/phrase/strings-openapi/issues/518)) ([f3730a1](https://github.com/phrase/strings-openapi/commit/f3730a1ab8e1377aa5f4f2793b0bd72c3dab1664))
+
+## [2.19.3](https://github.com/phrase/strings-openapi/compare/cli-v2.19.2...cli-v2.19.3) (2024-01-02)
 
 
 ### Bug Fixes
 
-* **API:** Create Custom Metadata endpoint fix [TSI-2222] ([#499](https://github.com/phrase/openapi/issues/499)) ([ce2ed94](https://github.com/phrase/openapi/commit/ce2ed9488e111fb5d9bc3810a78c47d23553c8b7))
+* **CLI:** retrigger release for GO ([fca7edb](https://github.com/phrase/strings-openapi/commit/fca7edb2bfecaeb2ed92c5f50acb8d820ef94cb0))
+* **GO:** fix type mismatch error ([fca7edb](https://github.com/phrase/strings-openapi/commit/fca7edb2bfecaeb2ed92c5f50acb8d820ef94cb0))
+* **GO:** fix type mismatch for nested args ([#515](https://github.com/phrase/strings-openapi/issues/515)) ([fca7edb](https://github.com/phrase/strings-openapi/commit/fca7edb2bfecaeb2ed92c5f50acb8d820ef94cb0))
 
-## [2.19.1](https://github.com/phrase/openapi/compare/cli-v2.19.0...cli-v2.19.1) (2023-12-21)
-
-
-### Bug Fixes
-
-* **CLI:** trigger new release ([#508](https://github.com/phrase/openapi/issues/508)) ([162eae3](https://github.com/phrase/openapi/commit/162eae3d941684e3708091ec7aeee816ca06e3d5))
-
-## [2.19.0](https://github.com/phrase/openapi/compare/cli-v2.18.0...cli-v2.19.0) (2023-12-15)
-
-
-### Features
-
-* **CLI:** Improve push error display [TSI-1736] ([#491](https://github.com/phrase/openapi/issues/491)) ([555c017](https://github.com/phrase/openapi/commit/555c01712eec53aaf25fbe075359c8411a64eb7c))
-
-## [2.18.0](https://github.com/phrase/openapi/compare/cli-v2.17.0...cli-v2.18.0) (2023-12-14)
-
-
-### Features
-
-* **CLI:** On push, print upload URL [TSI-1735] ([#485](https://github.com/phrase/openapi/issues/485)) ([cbdc8ed](https://github.com/phrase/openapi/commit/cbdc8ed12217cb775d41faa662b9890050ad5a4e))
-
-## [2.17.0](https://github.com/phrase/openapi/compare/cli-v2.16.0...cli-v2.17.0) (2023-12-13)
-
-
-### Features
-
-* **API:** add Custom Metadata endpoints ([#474](https://github.com/phrase/openapi/issues/474)) ([d407d8b](https://github.com/phrase/openapi/commit/d407d8be5ccddec1afde14a12804a7a616f77d7a))
-* **API:** Add custom_metadata_filters param to locale download endpoint [TSI-2174] ([#478](https://github.com/phrase/openapi/issues/478)) ([3623478](https://github.com/phrase/openapi/commit/3623478fc1518b457ab018b5630a693081637d6e))
-* **API:** Add url field to uploads ([#481](https://github.com/phrase/openapi/issues/481)) ([7332a84](https://github.com/phrase/openapi/commit/7332a84f9958346f2fb28dee4b0353519ef466d5))
+## [2.19.2](https://github.com/phrase/strings-openapi/compare/cli-v2.19.1...cli-v2.19.2) (2024-01-02)
 
 
 ### Bug Fixes
 
-* **CLI:** fix required parameter handling ([#488](https://github.com/phrase/openapi/issues/488)) ([3d0412d](https://github.com/phrase/openapi/commit/3d0412df3c40b19cf8b12d5105e730990fd137b5))
+* **API:** Create Custom Metadata endpoint fix [TSI-2222] ([#499](https://github.com/phrase/strings-openapi/issues/499)) ([ce2ed94](https://github.com/phrase/strings-openapi/commit/ce2ed9488e111fb5d9bc3810a78c47d23553c8b7))
 
-## [2.16.0](https://github.com/phrase/openapi/compare/cli-v2.15.0...cli-v2.16.0) (2023-11-28)
-
-
-### Features
-
-* Add reports locales endpoint to API [TSS-2439] ([#465](https://github.com/phrase/openapi/issues/465)) ([e03aa9f](https://github.com/phrase/openapi/commit/e03aa9f49f031517b36db715fe70e8e0b65a438b))
-
-## [2.15.0](https://github.com/phrase/openapi/compare/cli-v2.14.0...cli-v2.15.0) (2023-11-03)
-
-
-### Features
-
-* [TSI-2083] enable format_options argument for java-client   ([#426](https://github.com/phrase/openapi/issues/426)) ([faa8cb3](https://github.com/phrase/openapi/commit/faa8cb353ba9f1030b9f7cfd46b894b4d6d26e70))
-* **CLI:** On pull error, print the API response ([#463](https://github.com/phrase/openapi/issues/463)) ([b0b6ed1](https://github.com/phrase/openapi/commit/b0b6ed1b928f2c64fb618de76d88742e5f0cee8c))
-* Update openapi-generator to v7 ([#418](https://github.com/phrase/openapi/issues/418)) ([524626f](https://github.com/phrase/openapi/commit/524626f5e914bfef6025d0e1c2cbc7a728d08f56))
-
-## [2.14.0](https://github.com/phrase/openapi/compare/cli-v2.13.0...cli-v2.14.0) (2023-10-23)
-
-
-### Features
-
-* **API:** Add order param to comment list endpoints ([#441](https://github.com/phrase/openapi/issues/441)) ([441c9c4](https://github.com/phrase/openapi/commit/441c9c46169f8c5ac4e71ade09a95dab136314ef))
-
-## [2.13.0](https://github.com/phrase/openapi/compare/cli-v2.12.0...cli-v2.13.0) (2023-10-13)
-
-
-### Features
-
-* **API:** Implement figma attachments endpoints ([#415](https://github.com/phrase/openapi/issues/415)) ([970e612](https://github.com/phrase/openapi/commit/970e612fda620ca882a221ef541036b8d200b675))
-
-## [2.12.0](https://github.com/phrase/openapi/compare/cli-v2.11.0...cli-v2.12.0) (2023-09-14)
-
-
-### Features
-
-* **CLI:** use phrase-go v2.14 ([#413](https://github.com/phrase/openapi/issues/413)) ([bf96057](https://github.com/phrase/openapi/commit/bf96057e8e0fffde405a65df5e2c993696080c58))
-* Optionally tag only affected keys on upload [TSI-2041] ([#412](https://github.com/phrase/openapi/issues/412)) ([e8f958e](https://github.com/phrase/openapi/commit/e8f958e91469c2542f44ab68469c933688958383))
-* **TSI-1946:** Add reviewed_at to translations ([#396](https://github.com/phrase/openapi/issues/396)) ([3e663d9](https://github.com/phrase/openapi/commit/3e663d971a99a816f0165dd6653a9a1e8a87c95e))
-
-## [2.11.0](https://github.com/phrase/openapi/compare/cli-v2.10.0...cli-v2.11.0) (2023-08-28)
-
-
-### Features
-
-* **API:** Document new query parameters ([#393](https://github.com/phrase/openapi/issues/393)) ([770515a](https://github.com/phrase/openapi/commit/770515a9628122955bb3919405babf9392684eb9))
-
-## [2.10.0](https://github.com/phrase/openapi/compare/cli-v2.9.1...cli-v2.10.0) (2023-08-24)
-
-
-### Features
-
-* **API:** Introduce comment replies endpoints ([#383](https://github.com/phrase/openapi/issues/383)) ([71351ac](https://github.com/phrase/openapi/commit/71351ac285f4f49976092e176c77b09f3485eb65))
-
-## [2.9.1](https://github.com/phrase/openapi/compare/cli-v2.9.0...cli-v2.9.1) (2023-08-24)
+## [2.19.1](https://github.com/phrase/strings-openapi/compare/cli-v2.19.0...cli-v2.19.1) (2023-12-21)
 
 
 ### Bug Fixes
 
-* **cli:** Bump go library version ([#384](https://github.com/phrase/openapi/issues/384)) ([ab2f655](https://github.com/phrase/openapi/commit/ab2f6556184bc7171c00c3f1b81908aec0e57a04))
+* **CLI:** trigger new release ([#508](https://github.com/phrase/strings-openapi/issues/508)) ([162eae3](https://github.com/phrase/strings-openapi/commit/162eae3d941684e3708091ec7aeee816ca06e3d5))
 
-## [2.9.0](https://github.com/phrase/openapi/compare/cli-v2.8.4...cli-v2.9.0) (2023-08-22)
+## [2.19.0](https://github.com/phrase/strings-openapi/compare/cli-v2.18.0...cli-v2.19.0) (2023-12-15)
 
 
 ### Features
 
-* **TSE-950:** Document comment_reactions endpoints ([#380](https://github.com/phrase/openapi/issues/380)) ([f230244](https://github.com/phrase/openapi/commit/f230244e6e9c069b18edc4c35dd5e290fd14793b))
+* **CLI:** Improve push error display [TSI-1736] ([#491](https://github.com/phrase/strings-openapi/issues/491)) ([555c017](https://github.com/phrase/strings-openapi/commit/555c01712eec53aaf25fbe075359c8411a64eb7c))
 
-## [2.8.4](https://github.com/phrase/openapi/compare/cli-v2.8.3...cli-v2.8.4) (2023-07-31)
+## [2.18.0](https://github.com/phrase/strings-openapi/compare/cli-v2.17.0...cli-v2.18.0) (2023-12-14)
+
+
+### Features
+
+* **CLI:** On push, print upload URL [TSI-1735] ([#485](https://github.com/phrase/strings-openapi/issues/485)) ([cbdc8ed](https://github.com/phrase/strings-openapi/commit/cbdc8ed12217cb775d41faa662b9890050ad5a4e))
+
+## [2.17.0](https://github.com/phrase/strings-openapi/compare/cli-v2.16.0...cli-v2.17.0) (2023-12-13)
+
+
+### Features
+
+* **API:** add Custom Metadata endpoints ([#474](https://github.com/phrase/strings-openapi/issues/474)) ([d407d8b](https://github.com/phrase/strings-openapi/commit/d407d8be5ccddec1afde14a12804a7a616f77d7a))
+* **API:** Add custom_metadata_filters param to locale download endpoint [TSI-2174] ([#478](https://github.com/phrase/strings-openapi/issues/478)) ([3623478](https://github.com/phrase/strings-openapi/commit/3623478fc1518b457ab018b5630a693081637d6e))
+* **API:** Add url field to uploads ([#481](https://github.com/phrase/strings-openapi/issues/481)) ([7332a84](https://github.com/phrase/strings-openapi/commit/7332a84f9958346f2fb28dee4b0353519ef466d5))
 
 
 ### Bug Fixes
 
-* **schemas:** Fix gitlab_sync type mismatch ([#373](https://github.com/phrase/openapi/issues/373)) ([1cb1f65](https://github.com/phrase/openapi/commit/1cb1f650598c68afee6e2cd7c3c4ede1484aba35))
+* **CLI:** fix required parameter handling ([#488](https://github.com/phrase/strings-openapi/issues/488)) ([3d0412d](https://github.com/phrase/strings-openapi/commit/3d0412df3c40b19cf8b12d5105e730990fd137b5))
 
-## [2.8.3](https://github.com/phrase/openapi/compare/cli-v2.8.2...cli-v2.8.3) (2023-07-28)
+## [2.16.0](https://github.com/phrase/strings-openapi/compare/cli-v2.15.0...cli-v2.16.0) (2023-11-28)
+
+
+### Features
+
+* Add reports locales endpoint to API [TSS-2439] ([#465](https://github.com/phrase/strings-openapi/issues/465)) ([e03aa9f](https://github.com/phrase/strings-openapi/commit/e03aa9f49f031517b36db715fe70e8e0b65a438b))
+
+## [2.15.0](https://github.com/phrase/strings-openapi/compare/cli-v2.14.0...cli-v2.15.0) (2023-11-03)
+
+
+### Features
+
+* [TSI-2083] enable format_options argument for java-client   ([#426](https://github.com/phrase/strings-openapi/issues/426)) ([faa8cb3](https://github.com/phrase/strings-openapi/commit/faa8cb353ba9f1030b9f7cfd46b894b4d6d26e70))
+* **CLI:** On pull error, print the API response ([#463](https://github.com/phrase/strings-openapi/issues/463)) ([b0b6ed1](https://github.com/phrase/strings-openapi/commit/b0b6ed1b928f2c64fb618de76d88742e5f0cee8c))
+* Update openapi-generator to v7 ([#418](https://github.com/phrase/strings-openapi/issues/418)) ([524626f](https://github.com/phrase/strings-openapi/commit/524626f5e914bfef6025d0e1c2cbc7a728d08f56))
+
+## [2.14.0](https://github.com/phrase/strings-openapi/compare/cli-v2.13.0...cli-v2.14.0) (2023-10-23)
+
+
+### Features
+
+* **API:** Add order param to comment list endpoints ([#441](https://github.com/phrase/strings-openapi/issues/441)) ([441c9c4](https://github.com/phrase/strings-openapi/commit/441c9c46169f8c5ac4e71ade09a95dab136314ef))
+
+## [2.13.0](https://github.com/phrase/strings-openapi/compare/cli-v2.12.0...cli-v2.13.0) (2023-10-13)
+
+
+### Features
+
+* **API:** Implement figma attachments endpoints ([#415](https://github.com/phrase/strings-openapi/issues/415)) ([970e612](https://github.com/phrase/strings-openapi/commit/970e612fda620ca882a221ef541036b8d200b675))
+
+## [2.12.0](https://github.com/phrase/strings-openapi/compare/cli-v2.11.0...cli-v2.12.0) (2023-09-14)
+
+
+### Features
+
+* **CLI:** use phrase-go v2.14 ([#413](https://github.com/phrase/strings-openapi/issues/413)) ([bf96057](https://github.com/phrase/strings-openapi/commit/bf96057e8e0fffde405a65df5e2c993696080c58))
+* Optionally tag only affected keys on upload [TSI-2041] ([#412](https://github.com/phrase/strings-openapi/issues/412)) ([e8f958e](https://github.com/phrase/strings-openapi/commit/e8f958e91469c2542f44ab68469c933688958383))
+* **TSI-1946:** Add reviewed_at to translations ([#396](https://github.com/phrase/strings-openapi/issues/396)) ([3e663d9](https://github.com/phrase/strings-openapi/commit/3e663d971a99a816f0165dd6653a9a1e8a87c95e))
+
+## [2.11.0](https://github.com/phrase/strings-openapi/compare/cli-v2.10.0...cli-v2.11.0) (2023-08-28)
+
+
+### Features
+
+* **API:** Document new query parameters ([#393](https://github.com/phrase/strings-openapi/issues/393)) ([770515a](https://github.com/phrase/strings-openapi/commit/770515a9628122955bb3919405babf9392684eb9))
+
+## [2.10.0](https://github.com/phrase/strings-openapi/compare/cli-v2.9.1...cli-v2.10.0) (2023-08-24)
+
+
+### Features
+
+* **API:** Introduce comment replies endpoints ([#383](https://github.com/phrase/strings-openapi/issues/383)) ([71351ac](https://github.com/phrase/strings-openapi/commit/71351ac285f4f49976092e176c77b09f3485eb65))
+
+## [2.9.1](https://github.com/phrase/strings-openapi/compare/cli-v2.9.0...cli-v2.9.1) (2023-08-24)
 
 
 ### Bug Fixes
 
-* Fix gitlab_sync history status type mismatch ([#363](https://github.com/phrase/openapi/issues/363)) ([ebcaa4e](https://github.com/phrase/openapi/commit/ebcaa4e5dfcb2f73559a56c78b0f2512ca798375))
+* **cli:** Bump go library version ([#384](https://github.com/phrase/strings-openapi/issues/384)) ([ab2f655](https://github.com/phrase/strings-openapi/commit/ab2f6556184bc7171c00c3f1b81908aec0e57a04))
+
+## [2.9.0](https://github.com/phrase/strings-openapi/compare/cli-v2.8.4...cli-v2.9.0) (2023-08-22)
+
+
+### Features
+
+* **TSE-950:** Document comment_reactions endpoints ([#380](https://github.com/phrase/strings-openapi/issues/380)) ([f230244](https://github.com/phrase/strings-openapi/commit/f230244e6e9c069b18edc4c35dd5e290fd14793b))
+
+## [2.8.4](https://github.com/phrase/strings-openapi/compare/cli-v2.8.3...cli-v2.8.4) (2023-07-31)
+
+
+### Bug Fixes
+
+* **schemas:** Fix gitlab_sync type mismatch ([#373](https://github.com/phrase/strings-openapi/issues/373)) ([1cb1f65](https://github.com/phrase/strings-openapi/commit/1cb1f650598c68afee6e2cd7c3c4ede1484aba35))
+
+## [2.8.3](https://github.com/phrase/strings-openapi/compare/cli-v2.8.2...cli-v2.8.3) (2023-07-28)
+
+
+### Bug Fixes
+
+* Fix gitlab_sync history status type mismatch ([#363](https://github.com/phrase/strings-openapi/issues/363)) ([ebcaa4e](https://github.com/phrase/strings-openapi/commit/ebcaa4e5dfcb2f73559a56c78b0f2512ca798375))

--- a/clients/java/CHANGELOG.md
+++ b/clients/java/CHANGELOG.md
@@ -7,452 +7,452 @@
 
 * **API:** Add linked_translation to translation type ([#1005](https://github.com/phrase/strings-openapi/issues/1005)) ([b18e64c](https://github.com/phrase/strings-openapi/commit/b18e64c948d40a9e5f996e8fdf6dee07d1812b02))
 
-## [3.15.0](https://github.com/phrase/openapi/compare/java-v3.14.0...java-v3.15.0) (2026-01-09)
+## [3.15.0](https://github.com/phrase/strings-openapi/compare/java-v3.14.0...java-v3.15.0) (2026-01-09)
 
 
 ### Features
 
-* **API:** Add missing project flags to project details schema #SCD-141 ([#993](https://github.com/phrase/openapi/issues/993)) ([93fbdd7](https://github.com/phrase/openapi/commit/93fbdd76150ed94374ef888ac92c0c9b626de7c8))
+* **API:** Add missing project flags to project details schema #SCD-141 ([#993](https://github.com/phrase/strings-openapi/issues/993)) ([93fbdd7](https://github.com/phrase/strings-openapi/commit/93fbdd76150ed94374ef888ac92c0c9b626de7c8))
 
 
 ### Bug Fixes
 
-* **API:** drop invalid account locale params ([#992](https://github.com/phrase/openapi/issues/992)) ([87af83c](https://github.com/phrase/openapi/commit/87af83c94fd7e47340b5393847e93a31127abbe8))
+* **API:** drop invalid account locale params ([#992](https://github.com/phrase/strings-openapi/issues/992)) ([87af83c](https://github.com/phrase/strings-openapi/commit/87af83c94fd7e47340b5393847e93a31127abbe8))
 
-## [3.14.0](https://github.com/phrase/openapi/compare/java-v3.13.1...java-v3.14.0) (2025-12-11)
+## [3.14.0](https://github.com/phrase/strings-openapi/compare/java-v3.13.1...java-v3.14.0) (2025-12-11)
 
 
 ### Features
 
-* **API:** Add create comparison endpoint for branches [SCD-549] ([#966](https://github.com/phrase/openapi/issues/966)) ([4099e32](https://github.com/phrase/openapi/commit/4099e32d42744f9d73346077ef30b0f4bd5c849e))
-* **API:** add manual triggering of automations #SCM-953 ([#968](https://github.com/phrase/openapi/issues/968)) ([ebe1c68](https://github.com/phrase/openapi/commit/ebe1c68e472d87ea6c6cd2f76bb421406c30a274))
-* **API:** add use_locale_fallback option to download #SCD-620 ([#976](https://github.com/phrase/openapi/issues/976)) ([9266c68](https://github.com/phrase/openapi/commit/9266c680d8717bb736aed83625858f0b3419da54))
+* **API:** Add create comparison endpoint for branches [SCD-549] ([#966](https://github.com/phrase/strings-openapi/issues/966)) ([4099e32](https://github.com/phrase/strings-openapi/commit/4099e32d42744f9d73346077ef30b0f4bd5c849e))
+* **API:** add manual triggering of automations #SCM-953 ([#968](https://github.com/phrase/strings-openapi/issues/968)) ([ebe1c68](https://github.com/phrase/strings-openapi/commit/ebe1c68e472d87ea6c6cd2f76bb421406c30a274))
+* **API:** add use_locale_fallback option to download #SCD-620 ([#976](https://github.com/phrase/strings-openapi/issues/976)) ([9266c68](https://github.com/phrase/strings-openapi/commit/9266c680d8717bb736aed83625858f0b3419da54))
 
-## [3.13.1](https://github.com/phrase/openapi/compare/java-v3.13.0...java-v3.13.1) (2025-11-10)
+## [3.13.1](https://github.com/phrase/strings-openapi/compare/java-v3.13.0...java-v3.13.1) (2025-11-10)
 
 
 ### Bug Fixes
 
-* **API:** Add omit_translation_keys to Jobs#show endpoint ([#957](https://github.com/phrase/openapi/issues/957)) ([23ece66](https://github.com/phrase/openapi/commit/23ece66b05fc748a4598ce876cb2954ed1a385cc))
+* **API:** Add omit_translation_keys to Jobs#show endpoint ([#957](https://github.com/phrase/strings-openapi/issues/957)) ([23ece66](https://github.com/phrase/strings-openapi/commit/23ece66b05fc748a4598ce876cb2954ed1a385cc))
 
-## [3.13.0](https://github.com/phrase/openapi/compare/java-v3.12.0...java-v3.13.0) (2025-10-27)
-
-
-### Features
-
-* **API:** Support omit_translation_keys param in Jobs#show ([#944](https://github.com/phrase/openapi/issues/944)) ([690a2ce](https://github.com/phrase/openapi/commit/690a2ce992359e7920367699145d2d4ff3a206fa))
-
-## [3.12.0](https://github.com/phrase/openapi/compare/java-v3.11.0...java-v3.12.0) (2025-10-23)
+## [3.13.0](https://github.com/phrase/strings-openapi/compare/java-v3.12.0...java-v3.13.0) (2025-10-27)
 
 
 ### Features
 
-* **API:** Support source_locale_id param in uploads ([#935](https://github.com/phrase/openapi/issues/935)) ([304a406](https://github.com/phrase/openapi/commit/304a4061aaac8001a3a9e10c5cf985b04c31dab2))
+* **API:** Support omit_translation_keys param in Jobs#show ([#944](https://github.com/phrase/strings-openapi/issues/944)) ([690a2ce](https://github.com/phrase/strings-openapi/commit/690a2ce992359e7920367699145d2d4ff3a206fa))
 
-## [3.11.0](https://github.com/phrase/openapi/compare/java-v3.10.0...java-v3.11.0) (2025-10-16)
-
-
-### Features
-
-* List child branches ([#926](https://github.com/phrase/openapi/issues/926)) ([31d3b57](https://github.com/phrase/openapi/commit/31d3b57e0d1381149409b77c3e236b226cde22a1))
-
-## [3.10.0](https://github.com/phrase/openapi/compare/java-v3.9.0...java-v3.10.0) (2025-10-01)
+## [3.12.0](https://github.com/phrase/strings-openapi/compare/java-v3.11.0...java-v3.12.0) (2025-10-23)
 
 
 ### Features
 
-* add branch sync endpoint ([#912](https://github.com/phrase/openapi/issues/912)) ([3293917](https://github.com/phrase/openapi/commit/329391757b3f81574448b1b87506b85bfdeb6761))
+* **API:** Support source_locale_id param in uploads ([#935](https://github.com/phrase/strings-openapi/issues/935)) ([304a406](https://github.com/phrase/strings-openapi/commit/304a4061aaac8001a3a9e10c5cf985b04c31dab2))
 
-## [3.9.0](https://github.com/phrase/openapi/compare/java-v3.8.0...java-v3.9.0) (2025-09-30)
-
-
-### Features
-
-* **SCM-732:** expose Automation API ([#910](https://github.com/phrase/openapi/issues/910)) ([6eea53d](https://github.com/phrase/openapi/commit/6eea53d06aca8f43623ba90e2e0a8cd6761c9a13))
-
-## [3.8.0](https://github.com/phrase/openapi/compare/java-v3.7.0...java-v3.8.0) (2025-09-15)
+## [3.11.0](https://github.com/phrase/strings-openapi/compare/java-v3.10.0...java-v3.11.0) (2025-10-16)
 
 
 ### Features
 
-* **API:** Add "reviewed" param for tanslations#update ([#891](https://github.com/phrase/openapi/issues/891)) ([3f77286](https://github.com/phrase/openapi/commit/3f7728669fa68d5911dfca39a9e39c24cd20c0a4))
+* List child branches ([#926](https://github.com/phrase/strings-openapi/issues/926)) ([31d3b57](https://github.com/phrase/strings-openapi/commit/31d3b57e0d1381149409b77c3e236b226cde22a1))
 
-## [3.7.0](https://github.com/phrase/openapi/compare/java-v3.6.0...java-v3.7.0) (2025-08-01)
-
-
-### Features
-
-* **API:** Add support for `update_custom_metadata` option on upload ([#882](https://github.com/phrase/openapi/issues/882)) ([5b486ea](https://github.com/phrase/openapi/commit/5b486eabf30c84402a8e31911a5ba6fe3b343a89))
-
-## [3.6.0](https://github.com/phrase/openapi/compare/java-v3.5.0...java-v3.6.0) (2025-07-24)
+## [3.10.0](https://github.com/phrase/strings-openapi/compare/java-v3.9.0...java-v3.10.0) (2025-10-01)
 
 
 ### Features
 
-* **API:** Job and job locale annotations #SCD-145 ([#867](https://github.com/phrase/openapi/issues/867)) ([95b6c2a](https://github.com/phrase/openapi/commit/95b6c2a2ab798d01f9bc0d53a22dbf817a5eb0ee))
+* add branch sync endpoint ([#912](https://github.com/phrase/strings-openapi/issues/912)) ([3293917](https://github.com/phrase/strings-openapi/commit/329391757b3f81574448b1b87506b85bfdeb6761))
 
-## [3.5.0](https://github.com/phrase/openapi/compare/java-v3.4.0...java-v3.5.0) (2025-07-18)
-
-
-### Features
-
-* **API:** add updated_since param for downloads ([#858](https://github.com/phrase/openapi/issues/858)) ([db4196b](https://github.com/phrase/openapi/commit/db4196bfb1a45f628577bebb99aad7da1179c241))
-* **API:** Add use_ordinal_rules attribute to request body for create/update Keys endpoints ([#868](https://github.com/phrase/openapi/issues/868)) ([29410b5](https://github.com/phrase/openapi/commit/29410b5d4edee9645f449d2d7de53fb953c1f0c2))
-* **API:** Add use_ordinal_rules boolean [STRINGS-2273] ([#846](https://github.com/phrase/openapi/issues/846)) ([450ce0c](https://github.com/phrase/openapi/commit/450ce0cce6bb2064758c44b130b39dd5539c2681))
-
-## [3.4.0](https://github.com/phrase/openapi/compare/java-v3.3.0...java-v3.4.0) (2025-05-23)
+## [3.9.0](https://github.com/phrase/strings-openapi/compare/java-v3.8.0...java-v3.9.0) (2025-09-30)
 
 
 ### Features
 
-* **API:** Add omit_statistics param to tags#show ([#834](https://github.com/phrase/openapi/issues/834)) ([2058b18](https://github.com/phrase/openapi/commit/2058b18297133075885ac99770aee2e171811cd6))
+* **SCM-732:** expose Automation API ([#910](https://github.com/phrase/strings-openapi/issues/910)) ([6eea53d](https://github.com/phrase/strings-openapi/commit/6eea53d06aca8f43623ba90e2e0a8cd6761c9a13))
 
-## [3.3.0](https://github.com/phrase/openapi/compare/java-v3.2.0...java-v3.3.0) (2025-05-16)
+## [3.8.0](https://github.com/phrase/strings-openapi/compare/java-v3.7.0...java-v3.8.0) (2025-09-15)
 
 
 ### Features
 
-* **API:** Add "verify_mentioned_translations" parameter to uploads ([#830](https://github.com/phrase/openapi/issues/830)) ([f2fdf60](https://github.com/phrase/openapi/commit/f2fdf60dd97c3908293cd457a765dafde603bd9b))
-* **API:** Add processed & upload total translations on upload summary ([#824](https://github.com/phrase/openapi/issues/824)) ([081db68](https://github.com/phrase/openapi/commit/081db68d2ffcf5d66a81e07eec0a9572a1f9d633))
-* **API:** add updated_since filter to job list #STRINGS-1555 ([#799](https://github.com/phrase/openapi/issues/799)) ([dc9b6ed](https://github.com/phrase/openapi/commit/dc9b6ed12e013231d397820449086c87fea2f8ba))
-* **API:** Include roles in account response ([#811](https://github.com/phrase/openapi/issues/811)) ([dc27ee5](https://github.com/phrase/openapi/commit/dc27ee5117762222b6e1e6abb639f8e00c6a9101))
-* **API:** Translations unreview & batch unreview ([#831](https://github.com/phrase/openapi/issues/831)) ([6a696db](https://github.com/phrase/openapi/commit/6a696db00d80d8acaf5887a08a7a97997566eb8f))
+* **API:** Add "reviewed" param for tanslations#update ([#891](https://github.com/phrase/strings-openapi/issues/891)) ([3f77286](https://github.com/phrase/strings-openapi/commit/3f7728669fa68d5911dfca39a9e39c24cd20c0a4))
+
+## [3.7.0](https://github.com/phrase/strings-openapi/compare/java-v3.6.0...java-v3.7.0) (2025-08-01)
+
+
+### Features
+
+* **API:** Add support for `update_custom_metadata` option on upload ([#882](https://github.com/phrase/strings-openapi/issues/882)) ([5b486ea](https://github.com/phrase/strings-openapi/commit/5b486eabf30c84402a8e31911a5ba6fe3b343a89))
+
+## [3.6.0](https://github.com/phrase/strings-openapi/compare/java-v3.5.0...java-v3.6.0) (2025-07-24)
+
+
+### Features
+
+* **API:** Job and job locale annotations #SCD-145 ([#867](https://github.com/phrase/strings-openapi/issues/867)) ([95b6c2a](https://github.com/phrase/strings-openapi/commit/95b6c2a2ab798d01f9bc0d53a22dbf817a5eb0ee))
+
+## [3.5.0](https://github.com/phrase/strings-openapi/compare/java-v3.4.0...java-v3.5.0) (2025-07-18)
+
+
+### Features
+
+* **API:** add updated_since param for downloads ([#858](https://github.com/phrase/strings-openapi/issues/858)) ([db4196b](https://github.com/phrase/strings-openapi/commit/db4196bfb1a45f628577bebb99aad7da1179c241))
+* **API:** Add use_ordinal_rules attribute to request body for create/update Keys endpoints ([#868](https://github.com/phrase/strings-openapi/issues/868)) ([29410b5](https://github.com/phrase/strings-openapi/commit/29410b5d4edee9645f449d2d7de53fb953c1f0c2))
+* **API:** Add use_ordinal_rules boolean [STRINGS-2273] ([#846](https://github.com/phrase/strings-openapi/issues/846)) ([450ce0c](https://github.com/phrase/strings-openapi/commit/450ce0cce6bb2064758c44b130b39dd5539c2681))
+
+## [3.4.0](https://github.com/phrase/strings-openapi/compare/java-v3.3.0...java-v3.4.0) (2025-05-23)
+
+
+### Features
+
+* **API:** Add omit_statistics param to tags#show ([#834](https://github.com/phrase/strings-openapi/issues/834)) ([2058b18](https://github.com/phrase/strings-openapi/commit/2058b18297133075885ac99770aee2e171811cd6))
+
+## [3.3.0](https://github.com/phrase/strings-openapi/compare/java-v3.2.0...java-v3.3.0) (2025-05-16)
+
+
+### Features
+
+* **API:** Add "verify_mentioned_translations" parameter to uploads ([#830](https://github.com/phrase/strings-openapi/issues/830)) ([f2fdf60](https://github.com/phrase/strings-openapi/commit/f2fdf60dd97c3908293cd457a765dafde603bd9b))
+* **API:** Add processed & upload total translations on upload summary ([#824](https://github.com/phrase/strings-openapi/issues/824)) ([081db68](https://github.com/phrase/strings-openapi/commit/081db68d2ffcf5d66a81e07eec0a9572a1f9d633))
+* **API:** add updated_since filter to job list #STRINGS-1555 ([#799](https://github.com/phrase/strings-openapi/issues/799)) ([dc9b6ed](https://github.com/phrase/strings-openapi/commit/dc9b6ed12e013231d397820449086c87fea2f8ba))
+* **API:** Include roles in account response ([#811](https://github.com/phrase/strings-openapi/issues/811)) ([dc27ee5](https://github.com/phrase/strings-openapi/commit/dc27ee5117762222b6e1e6abb639f8e00c6a9101))
+* **API:** Translations unreview & batch unreview ([#831](https://github.com/phrase/strings-openapi/issues/831)) ([6a696db](https://github.com/phrase/strings-openapi/commit/6a696db00d80d8acaf5887a08a7a97997566eb8f))
 
 
 ### Bug Fixes
 
-* **API:** Remove request body from GET comments ([#817](https://github.com/phrase/openapi/issues/817)) ([2646001](https://github.com/phrase/openapi/commit/264600132e80ac03983e0ae86e99db3d6fb9080d))
+* **API:** Remove request body from GET comments ([#817](https://github.com/phrase/strings-openapi/issues/817)) ([2646001](https://github.com/phrase/strings-openapi/commit/264600132e80ac03983e0ae86e99db3d6fb9080d))
 
-## [3.2.0](https://github.com/phrase/openapi/compare/java-v3.1.0...java-v3.2.0) (2025-02-17)
-
-
-### Features
-
-* **API:** document tags attribute of an upload #STRINGS-1221 ([#790](https://github.com/phrase/openapi/issues/790)) ([fff505b](https://github.com/phrase/openapi/commit/fff505bdff35a0033fee06e505c42fe794c88562))
-
-## [3.1.0](https://github.com/phrase/openapi/compare/java-v3.0.3...java-v3.1.0) (2025-02-17)
+## [3.2.0](https://github.com/phrase/strings-openapi/compare/java-v3.1.0...java-v3.2.0) (2025-02-17)
 
 
 ### Features
 
-* **API:** Add locale_ids param to synchronous download endpoint [STRINGS-1492] ([#780](https://github.com/phrase/openapi/issues/780)) ([47186a4](https://github.com/phrase/openapi/commit/47186a44fc8c0b8e466636acf3d49413b1f29f30))
-* **API:** Add source last updated at information on job details ([#777](https://github.com/phrase/openapi/issues/777)) ([c9b8423](https://github.com/phrase/openapi/commit/c9b8423766b4138980d0553502b3e18ca524f34e))
+* **API:** document tags attribute of an upload #STRINGS-1221 ([#790](https://github.com/phrase/strings-openapi/issues/790)) ([fff505b](https://github.com/phrase/strings-openapi/commit/fff505bdff35a0033fee06e505c42fe794c88562))
 
-## [3.0.3](https://github.com/phrase/openapi/compare/java-v3.0.2...java-v3.0.3) (2025-01-29)
-
-
-### Bug Fixes
-
-* **API:** pass translation_key_ids when removing keys from job ([#771](https://github.com/phrase/openapi/issues/771)) ([f670e27](https://github.com/phrase/openapi/commit/f670e2763b1112fefd1812109b3c09def42b7bd2))
-
-## [3.0.2](https://github.com/phrase/openapi/compare/java-v3.0.1...java-v3.0.2) (2025-01-06)
+## [3.1.0](https://github.com/phrase/strings-openapi/compare/java-v3.0.3...java-v3.1.0) (2025-02-17)
 
 
-### Bug Fixes
+### Features
 
-* **CLI:** Adjust operationId for quality_performance_score #STRINGS-1104 ([#721](https://github.com/phrase/openapi/issues/721)) ([7aa3b9b](https://github.com/phrase/openapi/commit/7aa3b9b508d1d24a4af7f4977b1a2fead8bfda78))
+* **API:** Add locale_ids param to synchronous download endpoint [STRINGS-1492] ([#780](https://github.com/phrase/strings-openapi/issues/780)) ([47186a4](https://github.com/phrase/strings-openapi/commit/47186a44fc8c0b8e466636acf3d49413b1f29f30))
+* **API:** Add source last updated at information on job details ([#777](https://github.com/phrase/strings-openapi/issues/777)) ([c9b8423](https://github.com/phrase/strings-openapi/commit/c9b8423766b4138980d0553502b3e18ca524f34e))
 
-## [3.0.1](https://github.com/phrase/openapi/compare/java-v3.0.0...java-v3.0.1) (2024-12-20)
+## [3.0.3](https://github.com/phrase/strings-openapi/compare/java-v3.0.2...java-v3.0.3) (2025-01-29)
 
 
 ### Bug Fixes
 
-* **API:** Repo Sync Event errors field type #STRINGS-1074 ([#756](https://github.com/phrase/openapi/issues/756)) ([c7670e0](https://github.com/phrase/openapi/commit/c7670e04810f95359d72ba6346b5f626bfb77b6f))
-* **API:** Repo Sync schema fixes #STRINGS-1074 ([#748](https://github.com/phrase/openapi/issues/748)) ([033be10](https://github.com/phrase/openapi/commit/033be1003fe01b5115de1f8ba2336d32b4862bfd))
+* **API:** pass translation_key_ids when removing keys from job ([#771](https://github.com/phrase/strings-openapi/issues/771)) ([f670e27](https://github.com/phrase/strings-openapi/commit/f670e2763b1112fefd1812109b3c09def42b7bd2))
 
-## [3.0.0](https://github.com/phrase/openapi/compare/java-v2.7.0...java-v3.0.0) (2024-12-18)
+## [3.0.2](https://github.com/phrase/strings-openapi/compare/java-v3.0.1...java-v3.0.2) (2025-01-06)
+
+
+### Bug Fixes
+
+* **CLI:** Adjust operationId for quality_performance_score #STRINGS-1104 ([#721](https://github.com/phrase/strings-openapi/issues/721)) ([7aa3b9b](https://github.com/phrase/strings-openapi/commit/7aa3b9b508d1d24a4af7f4977b1a2fead8bfda78))
+
+## [3.0.1](https://github.com/phrase/strings-openapi/compare/java-v3.0.0...java-v3.0.1) (2024-12-20)
+
+
+### Bug Fixes
+
+* **API:** Repo Sync Event errors field type #STRINGS-1074 ([#756](https://github.com/phrase/strings-openapi/issues/756)) ([c7670e0](https://github.com/phrase/strings-openapi/commit/c7670e04810f95359d72ba6346b5f626bfb77b6f))
+* **API:** Repo Sync schema fixes #STRINGS-1074 ([#748](https://github.com/phrase/strings-openapi/issues/748)) ([033be10](https://github.com/phrase/strings-openapi/commit/033be1003fe01b5115de1f8ba2336d32b4862bfd))
+
+## [3.0.0](https://github.com/phrase/strings-openapi/compare/java-v2.7.0...java-v3.0.0) (2024-12-18)
 
 
 ### ⚠ BREAKING CHANGES
 
-* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/openapi/issues/735))
+* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/strings-openapi/issues/735))
 
 ### Features
 
-* **API:** Add 'default_encoding' documentation ([#733](https://github.com/phrase/openapi/issues/733)) ([0139c51](https://github.com/phrase/openapi/commit/0139c51da747fbe7bc9929bcf3534aad7f22f39a))
-* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/openapi/issues/735)) ([c3bd8ec](https://github.com/phrase/openapi/commit/c3bd8eccaabcfa1b1066ea4438971ac59833af46))
+* **API:** Add 'default_encoding' documentation ([#733](https://github.com/phrase/strings-openapi/issues/733)) ([0139c51](https://github.com/phrase/strings-openapi/commit/0139c51da747fbe7bc9929bcf3534aad7f22f39a))
+* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/strings-openapi/issues/735)) ([c3bd8ec](https://github.com/phrase/strings-openapi/commit/c3bd8eccaabcfa1b1066ea4438971ac59833af46))
 
 
 ### Bug Fixes
 
-* **API:** Add missing branch parameter to job comment endpoints #STRINGS-988 ([#724](https://github.com/phrase/openapi/issues/724)) ([64d399c](https://github.com/phrase/openapi/commit/64d399ced0980ac2a48366f91110047287a0c590))
+* **API:** Add missing branch parameter to job comment endpoints #STRINGS-988 ([#724](https://github.com/phrase/strings-openapi/issues/724)) ([64d399c](https://github.com/phrase/strings-openapi/commit/64d399ced0980ac2a48366f91110047287a0c590))
 
-## [2.7.0](https://github.com/phrase/openapi/compare/java-v2.6.0...java-v2.7.0) (2024-11-27)
-
-
-### Features
-
-* **API:** autotranslate param in key creation [STRINGS-786] ([#713](https://github.com/phrase/openapi/issues/713)) ([581d0ff](https://github.com/phrase/openapi/commit/581d0ff5f1d06757e5ddd9603b78fc8d435d68ee))
-
-
-### Bug Fixes
-
-* **API:** Comment creation schema fix #STRINGS-866 ([#718](https://github.com/phrase/openapi/issues/718)) ([e201d13](https://github.com/phrase/openapi/commit/e201d1360c89698dd8d3642cc28f89dd0e50a1fb))
-
-## [2.6.0](https://github.com/phrase/openapi/compare/java-v2.5.0...java-v2.6.0) (2024-11-08)
+## [2.7.0](https://github.com/phrase/strings-openapi/compare/java-v2.6.0...java-v2.7.0) (2024-11-27)
 
 
 ### Features
 
-* **API:** Add Pagination header to POST search endpoints [[#457](https://github.com/phrase/openapi/issues/457)] ([#706](https://github.com/phrase/openapi/issues/706)) ([9a79fa3](https://github.com/phrase/openapi/commit/9a79fa31bb3b9d58272fa2f4e82d72d0d44a93a0))
+* **API:** autotranslate param in key creation [STRINGS-786] ([#713](https://github.com/phrase/strings-openapi/issues/713)) ([581d0ff](https://github.com/phrase/strings-openapi/commit/581d0ff5f1d06757e5ddd9603b78fc8d435d68ee))
 
-## [2.5.0](https://github.com/phrase/openapi/compare/java-v2.4.1...java-v2.5.0) (2024-10-02)
+
+### Bug Fixes
+
+* **API:** Comment creation schema fix #STRINGS-866 ([#718](https://github.com/phrase/strings-openapi/issues/718)) ([e201d13](https://github.com/phrase/strings-openapi/commit/e201d1360c89698dd8d3642cc28f89dd0e50a1fb))
+
+## [2.6.0](https://github.com/phrase/strings-openapi/compare/java-v2.5.0...java-v2.6.0) (2024-11-08)
 
 
 ### Features
 
-* Add translation key prefixes for upload and download ([#687](https://github.com/phrase/openapi/issues/687)) ([9c9c959](https://github.com/phrase/openapi/commit/9c9c959830631bcac8beaf1de30ab31755ac1ee5))
+* **API:** Add Pagination header to POST search endpoints [[#457](https://github.com/phrase/strings-openapi/issues/457)] ([#706](https://github.com/phrase/strings-openapi/issues/706)) ([9a79fa3](https://github.com/phrase/strings-openapi/commit/9a79fa31bb3b9d58272fa2f4e82d72d0d44a93a0))
 
-
-### Bug Fixes
-
-* **API:** Format list is not paginated and authenticated #STRINGS-458 ([#690](https://github.com/phrase/openapi/issues/690)) ([25e90f4](https://github.com/phrase/openapi/commit/25e90f46513e70cf328be80c36ae785cead05851))
-
-## [2.4.1](https://github.com/phrase/openapi/compare/java-v2.4.0...java-v2.4.1) (2024-09-25)
-
-
-### Bug Fixes
-
-* **java:** Properly encode nested parameters with file upload ([#688](https://github.com/phrase/openapi/issues/688)) ([c32abb5](https://github.com/phrase/openapi/commit/c32abb5d862ffc6239be9bda3510a8f4b33e0722))
-
-## [2.4.0](https://github.com/phrase/openapi/compare/java-v2.3.0...java-v2.4.0) (2024-09-03)
+## [2.5.0](https://github.com/phrase/strings-openapi/compare/java-v2.4.1...java-v2.5.0) (2024-10-02)
 
 
 ### Features
 
-* Add update_translations_on_source_match ([#670](https://github.com/phrase/openapi/issues/670)) ([11003ac](https://github.com/phrase/openapi/commit/11003ace7353bf99893482ca4aa32214abf3e581))
+* Add translation key prefixes for upload and download ([#687](https://github.com/phrase/strings-openapi/issues/687)) ([9c9c959](https://github.com/phrase/strings-openapi/commit/9c9c959830631bcac8beaf1de30ab31755ac1ee5))
 
-## [2.3.0](https://github.com/phrase/openapi/compare/java-v2.2.1...java-v2.3.0) (2024-07-02)
+
+### Bug Fixes
+
+* **API:** Format list is not paginated and authenticated #STRINGS-458 ([#690](https://github.com/phrase/strings-openapi/issues/690)) ([25e90f4](https://github.com/phrase/strings-openapi/commit/25e90f46513e70cf328be80c36ae785cead05851))
+
+## [2.4.1](https://github.com/phrase/strings-openapi/compare/java-v2.4.0...java-v2.4.1) (2024-09-25)
+
+
+### Bug Fixes
+
+* **java:** Properly encode nested parameters with file upload ([#688](https://github.com/phrase/strings-openapi/issues/688)) ([c32abb5](https://github.com/phrase/strings-openapi/commit/c32abb5d862ffc6239be9bda3510a8f4b33e0722))
+
+## [2.4.0](https://github.com/phrase/strings-openapi/compare/java-v2.3.0...java-v2.4.0) (2024-09-03)
 
 
 ### Features
 
-* add repo sync events show endpoint ([#641](https://github.com/phrase/openapi/issues/641)) ([e1d9cfb](https://github.com/phrase/openapi/commit/e1d9cfb23e079fea2d9e5475dff9a4137f1f0154))
-* **API:** Async downloads [TSI-2515] ([#642](https://github.com/phrase/openapi/issues/642)) ([6fcab5d](https://github.com/phrase/openapi/commit/6fcab5d4719f64e8e5dd49c327dc9348b384de4c))
+* Add update_translations_on_source_match ([#670](https://github.com/phrase/strings-openapi/issues/670)) ([11003ac](https://github.com/phrase/strings-openapi/commit/11003ace7353bf99893482ca4aa32214abf3e581))
 
-## [2.2.1](https://github.com/phrase/openapi/compare/java-v2.2.0...java-v2.2.1) (2024-06-18)
-
-
-### Bug Fixes
-
-* add app_min_version and app_max_version param to releases ([#633](https://github.com/phrase/openapi/issues/633)) ([b384301](https://github.com/phrase/openapi/commit/b3843012460ace4c1d34c4373e5158595466adcb))
-
-## [2.2.0](https://github.com/phrase/openapi/compare/java-v2.1.1...java-v2.2.0) (2024-06-12)
+## [2.3.0](https://github.com/phrase/strings-openapi/compare/java-v2.2.1...java-v2.3.0) (2024-07-02)
 
 
 ### Features
 
-* **API:** Add OTA Release Triggers API [TSI-2485] ([#622](https://github.com/phrase/openapi/issues/622)) ([8cb91dc](https://github.com/phrase/openapi/commit/8cb91dcce2c19ca700cf9d0713fa74f28ad59434))
+* add repo sync events show endpoint ([#641](https://github.com/phrase/strings-openapi/issues/641)) ([e1d9cfb](https://github.com/phrase/strings-openapi/commit/e1d9cfb23e079fea2d9e5475dff9a4137f1f0154))
+* **API:** Async downloads [TSI-2515] ([#642](https://github.com/phrase/strings-openapi/issues/642)) ([6fcab5d](https://github.com/phrase/strings-openapi/commit/6fcab5d4719f64e8e5dd49c327dc9348b384de4c))
 
-## [2.1.1](https://github.com/phrase/openapi/compare/java-v2.1.0...java-v2.1.1) (2024-05-31)
+## [2.2.1](https://github.com/phrase/strings-openapi/compare/java-v2.2.0...java-v2.2.1) (2024-06-18)
 
 
 ### Bug Fixes
 
-* **CLI:** use id instead of repo_sync_id as param ([#618](https://github.com/phrase/openapi/issues/618)) ([7a1a0d9](https://github.com/phrase/openapi/commit/7a1a0d9115262dc7fa3065ee7cc76bec7a381ddb))
-* **PHP:** Fix deserializing custom metadata values in key response ([#607](https://github.com/phrase/openapi/issues/607)) ([b6eeeba](https://github.com/phrase/openapi/commit/b6eeeba223e3eabec268a8f3d372afcb6abd09dd))
+* add app_min_version and app_max_version param to releases ([#633](https://github.com/phrase/strings-openapi/issues/633)) ([b384301](https://github.com/phrase/strings-openapi/commit/b3843012460ace4c1d34c4373e5158595466adcb))
 
-## [2.1.0](https://github.com/phrase/openapi/compare/java-v2.0.2...java-v2.1.0) (2024-04-29)
+## [2.2.0](https://github.com/phrase/strings-openapi/compare/java-v2.1.1...java-v2.2.0) (2024-06-12)
 
 
 ### Features
 
-* **API:** Add 'update_translation_keys' for Uploads [TSI-2292] ([#578](https://github.com/phrase/openapi/issues/578)) ([4492ec0](https://github.com/phrase/openapi/commit/4492ec0a7c62f9de9ab1c1125071615bddcc26ce))
+* **API:** Add OTA Release Triggers API [TSI-2485] ([#622](https://github.com/phrase/strings-openapi/issues/622)) ([8cb91dc](https://github.com/phrase/strings-openapi/commit/8cb91dcce2c19ca700cf9d0713fa74f28ad59434))
 
-## [2.0.2](https://github.com/phrase/openapi/compare/java-v2.0.1...java-v2.0.2) (2024-04-23)
-
-
-### Bug Fixes
-
-* **Java:** fix maven build ([#596](https://github.com/phrase/openapi/issues/596)) ([ec4449a](https://github.com/phrase/openapi/commit/ec4449a1ffdd5c601edcc61f1554d18b0d412cc8))
-
-## [2.0.1](https://github.com/phrase/openapi/compare/java-v2.0.0...java-v2.0.1) (2024-04-23)
+## [2.1.1](https://github.com/phrase/strings-openapi/compare/java-v2.1.0...java-v2.1.1) (2024-05-31)
 
 
 ### Bug Fixes
 
-* **Java:** fix maven build ([#593](https://github.com/phrase/openapi/issues/593)) ([ce5b408](https://github.com/phrase/openapi/commit/ce5b4081c41348df9750c4f3b79d50eb75c671f3))
+* **CLI:** use id instead of repo_sync_id as param ([#618](https://github.com/phrase/strings-openapi/issues/618)) ([7a1a0d9](https://github.com/phrase/strings-openapi/commit/7a1a0d9115262dc7fa3065ee7cc76bec7a381ddb))
+* **PHP:** Fix deserializing custom metadata values in key response ([#607](https://github.com/phrase/strings-openapi/issues/607)) ([b6eeeba](https://github.com/phrase/strings-openapi/commit/b6eeeba223e3eabec268a8f3d372afcb6abd09dd))
 
-## [2.0.0](https://github.com/phrase/openapi/compare/java-v1.23.0...java-v2.0.0) (2024-04-23)
+## [2.1.0](https://github.com/phrase/strings-openapi/compare/java-v2.0.2...java-v2.1.0) (2024-04-29)
+
+
+### Features
+
+* **API:** Add 'update_translation_keys' for Uploads [TSI-2292] ([#578](https://github.com/phrase/strings-openapi/issues/578)) ([4492ec0](https://github.com/phrase/strings-openapi/commit/4492ec0a7c62f9de9ab1c1125071615bddcc26ce))
+
+## [2.0.2](https://github.com/phrase/strings-openapi/compare/java-v2.0.1...java-v2.0.2) (2024-04-23)
+
+
+### Bug Fixes
+
+* **Java:** fix maven build ([#596](https://github.com/phrase/strings-openapi/issues/596)) ([ec4449a](https://github.com/phrase/strings-openapi/commit/ec4449a1ffdd5c601edcc61f1554d18b0d412cc8))
+
+## [2.0.1](https://github.com/phrase/strings-openapi/compare/java-v2.0.0...java-v2.0.1) (2024-04-23)
+
+
+### Bug Fixes
+
+* **Java:** fix maven build ([#593](https://github.com/phrase/strings-openapi/issues/593)) ([ce5b408](https://github.com/phrase/strings-openapi/commit/ce5b4081c41348df9750c4f3b79d50eb75c671f3))
+
+## [2.0.0](https://github.com/phrase/strings-openapi/compare/java-v1.23.0...java-v2.0.0) (2024-04-23)
 
 
 ### ⚠ BREAKING CHANGES
 
-* add missing required params ([#571](https://github.com/phrase/openapi/issues/571))
+* add missing required params ([#571](https://github.com/phrase/strings-openapi/issues/571))
 
 ### Code Refactoring
 
-* add missing required params ([#571](https://github.com/phrase/openapi/issues/571)) ([d810e9e](https://github.com/phrase/openapi/commit/d810e9ebc767e14ba9e56106de8c5774d9d6d178))
+* add missing required params ([#571](https://github.com/phrase/strings-openapi/issues/571)) ([d810e9e](https://github.com/phrase/strings-openapi/commit/d810e9ebc767e14ba9e56106de8c5774d9d6d178))
 
-## [1.23.0](https://github.com/phrase/openapi/compare/java-v1.22.0...java-v1.23.0) (2024-04-22)
-
-
-### Features
-
-* Add linked-parent to translation details ([#570](https://github.com/phrase/openapi/issues/570)) ([2c6f432](https://github.com/phrase/openapi/commit/2c6f43253e24b670b71ac810c85dce0759c29403))
-
-## [1.22.0](https://github.com/phrase/openapi/compare/java-v1.21.0...java-v1.22.0) (2024-04-17)
+## [1.23.0](https://github.com/phrase/strings-openapi/compare/java-v1.22.0...java-v1.23.0) (2024-04-22)
 
 
 ### Features
 
-* **API:** Add Repo Sync [TSI-1923] ([#569](https://github.com/phrase/openapi/issues/569)) ([0bd1756](https://github.com/phrase/openapi/commit/0bd17562018cb045ff41cc1ff5008b9419a0ed12))
+* Add linked-parent to translation details ([#570](https://github.com/phrase/strings-openapi/issues/570)) ([2c6f432](https://github.com/phrase/strings-openapi/commit/2c6f43253e24b670b71ac810c85dce0759c29403))
 
-## [1.21.0](https://github.com/phrase/openapi/compare/java-v1.20.0...java-v1.21.0) (2024-04-10)
+## [1.22.0](https://github.com/phrase/strings-openapi/compare/java-v1.21.0...java-v1.22.0) (2024-04-17)
 
 
 ### Features
 
-* **API:** add Linked Keys endpoints ([#555](https://github.com/phrase/openapi/issues/555)) ([4935dac](https://github.com/phrase/openapi/commit/4935dac58c787eaade2f1f65ce649f466b5e3a60))
+* **API:** Add Repo Sync [TSI-1923] ([#569](https://github.com/phrase/strings-openapi/issues/569)) ([0bd1756](https://github.com/phrase/strings-openapi/commit/0bd17562018cb045ff41cc1ff5008b9419a0ed12))
+
+## [1.21.0](https://github.com/phrase/strings-openapi/compare/java-v1.20.0...java-v1.21.0) (2024-04-10)
+
+
+### Features
+
+* **API:** add Linked Keys endpoints ([#555](https://github.com/phrase/strings-openapi/issues/555)) ([4935dac](https://github.com/phrase/strings-openapi/commit/4935dac58c787eaade2f1f65ce649f466b5e3a60))
 
 
 ### Bug Fixes
 
-* (API) Add mandatory params to linked keys endpoints ([#564](https://github.com/phrase/openapi/issues/564)) ([08d9846](https://github.com/phrase/openapi/commit/08d9846bc224d349e2ade9abf28d733afb1e8be3))
+* (API) Add mandatory params to linked keys endpoints ([#564](https://github.com/phrase/strings-openapi/issues/564)) ([08d9846](https://github.com/phrase/strings-openapi/commit/08d9846bc224d349e2ade9abf28d733afb1e8be3))
 
-## [1.20.0](https://github.com/phrase/openapi/compare/java-v1.19.2...java-v1.20.0) (2024-02-07)
+## [1.20.0](https://github.com/phrase/strings-openapi/compare/java-v1.19.2...java-v1.20.0) (2024-02-07)
 
 
 ### Features
 
-* add query param for properties ([#542](https://github.com/phrase/openapi/issues/542)) ([b4e12d0](https://github.com/phrase/openapi/commit/b4e12d04fd2916351f9201e1e6de504143ecc9aa))
+* add query param for properties ([#542](https://github.com/phrase/strings-openapi/issues/542)) ([b4e12d0](https://github.com/phrase/strings-openapi/commit/b4e12d04fd2916351f9201e1e6de504143ecc9aa))
 
-## [1.19.2](https://github.com/phrase/openapi/compare/java-v1.19.1...java-v1.19.2) (2024-02-05)
+## [1.19.2](https://github.com/phrase/strings-openapi/compare/java-v1.19.1...java-v1.19.2) (2024-02-05)
 
 
 ### Bug Fixes
 
-* **API:** allow nullable value for job's due_date ([#534](https://github.com/phrase/openapi/issues/534)) ([38b51b5](https://github.com/phrase/openapi/commit/38b51b51095394f8ce769873140038abba628514))
+* **API:** allow nullable value for job's due_date ([#534](https://github.com/phrase/strings-openapi/issues/534)) ([38b51b5](https://github.com/phrase/strings-openapi/commit/38b51b51095394f8ce769873140038abba628514))
 
-## [1.19.1](https://github.com/phrase/openapi/compare/java-v1.19.0...java-v1.19.1) (2024-02-01)
-
-
-### Bug Fixes
-
-* **API:** Adjust documentation of QPS endpoint ([#525](https://github.com/phrase/openapi/issues/525)) ([4b4f1ac](https://github.com/phrase/openapi/commit/4b4f1acf28fbd13b3d16c37162cdccfa05c38ffa))
-
-## [1.19.0](https://github.com/phrase/openapi/compare/java-v1.18.0...java-v1.19.0) (2024-01-17)
-
-
-### Features
-
-* **api:** Add QPS endpoint and documentation ([#521](https://github.com/phrase/openapi/issues/521)) ([d22c558](https://github.com/phrase/openapi/commit/d22c558adfbb7fcd13759e388c038744914e42fa))
+## [1.19.1](https://github.com/phrase/strings-openapi/compare/java-v1.19.0...java-v1.19.1) (2024-02-01)
 
 
 ### Bug Fixes
 
-* **API:** Create Custom Metadata endpoint fix [TSI-2222] ([#499](https://github.com/phrase/openapi/issues/499)) ([ce2ed94](https://github.com/phrase/openapi/commit/ce2ed9488e111fb5d9bc3810a78c47d23553c8b7))
+* **API:** Adjust documentation of QPS endpoint ([#525](https://github.com/phrase/strings-openapi/issues/525)) ([4b4f1ac](https://github.com/phrase/strings-openapi/commit/4b4f1acf28fbd13b3d16c37162cdccfa05c38ffa))
 
-## [1.18.0](https://github.com/phrase/openapi/compare/java-v1.17.0...java-v1.18.0) (2023-12-13)
-
-
-### Features
-
-* Add reports locales endpoint to API [TSS-2439] ([#465](https://github.com/phrase/openapi/issues/465)) ([e03aa9f](https://github.com/phrase/openapi/commit/e03aa9f49f031517b36db715fe70e8e0b65a438b))
-* **API:** add Custom Metadata endpoints ([#474](https://github.com/phrase/openapi/issues/474)) ([d407d8b](https://github.com/phrase/openapi/commit/d407d8be5ccddec1afde14a12804a7a616f77d7a))
-* **API:** Add custom_metadata_filters param to locale download endpoint [TSI-2174] ([#478](https://github.com/phrase/openapi/issues/478)) ([3623478](https://github.com/phrase/openapi/commit/3623478fc1518b457ab018b5630a693081637d6e))
-* **API:** Add url field to uploads ([#481](https://github.com/phrase/openapi/issues/481)) ([7332a84](https://github.com/phrase/openapi/commit/7332a84f9958346f2fb28dee4b0353519ef466d5))
-
-## [1.17.0](https://github.com/phrase/openapi/compare/java-v1.16.0...java-v1.17.0) (2023-11-03)
+## [1.19.0](https://github.com/phrase/strings-openapi/compare/java-v1.18.0...java-v1.19.0) (2024-01-17)
 
 
 ### Features
 
-* [TSI-2083] enable format_options argument for java-client   ([#426](https://github.com/phrase/openapi/issues/426)) ([faa8cb3](https://github.com/phrase/openapi/commit/faa8cb353ba9f1030b9f7cfd46b894b4d6d26e70))
-
-## [1.16.0](https://github.com/phrase/openapi/compare/java-v1.15.0...java-v1.16.0) (2023-10-30)
-
-
-### Features
-
-* Update openapi-generator to v7 ([#418](https://github.com/phrase/openapi/issues/418)) ([524626f](https://github.com/phrase/openapi/commit/524626f5e914bfef6025d0e1c2cbc7a728d08f56))
-
-## [1.15.0](https://github.com/phrase/openapi/compare/java-v1.14.0...java-v1.15.0) (2023-10-23)
-
-
-### Features
-
-* **API:** Add order param to comment list endpoints ([#441](https://github.com/phrase/openapi/issues/441)) ([441c9c4](https://github.com/phrase/openapi/commit/441c9c46169f8c5ac4e71ade09a95dab136314ef))
-
-## [1.14.0](https://github.com/phrase/openapi/compare/java-v1.13.0...java-v1.14.0) (2023-10-13)
-
-
-### Features
-
-* **API:** Implement figma attachments endpoints ([#415](https://github.com/phrase/openapi/issues/415)) ([970e612](https://github.com/phrase/openapi/commit/970e612fda620ca882a221ef541036b8d200b675))
-
-## [1.13.0](https://github.com/phrase/openapi/compare/java-v1.12.0...java-v1.13.0) (2023-09-12)
-
-
-### Features
-
-* Optionally tag only affected keys on upload [TSI-2041] ([#412](https://github.com/phrase/openapi/issues/412)) ([e8f958e](https://github.com/phrase/openapi/commit/e8f958e91469c2542f44ab68469c933688958383))
-* **TSI-1946:** Add reviewed_at to translations ([#396](https://github.com/phrase/openapi/issues/396)) ([3e663d9](https://github.com/phrase/openapi/commit/3e663d971a99a816f0165dd6653a9a1e8a87c95e))
-
-## [1.12.0](https://github.com/phrase/openapi/compare/java-v1.11.0...java-v1.12.0) (2023-08-28)
-
-
-### Features
-
-* **API:** Document new query parameters ([#393](https://github.com/phrase/openapi/issues/393)) ([770515a](https://github.com/phrase/openapi/commit/770515a9628122955bb3919405babf9392684eb9))
-
-## [1.11.0](https://github.com/phrase/openapi/compare/java-v1.10.0...java-v1.11.0) (2023-08-24)
-
-
-### Features
-
-* **API:** Introduce comment replies endpoints ([#383](https://github.com/phrase/openapi/issues/383)) ([71351ac](https://github.com/phrase/openapi/commit/71351ac285f4f49976092e176c77b09f3485eb65))
-
-## [1.10.0](https://github.com/phrase/openapi/compare/java-v1.9.6...java-v1.10.0) (2023-08-22)
-
-
-### Features
-
-* **TSE-950:** Document comment_reactions endpoints ([#380](https://github.com/phrase/openapi/issues/380)) ([f230244](https://github.com/phrase/openapi/commit/f230244e6e9c069b18edc4c35dd5e290fd14793b))
+* **api:** Add QPS endpoint and documentation ([#521](https://github.com/phrase/strings-openapi/issues/521)) ([d22c558](https://github.com/phrase/strings-openapi/commit/d22c558adfbb7fcd13759e388c038744914e42fa))
 
 
 ### Bug Fixes
 
-* **schemas:** Fix gitlab_sync type mismatch ([#373](https://github.com/phrase/openapi/issues/373)) ([1cb1f65](https://github.com/phrase/openapi/commit/1cb1f650598c68afee6e2cd7c3c4ede1484aba35))
+* **API:** Create Custom Metadata endpoint fix [TSI-2222] ([#499](https://github.com/phrase/strings-openapi/issues/499)) ([ce2ed94](https://github.com/phrase/strings-openapi/commit/ce2ed9488e111fb5d9bc3810a78c47d23553c8b7))
 
-## [1.9.6](https://github.com/phrase/openapi/compare/java-v1.9.5...java-v1.9.6) (2023-07-28)
+## [1.18.0](https://github.com/phrase/strings-openapi/compare/java-v1.17.0...java-v1.18.0) (2023-12-13)
+
+
+### Features
+
+* Add reports locales endpoint to API [TSS-2439] ([#465](https://github.com/phrase/strings-openapi/issues/465)) ([e03aa9f](https://github.com/phrase/strings-openapi/commit/e03aa9f49f031517b36db715fe70e8e0b65a438b))
+* **API:** add Custom Metadata endpoints ([#474](https://github.com/phrase/strings-openapi/issues/474)) ([d407d8b](https://github.com/phrase/strings-openapi/commit/d407d8be5ccddec1afde14a12804a7a616f77d7a))
+* **API:** Add custom_metadata_filters param to locale download endpoint [TSI-2174] ([#478](https://github.com/phrase/strings-openapi/issues/478)) ([3623478](https://github.com/phrase/strings-openapi/commit/3623478fc1518b457ab018b5630a693081637d6e))
+* **API:** Add url field to uploads ([#481](https://github.com/phrase/strings-openapi/issues/481)) ([7332a84](https://github.com/phrase/strings-openapi/commit/7332a84f9958346f2fb28dee4b0353519ef466d5))
+
+## [1.17.0](https://github.com/phrase/strings-openapi/compare/java-v1.16.0...java-v1.17.0) (2023-11-03)
+
+
+### Features
+
+* [TSI-2083] enable format_options argument for java-client   ([#426](https://github.com/phrase/strings-openapi/issues/426)) ([faa8cb3](https://github.com/phrase/strings-openapi/commit/faa8cb353ba9f1030b9f7cfd46b894b4d6d26e70))
+
+## [1.16.0](https://github.com/phrase/strings-openapi/compare/java-v1.15.0...java-v1.16.0) (2023-10-30)
+
+
+### Features
+
+* Update openapi-generator to v7 ([#418](https://github.com/phrase/strings-openapi/issues/418)) ([524626f](https://github.com/phrase/strings-openapi/commit/524626f5e914bfef6025d0e1c2cbc7a728d08f56))
+
+## [1.15.0](https://github.com/phrase/strings-openapi/compare/java-v1.14.0...java-v1.15.0) (2023-10-23)
+
+
+### Features
+
+* **API:** Add order param to comment list endpoints ([#441](https://github.com/phrase/strings-openapi/issues/441)) ([441c9c4](https://github.com/phrase/strings-openapi/commit/441c9c46169f8c5ac4e71ade09a95dab136314ef))
+
+## [1.14.0](https://github.com/phrase/strings-openapi/compare/java-v1.13.0...java-v1.14.0) (2023-10-13)
+
+
+### Features
+
+* **API:** Implement figma attachments endpoints ([#415](https://github.com/phrase/strings-openapi/issues/415)) ([970e612](https://github.com/phrase/strings-openapi/commit/970e612fda620ca882a221ef541036b8d200b675))
+
+## [1.13.0](https://github.com/phrase/strings-openapi/compare/java-v1.12.0...java-v1.13.0) (2023-09-12)
+
+
+### Features
+
+* Optionally tag only affected keys on upload [TSI-2041] ([#412](https://github.com/phrase/strings-openapi/issues/412)) ([e8f958e](https://github.com/phrase/strings-openapi/commit/e8f958e91469c2542f44ab68469c933688958383))
+* **TSI-1946:** Add reviewed_at to translations ([#396](https://github.com/phrase/strings-openapi/issues/396)) ([3e663d9](https://github.com/phrase/strings-openapi/commit/3e663d971a99a816f0165dd6653a9a1e8a87c95e))
+
+## [1.12.0](https://github.com/phrase/strings-openapi/compare/java-v1.11.0...java-v1.12.0) (2023-08-28)
+
+
+### Features
+
+* **API:** Document new query parameters ([#393](https://github.com/phrase/strings-openapi/issues/393)) ([770515a](https://github.com/phrase/strings-openapi/commit/770515a9628122955bb3919405babf9392684eb9))
+
+## [1.11.0](https://github.com/phrase/strings-openapi/compare/java-v1.10.0...java-v1.11.0) (2023-08-24)
+
+
+### Features
+
+* **API:** Introduce comment replies endpoints ([#383](https://github.com/phrase/strings-openapi/issues/383)) ([71351ac](https://github.com/phrase/strings-openapi/commit/71351ac285f4f49976092e176c77b09f3485eb65))
+
+## [1.10.0](https://github.com/phrase/strings-openapi/compare/java-v1.9.6...java-v1.10.0) (2023-08-22)
+
+
+### Features
+
+* **TSE-950:** Document comment_reactions endpoints ([#380](https://github.com/phrase/strings-openapi/issues/380)) ([f230244](https://github.com/phrase/strings-openapi/commit/f230244e6e9c069b18edc4c35dd5e290fd14793b))
 
 
 ### Bug Fixes
 
-* Fix gitlab_sync history status type mismatch ([#363](https://github.com/phrase/openapi/issues/363)) ([ebcaa4e](https://github.com/phrase/openapi/commit/ebcaa4e5dfcb2f73559a56c78b0f2512ca798375))
+* **schemas:** Fix gitlab_sync type mismatch ([#373](https://github.com/phrase/strings-openapi/issues/373)) ([1cb1f65](https://github.com/phrase/strings-openapi/commit/1cb1f650598c68afee6e2cd7c3c4ede1484aba35))
 
-## [1.9.5](https://github.com/phrase/openapi/compare/java-v1.9.4...java-v1.9.5) (2023-06-21)
-
-
-### Bug Fixes
-
-* **java:** Use useGpgCmd instead of in memory key ([#351](https://github.com/phrase/openapi/issues/351)) ([ac93b39](https://github.com/phrase/openapi/commit/ac93b39973a089888ec1c236a333cde72d6b6ed3))
-
-## [1.9.4](https://github.com/phrase/openapi/compare/java-v1.9.3...java-v1.9.4) (2023-06-20)
+## [1.9.6](https://github.com/phrase/strings-openapi/compare/java-v1.9.5...java-v1.9.6) (2023-07-28)
 
 
 ### Bug Fixes
 
-* **java:** Pass multiline key using quotes ([#349](https://github.com/phrase/openapi/issues/349)) ([2375b28](https://github.com/phrase/openapi/commit/2375b28a91e721495066fd8d2aa64ef1b4cc834a))
+* Fix gitlab_sync history status type mismatch ([#363](https://github.com/phrase/strings-openapi/issues/363)) ([ebcaa4e](https://github.com/phrase/strings-openapi/commit/ebcaa4e5dfcb2f73559a56c78b0f2512ca798375))
 
-## [1.9.3](https://github.com/phrase/openapi/compare/java-v1.9.2...java-v1.9.3) (2023-06-20)
-
-
-### Bug Fixes
-
-* **java:** Support multiline GPG key [TSI-1816] ([#346](https://github.com/phrase/openapi/issues/346)) ([5796fee](https://github.com/phrase/openapi/commit/5796feef0839ac1dcdfb542e394f110218f7ccc0))
-
-## [1.9.2](https://github.com/phrase/openapi/compare/java-v1.9.1...java-v1.9.2) (2023-06-20)
+## [1.9.5](https://github.com/phrase/strings-openapi/compare/java-v1.9.4...java-v1.9.5) (2023-06-21)
 
 
 ### Bug Fixes
 
-* **java:** Pass secrets as vars [TSI-1816] ([#344](https://github.com/phrase/openapi/issues/344)) ([28c513e](https://github.com/phrase/openapi/commit/28c513ecda24663c0f4ced454667f9a45316a1f9))
+* **java:** Use useGpgCmd instead of in memory key ([#351](https://github.com/phrase/strings-openapi/issues/351)) ([ac93b39](https://github.com/phrase/strings-openapi/commit/ac93b39973a089888ec1c236a333cde72d6b6ed3))
 
-## [1.9.1](https://github.com/phrase/openapi/compare/java-v1.9.0...java-v1.9.1) (2023-06-20)
+## [1.9.4](https://github.com/phrase/strings-openapi/compare/java-v1.9.3...java-v1.9.4) (2023-06-20)
 
 
 ### Bug Fixes
 
-* Remove obsolete instructions from Java README ([#339](https://github.com/phrase/openapi/issues/339)) ([db5d52a](https://github.com/phrase/openapi/commit/db5d52ab7509e45f7f761f9b5fd3126b0c99e014))
+* **java:** Pass multiline key using quotes ([#349](https://github.com/phrase/strings-openapi/issues/349)) ([2375b28](https://github.com/phrase/strings-openapi/commit/2375b28a91e721495066fd8d2aa64ef1b4cc834a))
+
+## [1.9.3](https://github.com/phrase/strings-openapi/compare/java-v1.9.2...java-v1.9.3) (2023-06-20)
+
+
+### Bug Fixes
+
+* **java:** Support multiline GPG key [TSI-1816] ([#346](https://github.com/phrase/strings-openapi/issues/346)) ([5796fee](https://github.com/phrase/strings-openapi/commit/5796feef0839ac1dcdfb542e394f110218f7ccc0))
+
+## [1.9.2](https://github.com/phrase/strings-openapi/compare/java-v1.9.1...java-v1.9.2) (2023-06-20)
+
+
+### Bug Fixes
+
+* **java:** Pass secrets as vars [TSI-1816] ([#344](https://github.com/phrase/strings-openapi/issues/344)) ([28c513e](https://github.com/phrase/strings-openapi/commit/28c513ecda24663c0f4ced454667f9a45316a1f9))
+
+## [1.9.1](https://github.com/phrase/strings-openapi/compare/java-v1.9.0...java-v1.9.1) (2023-06-20)
+
+
+### Bug Fixes
+
+* Remove obsolete instructions from Java README ([#339](https://github.com/phrase/strings-openapi/issues/339)) ([db5d52a](https://github.com/phrase/strings-openapi/commit/db5d52ab7509e45f7f761f9b5fd3126b0c99e014))

--- a/clients/php/CHANGELOG.md
+++ b/clients/php/CHANGELOG.md
@@ -7,435 +7,435 @@
 
 * **API:** Add linked_translation to translation type ([#1005](https://github.com/phrase/strings-openapi/issues/1005)) ([b18e64c](https://github.com/phrase/strings-openapi/commit/b18e64c948d40a9e5f996e8fdf6dee07d1812b02))
 
-## [3.15.0](https://github.com/phrase/openapi/compare/php-v3.14.0...php-v3.15.0) (2026-01-09)
+## [3.15.0](https://github.com/phrase/strings-openapi/compare/php-v3.14.0...php-v3.15.0) (2026-01-09)
 
 
 ### Features
 
-* **API:** Add missing project flags to project details schema #SCD-141 ([#993](https://github.com/phrase/openapi/issues/993)) ([93fbdd7](https://github.com/phrase/openapi/commit/93fbdd76150ed94374ef888ac92c0c9b626de7c8))
+* **API:** Add missing project flags to project details schema #SCD-141 ([#993](https://github.com/phrase/strings-openapi/issues/993)) ([93fbdd7](https://github.com/phrase/strings-openapi/commit/93fbdd76150ed94374ef888ac92c0c9b626de7c8))
 
 
 ### Bug Fixes
 
-* **API:** drop invalid account locale params ([#992](https://github.com/phrase/openapi/issues/992)) ([87af83c](https://github.com/phrase/openapi/commit/87af83c94fd7e47340b5393847e93a31127abbe8))
+* **API:** drop invalid account locale params ([#992](https://github.com/phrase/strings-openapi/issues/992)) ([87af83c](https://github.com/phrase/strings-openapi/commit/87af83c94fd7e47340b5393847e93a31127abbe8))
 
-## [3.14.0](https://github.com/phrase/openapi/compare/php-v3.13.1...php-v3.14.0) (2025-12-11)
+## [3.14.0](https://github.com/phrase/strings-openapi/compare/php-v3.13.1...php-v3.14.0) (2025-12-11)
 
 
 ### Features
 
-* **API:** Add create comparison endpoint for branches [SCD-549] ([#966](https://github.com/phrase/openapi/issues/966)) ([4099e32](https://github.com/phrase/openapi/commit/4099e32d42744f9d73346077ef30b0f4bd5c849e))
-* **API:** add manual triggering of automations #SCM-953 ([#968](https://github.com/phrase/openapi/issues/968)) ([ebe1c68](https://github.com/phrase/openapi/commit/ebe1c68e472d87ea6c6cd2f76bb421406c30a274))
-* **API:** add use_locale_fallback option to download #SCD-620 ([#976](https://github.com/phrase/openapi/issues/976)) ([9266c68](https://github.com/phrase/openapi/commit/9266c680d8717bb736aed83625858f0b3419da54))
+* **API:** Add create comparison endpoint for branches [SCD-549] ([#966](https://github.com/phrase/strings-openapi/issues/966)) ([4099e32](https://github.com/phrase/strings-openapi/commit/4099e32d42744f9d73346077ef30b0f4bd5c849e))
+* **API:** add manual triggering of automations #SCM-953 ([#968](https://github.com/phrase/strings-openapi/issues/968)) ([ebe1c68](https://github.com/phrase/strings-openapi/commit/ebe1c68e472d87ea6c6cd2f76bb421406c30a274))
+* **API:** add use_locale_fallback option to download #SCD-620 ([#976](https://github.com/phrase/strings-openapi/issues/976)) ([9266c68](https://github.com/phrase/strings-openapi/commit/9266c680d8717bb736aed83625858f0b3419da54))
 
-## [3.13.1](https://github.com/phrase/openapi/compare/php-v3.13.0...php-v3.13.1) (2025-11-10)
+## [3.13.1](https://github.com/phrase/strings-openapi/compare/php-v3.13.0...php-v3.13.1) (2025-11-10)
 
 
 ### Bug Fixes
 
-* **API:** Add omit_translation_keys to Jobs#show endpoint ([#957](https://github.com/phrase/openapi/issues/957)) ([23ece66](https://github.com/phrase/openapi/commit/23ece66b05fc748a4598ce876cb2954ed1a385cc))
+* **API:** Add omit_translation_keys to Jobs#show endpoint ([#957](https://github.com/phrase/strings-openapi/issues/957)) ([23ece66](https://github.com/phrase/strings-openapi/commit/23ece66b05fc748a4598ce876cb2954ed1a385cc))
 
-## [3.13.0](https://github.com/phrase/openapi/compare/php-v3.12.0...php-v3.13.0) (2025-10-27)
-
-
-### Features
-
-* **API:** Support omit_translation_keys param in Jobs#show ([#944](https://github.com/phrase/openapi/issues/944)) ([690a2ce](https://github.com/phrase/openapi/commit/690a2ce992359e7920367699145d2d4ff3a206fa))
-
-## [3.12.0](https://github.com/phrase/openapi/compare/php-v3.11.0...php-v3.12.0) (2025-10-23)
+## [3.13.0](https://github.com/phrase/strings-openapi/compare/php-v3.12.0...php-v3.13.0) (2025-10-27)
 
 
 ### Features
 
-* **API:** Support source_locale_id param in uploads ([#935](https://github.com/phrase/openapi/issues/935)) ([304a406](https://github.com/phrase/openapi/commit/304a4061aaac8001a3a9e10c5cf985b04c31dab2))
+* **API:** Support omit_translation_keys param in Jobs#show ([#944](https://github.com/phrase/strings-openapi/issues/944)) ([690a2ce](https://github.com/phrase/strings-openapi/commit/690a2ce992359e7920367699145d2d4ff3a206fa))
 
-## [3.11.0](https://github.com/phrase/openapi/compare/php-v3.10.0...php-v3.11.0) (2025-10-16)
-
-
-### Features
-
-* List child branches ([#926](https://github.com/phrase/openapi/issues/926)) ([31d3b57](https://github.com/phrase/openapi/commit/31d3b57e0d1381149409b77c3e236b226cde22a1))
-
-## [3.10.0](https://github.com/phrase/openapi/compare/php-v3.9.0...php-v3.10.0) (2025-10-01)
+## [3.12.0](https://github.com/phrase/strings-openapi/compare/php-v3.11.0...php-v3.12.0) (2025-10-23)
 
 
 ### Features
 
-* add branch sync endpoint ([#912](https://github.com/phrase/openapi/issues/912)) ([3293917](https://github.com/phrase/openapi/commit/329391757b3f81574448b1b87506b85bfdeb6761))
+* **API:** Support source_locale_id param in uploads ([#935](https://github.com/phrase/strings-openapi/issues/935)) ([304a406](https://github.com/phrase/strings-openapi/commit/304a4061aaac8001a3a9e10c5cf985b04c31dab2))
 
-## [3.9.0](https://github.com/phrase/openapi/compare/php-v3.8.0...php-v3.9.0) (2025-09-30)
-
-
-### Features
-
-* **API:** Add "reviewed" param for tanslations#update ([#891](https://github.com/phrase/openapi/issues/891)) ([3f77286](https://github.com/phrase/openapi/commit/3f7728669fa68d5911dfca39a9e39c24cd20c0a4))
-* **SCM-732:** expose Automation API ([#910](https://github.com/phrase/openapi/issues/910)) ([6eea53d](https://github.com/phrase/openapi/commit/6eea53d06aca8f43623ba90e2e0a8cd6761c9a13))
-
-## [3.8.0](https://github.com/phrase/openapi/compare/php-v3.7.0...php-v3.8.0) (2025-08-01)
+## [3.11.0](https://github.com/phrase/strings-openapi/compare/php-v3.10.0...php-v3.11.0) (2025-10-16)
 
 
 ### Features
 
-* **API:** Add support for `update_custom_metadata` option on upload ([#882](https://github.com/phrase/openapi/issues/882)) ([5b486ea](https://github.com/phrase/openapi/commit/5b486eabf30c84402a8e31911a5ba6fe3b343a89))
+* List child branches ([#926](https://github.com/phrase/strings-openapi/issues/926)) ([31d3b57](https://github.com/phrase/strings-openapi/commit/31d3b57e0d1381149409b77c3e236b226cde22a1))
 
-## [3.7.0](https://github.com/phrase/openapi/compare/php-v3.6.0...php-v3.7.0) (2025-07-24)
-
-
-### Features
-
-* **API:** Job and job locale annotations #SCD-145 ([#867](https://github.com/phrase/openapi/issues/867)) ([95b6c2a](https://github.com/phrase/openapi/commit/95b6c2a2ab798d01f9bc0d53a22dbf817a5eb0ee))
-
-## [3.6.0](https://github.com/phrase/openapi/compare/php-v3.5.0...php-v3.6.0) (2025-07-18)
+## [3.10.0](https://github.com/phrase/strings-openapi/compare/php-v3.9.0...php-v3.10.0) (2025-10-01)
 
 
 ### Features
 
-* **API:** add updated_since param for downloads ([#858](https://github.com/phrase/openapi/issues/858)) ([db4196b](https://github.com/phrase/openapi/commit/db4196bfb1a45f628577bebb99aad7da1179c241))
-* **API:** Add use_ordinal_rules attribute to request body for create/update Keys endpoints ([#868](https://github.com/phrase/openapi/issues/868)) ([29410b5](https://github.com/phrase/openapi/commit/29410b5d4edee9645f449d2d7de53fb953c1f0c2))
-* **API:** Add use_ordinal_rules boolean [STRINGS-2273] ([#846](https://github.com/phrase/openapi/issues/846)) ([450ce0c](https://github.com/phrase/openapi/commit/450ce0cce6bb2064758c44b130b39dd5539c2681))
+* add branch sync endpoint ([#912](https://github.com/phrase/strings-openapi/issues/912)) ([3293917](https://github.com/phrase/strings-openapi/commit/329391757b3f81574448b1b87506b85bfdeb6761))
 
-## [3.5.0](https://github.com/phrase/openapi/compare/php-v3.4.0...php-v3.5.0) (2025-05-23)
+## [3.9.0](https://github.com/phrase/strings-openapi/compare/php-v3.8.0...php-v3.9.0) (2025-09-30)
 
 
 ### Features
 
-* **API:** Add omit_statistics param to tags#show ([#834](https://github.com/phrase/openapi/issues/834)) ([2058b18](https://github.com/phrase/openapi/commit/2058b18297133075885ac99770aee2e171811cd6))
+* **API:** Add "reviewed" param for tanslations#update ([#891](https://github.com/phrase/strings-openapi/issues/891)) ([3f77286](https://github.com/phrase/strings-openapi/commit/3f7728669fa68d5911dfca39a9e39c24cd20c0a4))
+* **SCM-732:** expose Automation API ([#910](https://github.com/phrase/strings-openapi/issues/910)) ([6eea53d](https://github.com/phrase/strings-openapi/commit/6eea53d06aca8f43623ba90e2e0a8cd6761c9a13))
 
-## [3.4.0](https://github.com/phrase/openapi/compare/php-v3.3.0...php-v3.4.0) (2025-05-16)
-
-
-### Features
-
-* **API:** Add "verify_mentioned_translations" parameter to uploads ([#830](https://github.com/phrase/openapi/issues/830)) ([f2fdf60](https://github.com/phrase/openapi/commit/f2fdf60dd97c3908293cd457a765dafde603bd9b))
-* **API:** Add processed & upload total translations on upload summary ([#824](https://github.com/phrase/openapi/issues/824)) ([081db68](https://github.com/phrase/openapi/commit/081db68d2ffcf5d66a81e07eec0a9572a1f9d633))
-* **API:** Translations unreview & batch unreview ([#831](https://github.com/phrase/openapi/issues/831)) ([6a696db](https://github.com/phrase/openapi/commit/6a696db00d80d8acaf5887a08a7a97997566eb8f))
-
-## [3.3.0](https://github.com/phrase/openapi/compare/php-v3.2.0...php-v3.3.0) (2025-04-09)
+## [3.8.0](https://github.com/phrase/strings-openapi/compare/php-v3.7.0...php-v3.8.0) (2025-08-01)
 
 
 ### Features
 
-* **API:** add updated_since filter to job list #STRINGS-1555 ([#799](https://github.com/phrase/openapi/issues/799)) ([dc9b6ed](https://github.com/phrase/openapi/commit/dc9b6ed12e013231d397820449086c87fea2f8ba))
-* **API:** Include roles in account response ([#811](https://github.com/phrase/openapi/issues/811)) ([dc27ee5](https://github.com/phrase/openapi/commit/dc27ee5117762222b6e1e6abb639f8e00c6a9101))
-* **PHP:** Address PHP 8.4 deprecations #STRINGS-1764 ([#823](https://github.com/phrase/openapi/issues/823)) ([683aa47](https://github.com/phrase/openapi/commit/683aa47667f69274fd7767bb3f222f3bcda566a5))
+* **API:** Add support for `update_custom_metadata` option on upload ([#882](https://github.com/phrase/strings-openapi/issues/882)) ([5b486ea](https://github.com/phrase/strings-openapi/commit/5b486eabf30c84402a8e31911a5ba6fe3b343a89))
+
+## [3.7.0](https://github.com/phrase/strings-openapi/compare/php-v3.6.0...php-v3.7.0) (2025-07-24)
+
+
+### Features
+
+* **API:** Job and job locale annotations #SCD-145 ([#867](https://github.com/phrase/strings-openapi/issues/867)) ([95b6c2a](https://github.com/phrase/strings-openapi/commit/95b6c2a2ab798d01f9bc0d53a22dbf817a5eb0ee))
+
+## [3.6.0](https://github.com/phrase/strings-openapi/compare/php-v3.5.0...php-v3.6.0) (2025-07-18)
+
+
+### Features
+
+* **API:** add updated_since param for downloads ([#858](https://github.com/phrase/strings-openapi/issues/858)) ([db4196b](https://github.com/phrase/strings-openapi/commit/db4196bfb1a45f628577bebb99aad7da1179c241))
+* **API:** Add use_ordinal_rules attribute to request body for create/update Keys endpoints ([#868](https://github.com/phrase/strings-openapi/issues/868)) ([29410b5](https://github.com/phrase/strings-openapi/commit/29410b5d4edee9645f449d2d7de53fb953c1f0c2))
+* **API:** Add use_ordinal_rules boolean [STRINGS-2273] ([#846](https://github.com/phrase/strings-openapi/issues/846)) ([450ce0c](https://github.com/phrase/strings-openapi/commit/450ce0cce6bb2064758c44b130b39dd5539c2681))
+
+## [3.5.0](https://github.com/phrase/strings-openapi/compare/php-v3.4.0...php-v3.5.0) (2025-05-23)
+
+
+### Features
+
+* **API:** Add omit_statistics param to tags#show ([#834](https://github.com/phrase/strings-openapi/issues/834)) ([2058b18](https://github.com/phrase/strings-openapi/commit/2058b18297133075885ac99770aee2e171811cd6))
+
+## [3.4.0](https://github.com/phrase/strings-openapi/compare/php-v3.3.0...php-v3.4.0) (2025-05-16)
+
+
+### Features
+
+* **API:** Add "verify_mentioned_translations" parameter to uploads ([#830](https://github.com/phrase/strings-openapi/issues/830)) ([f2fdf60](https://github.com/phrase/strings-openapi/commit/f2fdf60dd97c3908293cd457a765dafde603bd9b))
+* **API:** Add processed & upload total translations on upload summary ([#824](https://github.com/phrase/strings-openapi/issues/824)) ([081db68](https://github.com/phrase/strings-openapi/commit/081db68d2ffcf5d66a81e07eec0a9572a1f9d633))
+* **API:** Translations unreview & batch unreview ([#831](https://github.com/phrase/strings-openapi/issues/831)) ([6a696db](https://github.com/phrase/strings-openapi/commit/6a696db00d80d8acaf5887a08a7a97997566eb8f))
+
+## [3.3.0](https://github.com/phrase/strings-openapi/compare/php-v3.2.0...php-v3.3.0) (2025-04-09)
+
+
+### Features
+
+* **API:** add updated_since filter to job list #STRINGS-1555 ([#799](https://github.com/phrase/strings-openapi/issues/799)) ([dc9b6ed](https://github.com/phrase/strings-openapi/commit/dc9b6ed12e013231d397820449086c87fea2f8ba))
+* **API:** Include roles in account response ([#811](https://github.com/phrase/strings-openapi/issues/811)) ([dc27ee5](https://github.com/phrase/strings-openapi/commit/dc27ee5117762222b6e1e6abb639f8e00c6a9101))
+* **PHP:** Address PHP 8.4 deprecations #STRINGS-1764 ([#823](https://github.com/phrase/strings-openapi/issues/823)) ([683aa47](https://github.com/phrase/strings-openapi/commit/683aa47667f69274fd7767bb3f222f3bcda566a5))
 
 
 ### Bug Fixes
 
-* **API:** Remove request body from GET comments ([#817](https://github.com/phrase/openapi/issues/817)) ([2646001](https://github.com/phrase/openapi/commit/264600132e80ac03983e0ae86e99db3d6fb9080d))
+* **API:** Remove request body from GET comments ([#817](https://github.com/phrase/strings-openapi/issues/817)) ([2646001](https://github.com/phrase/strings-openapi/commit/264600132e80ac03983e0ae86e99db3d6fb9080d))
 
-## [3.2.0](https://github.com/phrase/openapi/compare/php-v3.1.0...php-v3.2.0) (2025-02-17)
-
-
-### Features
-
-* **API:** document tags attribute of an upload #STRINGS-1221 ([#790](https://github.com/phrase/openapi/issues/790)) ([fff505b](https://github.com/phrase/openapi/commit/fff505bdff35a0033fee06e505c42fe794c88562))
-
-## [3.1.0](https://github.com/phrase/openapi/compare/php-v3.0.3...php-v3.1.0) (2025-02-17)
+## [3.2.0](https://github.com/phrase/strings-openapi/compare/php-v3.1.0...php-v3.2.0) (2025-02-17)
 
 
 ### Features
 
-* **API:** Add locale_ids param to synchronous download endpoint [STRINGS-1492] ([#780](https://github.com/phrase/openapi/issues/780)) ([47186a4](https://github.com/phrase/openapi/commit/47186a44fc8c0b8e466636acf3d49413b1f29f30))
-* **API:** Add source last updated at information on job details ([#777](https://github.com/phrase/openapi/issues/777)) ([c9b8423](https://github.com/phrase/openapi/commit/c9b8423766b4138980d0553502b3e18ca524f34e))
+* **API:** document tags attribute of an upload #STRINGS-1221 ([#790](https://github.com/phrase/strings-openapi/issues/790)) ([fff505b](https://github.com/phrase/strings-openapi/commit/fff505bdff35a0033fee06e505c42fe794c88562))
 
-## [3.0.3](https://github.com/phrase/openapi/compare/php-v3.0.2...php-v3.0.3) (2025-01-29)
-
-
-### Bug Fixes
-
-* **API:** pass translation_key_ids when removing keys from job ([#771](https://github.com/phrase/openapi/issues/771)) ([f670e27](https://github.com/phrase/openapi/commit/f670e2763b1112fefd1812109b3c09def42b7bd2))
-
-## [3.0.2](https://github.com/phrase/openapi/compare/php-v3.0.1...php-v3.0.2) (2025-01-06)
+## [3.1.0](https://github.com/phrase/strings-openapi/compare/php-v3.0.3...php-v3.1.0) (2025-02-17)
 
 
-### Bug Fixes
+### Features
 
-* **CLI:** Adjust operationId for quality_performance_score #STRINGS-1104 ([#721](https://github.com/phrase/openapi/issues/721)) ([7aa3b9b](https://github.com/phrase/openapi/commit/7aa3b9b508d1d24a4af7f4977b1a2fead8bfda78))
+* **API:** Add locale_ids param to synchronous download endpoint [STRINGS-1492] ([#780](https://github.com/phrase/strings-openapi/issues/780)) ([47186a4](https://github.com/phrase/strings-openapi/commit/47186a44fc8c0b8e466636acf3d49413b1f29f30))
+* **API:** Add source last updated at information on job details ([#777](https://github.com/phrase/strings-openapi/issues/777)) ([c9b8423](https://github.com/phrase/strings-openapi/commit/c9b8423766b4138980d0553502b3e18ca524f34e))
 
-## [3.0.1](https://github.com/phrase/openapi/compare/php-v3.0.0...php-v3.0.1) (2024-12-20)
+## [3.0.3](https://github.com/phrase/strings-openapi/compare/php-v3.0.2...php-v3.0.3) (2025-01-29)
 
 
 ### Bug Fixes
 
-* **API:** Repo Sync Event errors field type #STRINGS-1074 ([#756](https://github.com/phrase/openapi/issues/756)) ([c7670e0](https://github.com/phrase/openapi/commit/c7670e04810f95359d72ba6346b5f626bfb77b6f))
-* **API:** Repo Sync schema fixes #STRINGS-1074 ([#748](https://github.com/phrase/openapi/issues/748)) ([033be10](https://github.com/phrase/openapi/commit/033be1003fe01b5115de1f8ba2336d32b4862bfd))
+* **API:** pass translation_key_ids when removing keys from job ([#771](https://github.com/phrase/strings-openapi/issues/771)) ([f670e27](https://github.com/phrase/strings-openapi/commit/f670e2763b1112fefd1812109b3c09def42b7bd2))
 
-## [3.0.0](https://github.com/phrase/openapi/compare/php-v2.7.0...php-v3.0.0) (2024-12-18)
+## [3.0.2](https://github.com/phrase/strings-openapi/compare/php-v3.0.1...php-v3.0.2) (2025-01-06)
+
+
+### Bug Fixes
+
+* **CLI:** Adjust operationId for quality_performance_score #STRINGS-1104 ([#721](https://github.com/phrase/strings-openapi/issues/721)) ([7aa3b9b](https://github.com/phrase/strings-openapi/commit/7aa3b9b508d1d24a4af7f4977b1a2fead8bfda78))
+
+## [3.0.1](https://github.com/phrase/strings-openapi/compare/php-v3.0.0...php-v3.0.1) (2024-12-20)
+
+
+### Bug Fixes
+
+* **API:** Repo Sync Event errors field type #STRINGS-1074 ([#756](https://github.com/phrase/strings-openapi/issues/756)) ([c7670e0](https://github.com/phrase/strings-openapi/commit/c7670e04810f95359d72ba6346b5f626bfb77b6f))
+* **API:** Repo Sync schema fixes #STRINGS-1074 ([#748](https://github.com/phrase/strings-openapi/issues/748)) ([033be10](https://github.com/phrase/strings-openapi/commit/033be1003fe01b5115de1f8ba2336d32b4862bfd))
+
+## [3.0.0](https://github.com/phrase/strings-openapi/compare/php-v2.7.0...php-v3.0.0) (2024-12-18)
 
 
 ### ⚠ BREAKING CHANGES
 
-* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/openapi/issues/735))
+* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/strings-openapi/issues/735))
 
 ### Features
 
-* **API:** Add 'default_encoding' documentation ([#733](https://github.com/phrase/openapi/issues/733)) ([0139c51](https://github.com/phrase/openapi/commit/0139c51da747fbe7bc9929bcf3534aad7f22f39a))
-* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/openapi/issues/735)) ([c3bd8ec](https://github.com/phrase/openapi/commit/c3bd8eccaabcfa1b1066ea4438971ac59833af46))
+* **API:** Add 'default_encoding' documentation ([#733](https://github.com/phrase/strings-openapi/issues/733)) ([0139c51](https://github.com/phrase/strings-openapi/commit/0139c51da747fbe7bc9929bcf3534aad7f22f39a))
+* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/strings-openapi/issues/735)) ([c3bd8ec](https://github.com/phrase/strings-openapi/commit/c3bd8eccaabcfa1b1066ea4438971ac59833af46))
 
 
 ### Bug Fixes
 
-* **API:** Add missing branch parameter to job comment endpoints #STRINGS-988 ([#724](https://github.com/phrase/openapi/issues/724)) ([64d399c](https://github.com/phrase/openapi/commit/64d399ced0980ac2a48366f91110047287a0c590))
+* **API:** Add missing branch parameter to job comment endpoints #STRINGS-988 ([#724](https://github.com/phrase/strings-openapi/issues/724)) ([64d399c](https://github.com/phrase/strings-openapi/commit/64d399ced0980ac2a48366f91110047287a0c590))
 
-## [2.7.0](https://github.com/phrase/openapi/compare/php-v2.6.0...php-v2.7.0) (2024-11-27)
-
-
-### Features
-
-* **API:** autotranslate param in key creation [STRINGS-786] ([#713](https://github.com/phrase/openapi/issues/713)) ([581d0ff](https://github.com/phrase/openapi/commit/581d0ff5f1d06757e5ddd9603b78fc8d435d68ee))
-
-
-### Bug Fixes
-
-* **API:** Comment creation schema fix #STRINGS-866 ([#718](https://github.com/phrase/openapi/issues/718)) ([e201d13](https://github.com/phrase/openapi/commit/e201d1360c89698dd8d3642cc28f89dd0e50a1fb))
-
-## [2.6.0](https://github.com/phrase/openapi/compare/php-v2.5.0...php-v2.6.0) (2024-11-08)
+## [2.7.0](https://github.com/phrase/strings-openapi/compare/php-v2.6.0...php-v2.7.0) (2024-11-27)
 
 
 ### Features
 
-* **API:** Add Pagination header to POST search endpoints [[#457](https://github.com/phrase/openapi/issues/457)] ([#706](https://github.com/phrase/openapi/issues/706)) ([9a79fa3](https://github.com/phrase/openapi/commit/9a79fa31bb3b9d58272fa2f4e82d72d0d44a93a0))
+* **API:** autotranslate param in key creation [STRINGS-786] ([#713](https://github.com/phrase/strings-openapi/issues/713)) ([581d0ff](https://github.com/phrase/strings-openapi/commit/581d0ff5f1d06757e5ddd9603b78fc8d435d68ee))
 
 
 ### Bug Fixes
 
-* **PHP:** Fix serializing nested form parameters #STRINGS-730 ([#703](https://github.com/phrase/openapi/issues/703)) ([32746b1](https://github.com/phrase/openapi/commit/32746b1a68f217a6130f27b7b52997941f8f6c9d))
+* **API:** Comment creation schema fix #STRINGS-866 ([#718](https://github.com/phrase/strings-openapi/issues/718)) ([e201d13](https://github.com/phrase/strings-openapi/commit/e201d1360c89698dd8d3642cc28f89dd0e50a1fb))
 
-## [2.5.0](https://github.com/phrase/openapi/compare/php-v2.4.0...php-v2.5.0) (2024-10-02)
+## [2.6.0](https://github.com/phrase/strings-openapi/compare/php-v2.5.0...php-v2.6.0) (2024-11-08)
 
 
 ### Features
 
-* Add translation key prefixes for upload and download ([#687](https://github.com/phrase/openapi/issues/687)) ([9c9c959](https://github.com/phrase/openapi/commit/9c9c959830631bcac8beaf1de30ab31755ac1ee5))
+* **API:** Add Pagination header to POST search endpoints [[#457](https://github.com/phrase/strings-openapi/issues/457)] ([#706](https://github.com/phrase/strings-openapi/issues/706)) ([9a79fa3](https://github.com/phrase/strings-openapi/commit/9a79fa31bb3b9d58272fa2f4e82d72d0d44a93a0))
 
 
 ### Bug Fixes
 
-* **API:** Format list is not paginated and authenticated #STRINGS-458 ([#690](https://github.com/phrase/openapi/issues/690)) ([25e90f4](https://github.com/phrase/openapi/commit/25e90f46513e70cf328be80c36ae785cead05851))
+* **PHP:** Fix serializing nested form parameters #STRINGS-730 ([#703](https://github.com/phrase/strings-openapi/issues/703)) ([32746b1](https://github.com/phrase/strings-openapi/commit/32746b1a68f217a6130f27b7b52997941f8f6c9d))
 
-## [2.4.0](https://github.com/phrase/openapi/compare/php-v2.3.1...php-v2.4.0) (2024-09-09)
+## [2.5.0](https://github.com/phrase/strings-openapi/compare/php-v2.4.0...php-v2.5.0) (2024-10-02)
 
 
 ### Features
 
-* Add update_translations_on_source_match ([#670](https://github.com/phrase/openapi/issues/670)) ([11003ac](https://github.com/phrase/openapi/commit/11003ace7353bf99893482ca4aa32214abf3e581))
-
-## [2.3.1](https://github.com/phrase/openapi/compare/php-v2.3.0...php-v2.3.1) (2024-08-01)
+* Add translation key prefixes for upload and download ([#687](https://github.com/phrase/strings-openapi/issues/687)) ([9c9c959](https://github.com/phrase/strings-openapi/commit/9c9c959830631bcac8beaf1de30ab31755ac1ee5))
 
 
 ### Bug Fixes
 
-* **PHP:** Fix query param serialization of nested objects [TSI-2593] ([#663](https://github.com/phrase/openapi/issues/663)) ([c3a6525](https://github.com/phrase/openapi/commit/c3a6525328028e33a5c703724b9ac7803a4db8f1))
+* **API:** Format list is not paginated and authenticated #STRINGS-458 ([#690](https://github.com/phrase/strings-openapi/issues/690)) ([25e90f4](https://github.com/phrase/strings-openapi/commit/25e90f46513e70cf328be80c36ae785cead05851))
 
-## [2.3.0](https://github.com/phrase/openapi/compare/php-v2.2.1...php-v2.3.0) (2024-07-02)
+## [2.4.0](https://github.com/phrase/strings-openapi/compare/php-v2.3.1...php-v2.4.0) (2024-09-09)
 
 
 ### Features
 
-* add repo sync events show endpoint ([#641](https://github.com/phrase/openapi/issues/641)) ([e1d9cfb](https://github.com/phrase/openapi/commit/e1d9cfb23e079fea2d9e5475dff9a4137f1f0154))
-* **API:** Async downloads [TSI-2515] ([#642](https://github.com/phrase/openapi/issues/642)) ([6fcab5d](https://github.com/phrase/openapi/commit/6fcab5d4719f64e8e5dd49c327dc9348b384de4c))
+* Add update_translations_on_source_match ([#670](https://github.com/phrase/strings-openapi/issues/670)) ([11003ac](https://github.com/phrase/strings-openapi/commit/11003ace7353bf99893482ca4aa32214abf3e581))
 
-## [2.2.1](https://github.com/phrase/openapi/compare/php-v2.2.0...php-v2.2.1) (2024-06-18)
+## [2.3.1](https://github.com/phrase/strings-openapi/compare/php-v2.3.0...php-v2.3.1) (2024-08-01)
 
 
 ### Bug Fixes
 
-* add app_min_version and app_max_version param to releases ([#633](https://github.com/phrase/openapi/issues/633)) ([b384301](https://github.com/phrase/openapi/commit/b3843012460ace4c1d34c4373e5158595466adcb))
+* **PHP:** Fix query param serialization of nested objects [TSI-2593] ([#663](https://github.com/phrase/strings-openapi/issues/663)) ([c3a6525](https://github.com/phrase/strings-openapi/commit/c3a6525328028e33a5c703724b9ac7803a4db8f1))
 
-## [2.2.0](https://github.com/phrase/openapi/compare/php-v2.1.2...php-v2.2.0) (2024-06-12)
+## [2.3.0](https://github.com/phrase/strings-openapi/compare/php-v2.2.1...php-v2.3.0) (2024-07-02)
 
 
 ### Features
 
-* **API:** Add OTA Release Triggers API [TSI-2485] ([#622](https://github.com/phrase/openapi/issues/622)) ([8cb91dc](https://github.com/phrase/openapi/commit/8cb91dcce2c19ca700cf9d0713fa74f28ad59434))
+* add repo sync events show endpoint ([#641](https://github.com/phrase/strings-openapi/issues/641)) ([e1d9cfb](https://github.com/phrase/strings-openapi/commit/e1d9cfb23e079fea2d9e5475dff9a4137f1f0154))
+* **API:** Async downloads [TSI-2515] ([#642](https://github.com/phrase/strings-openapi/issues/642)) ([6fcab5d](https://github.com/phrase/strings-openapi/commit/6fcab5d4719f64e8e5dd49c327dc9348b384de4c))
 
-## [2.1.2](https://github.com/phrase/openapi/compare/php-v2.1.1...php-v2.1.2) (2024-05-31)
-
-
-### Bug Fixes
-
-* **CLI:** use id instead of repo_sync_id as param ([#618](https://github.com/phrase/openapi/issues/618)) ([7a1a0d9](https://github.com/phrase/openapi/commit/7a1a0d9115262dc7fa3065ee7cc76bec7a381ddb))
-
-## [2.1.1](https://github.com/phrase/openapi/compare/php-v2.1.0...php-v2.1.1) (2024-05-02)
+## [2.2.1](https://github.com/phrase/strings-openapi/compare/php-v2.2.0...php-v2.2.1) (2024-06-18)
 
 
 ### Bug Fixes
 
-* **PHP:** Fix deserializing custom metadata values in key response ([#607](https://github.com/phrase/openapi/issues/607)) ([b6eeeba](https://github.com/phrase/openapi/commit/b6eeeba223e3eabec268a8f3d372afcb6abd09dd))
+* add app_min_version and app_max_version param to releases ([#633](https://github.com/phrase/strings-openapi/issues/633)) ([b384301](https://github.com/phrase/strings-openapi/commit/b3843012460ace4c1d34c4373e5158595466adcb))
 
-## [2.1.0](https://github.com/phrase/openapi/compare/php-v2.0.0...php-v2.1.0) (2024-04-29)
+## [2.2.0](https://github.com/phrase/strings-openapi/compare/php-v2.1.2...php-v2.2.0) (2024-06-12)
 
 
 ### Features
 
-* **API:** Add 'update_translation_keys' for Uploads [TSI-2292] ([#578](https://github.com/phrase/openapi/issues/578)) ([4492ec0](https://github.com/phrase/openapi/commit/4492ec0a7c62f9de9ab1c1125071615bddcc26ce))
+* **API:** Add OTA Release Triggers API [TSI-2485] ([#622](https://github.com/phrase/strings-openapi/issues/622)) ([8cb91dc](https://github.com/phrase/strings-openapi/commit/8cb91dcce2c19ca700cf9d0713fa74f28ad59434))
 
-## [2.0.0](https://github.com/phrase/openapi/compare/php-v1.22.0...php-v2.0.0) (2024-04-23)
+## [2.1.2](https://github.com/phrase/strings-openapi/compare/php-v2.1.1...php-v2.1.2) (2024-05-31)
+
+
+### Bug Fixes
+
+* **CLI:** use id instead of repo_sync_id as param ([#618](https://github.com/phrase/strings-openapi/issues/618)) ([7a1a0d9](https://github.com/phrase/strings-openapi/commit/7a1a0d9115262dc7fa3065ee7cc76bec7a381ddb))
+
+## [2.1.1](https://github.com/phrase/strings-openapi/compare/php-v2.1.0...php-v2.1.1) (2024-05-02)
+
+
+### Bug Fixes
+
+* **PHP:** Fix deserializing custom metadata values in key response ([#607](https://github.com/phrase/strings-openapi/issues/607)) ([b6eeeba](https://github.com/phrase/strings-openapi/commit/b6eeeba223e3eabec268a8f3d372afcb6abd09dd))
+
+## [2.1.0](https://github.com/phrase/strings-openapi/compare/php-v2.0.0...php-v2.1.0) (2024-04-29)
+
+
+### Features
+
+* **API:** Add 'update_translation_keys' for Uploads [TSI-2292] ([#578](https://github.com/phrase/strings-openapi/issues/578)) ([4492ec0](https://github.com/phrase/strings-openapi/commit/4492ec0a7c62f9de9ab1c1125071615bddcc26ce))
+
+## [2.0.0](https://github.com/phrase/strings-openapi/compare/php-v1.22.0...php-v2.0.0) (2024-04-23)
 
 
 ### ⚠ BREAKING CHANGES
 
-* add missing required params ([#571](https://github.com/phrase/openapi/issues/571))
+* add missing required params ([#571](https://github.com/phrase/strings-openapi/issues/571))
 
 ### Code Refactoring
 
-* add missing required params ([#571](https://github.com/phrase/openapi/issues/571)) ([d810e9e](https://github.com/phrase/openapi/commit/d810e9ebc767e14ba9e56106de8c5774d9d6d178))
+* add missing required params ([#571](https://github.com/phrase/strings-openapi/issues/571)) ([d810e9e](https://github.com/phrase/strings-openapi/commit/d810e9ebc767e14ba9e56106de8c5774d9d6d178))
 
-## [1.22.0](https://github.com/phrase/openapi/compare/php-v1.21.0...php-v1.22.0) (2024-04-22)
+## [1.22.0](https://github.com/phrase/strings-openapi/compare/php-v1.21.0...php-v1.22.0) (2024-04-22)
 
 
 ### Features
 
-* [TSI-2083] enable format_options argument for java-client   ([#426](https://github.com/phrase/openapi/issues/426)) ([faa8cb3](https://github.com/phrase/openapi/commit/faa8cb353ba9f1030b9f7cfd46b894b4d6d26e70))
-* Add linked-parent to translation details ([#570](https://github.com/phrase/openapi/issues/570)) ([2c6f432](https://github.com/phrase/openapi/commit/2c6f43253e24b670b71ac810c85dce0759c29403))
-* add query param for properties ([#542](https://github.com/phrase/openapi/issues/542)) ([b4e12d0](https://github.com/phrase/openapi/commit/b4e12d04fd2916351f9201e1e6de504143ecc9aa))
-* Add reports locales endpoint to API [TSS-2439] ([#465](https://github.com/phrase/openapi/issues/465)) ([e03aa9f](https://github.com/phrase/openapi/commit/e03aa9f49f031517b36db715fe70e8e0b65a438b))
-* **API:** add Custom Metadata endpoints ([#474](https://github.com/phrase/openapi/issues/474)) ([d407d8b](https://github.com/phrase/openapi/commit/d407d8be5ccddec1afde14a12804a7a616f77d7a))
-* **API:** Add custom_metadata_filters param to locale download endpoint [TSI-2174] ([#478](https://github.com/phrase/openapi/issues/478)) ([3623478](https://github.com/phrase/openapi/commit/3623478fc1518b457ab018b5630a693081637d6e))
-* **API:** add Linked Keys endpoints ([#555](https://github.com/phrase/openapi/issues/555)) ([4935dac](https://github.com/phrase/openapi/commit/4935dac58c787eaade2f1f65ce649f466b5e3a60))
-* **API:** Add order param to comment list endpoints ([#441](https://github.com/phrase/openapi/issues/441)) ([441c9c4](https://github.com/phrase/openapi/commit/441c9c46169f8c5ac4e71ade09a95dab136314ef))
-* **api:** Add QPS endpoint and documentation ([#521](https://github.com/phrase/openapi/issues/521)) ([d22c558](https://github.com/phrase/openapi/commit/d22c558adfbb7fcd13759e388c038744914e42fa))
-* **API:** Add Repo Sync [TSI-1923] ([#569](https://github.com/phrase/openapi/issues/569)) ([0bd1756](https://github.com/phrase/openapi/commit/0bd17562018cb045ff41cc1ff5008b9419a0ed12))
-* **API:** Add url field to uploads ([#481](https://github.com/phrase/openapi/issues/481)) ([7332a84](https://github.com/phrase/openapi/commit/7332a84f9958346f2fb28dee4b0353519ef466d5))
-* **API:** Document new query parameters ([#393](https://github.com/phrase/openapi/issues/393)) ([770515a](https://github.com/phrase/openapi/commit/770515a9628122955bb3919405babf9392684eb9))
-* **API:** Implement figma attachments endpoints ([#415](https://github.com/phrase/openapi/issues/415)) ([970e612](https://github.com/phrase/openapi/commit/970e612fda620ca882a221ef541036b8d200b675))
-* **API:** Introduce comment replies endpoints ([#383](https://github.com/phrase/openapi/issues/383)) ([71351ac](https://github.com/phrase/openapi/commit/71351ac285f4f49976092e176c77b09f3485eb65))
-* Optionally tag only affected keys on upload [TSI-2041] ([#412](https://github.com/phrase/openapi/issues/412)) ([e8f958e](https://github.com/phrase/openapi/commit/e8f958e91469c2542f44ab68469c933688958383))
-* **TSE-950:** Document comment_reactions endpoints ([#380](https://github.com/phrase/openapi/issues/380)) ([f230244](https://github.com/phrase/openapi/commit/f230244e6e9c069b18edc4c35dd5e290fd14793b))
-* **TSI-1946:** Add reviewed_at to translations ([#396](https://github.com/phrase/openapi/issues/396)) ([3e663d9](https://github.com/phrase/openapi/commit/3e663d971a99a816f0165dd6653a9a1e8a87c95e))
-* Update openapi-generator to v7 ([#418](https://github.com/phrase/openapi/issues/418)) ([524626f](https://github.com/phrase/openapi/commit/524626f5e914bfef6025d0e1c2cbc7a728d08f56))
+* [TSI-2083] enable format_options argument for java-client   ([#426](https://github.com/phrase/strings-openapi/issues/426)) ([faa8cb3](https://github.com/phrase/strings-openapi/commit/faa8cb353ba9f1030b9f7cfd46b894b4d6d26e70))
+* Add linked-parent to translation details ([#570](https://github.com/phrase/strings-openapi/issues/570)) ([2c6f432](https://github.com/phrase/strings-openapi/commit/2c6f43253e24b670b71ac810c85dce0759c29403))
+* add query param for properties ([#542](https://github.com/phrase/strings-openapi/issues/542)) ([b4e12d0](https://github.com/phrase/strings-openapi/commit/b4e12d04fd2916351f9201e1e6de504143ecc9aa))
+* Add reports locales endpoint to API [TSS-2439] ([#465](https://github.com/phrase/strings-openapi/issues/465)) ([e03aa9f](https://github.com/phrase/strings-openapi/commit/e03aa9f49f031517b36db715fe70e8e0b65a438b))
+* **API:** add Custom Metadata endpoints ([#474](https://github.com/phrase/strings-openapi/issues/474)) ([d407d8b](https://github.com/phrase/strings-openapi/commit/d407d8be5ccddec1afde14a12804a7a616f77d7a))
+* **API:** Add custom_metadata_filters param to locale download endpoint [TSI-2174] ([#478](https://github.com/phrase/strings-openapi/issues/478)) ([3623478](https://github.com/phrase/strings-openapi/commit/3623478fc1518b457ab018b5630a693081637d6e))
+* **API:** add Linked Keys endpoints ([#555](https://github.com/phrase/strings-openapi/issues/555)) ([4935dac](https://github.com/phrase/strings-openapi/commit/4935dac58c787eaade2f1f65ce649f466b5e3a60))
+* **API:** Add order param to comment list endpoints ([#441](https://github.com/phrase/strings-openapi/issues/441)) ([441c9c4](https://github.com/phrase/strings-openapi/commit/441c9c46169f8c5ac4e71ade09a95dab136314ef))
+* **api:** Add QPS endpoint and documentation ([#521](https://github.com/phrase/strings-openapi/issues/521)) ([d22c558](https://github.com/phrase/strings-openapi/commit/d22c558adfbb7fcd13759e388c038744914e42fa))
+* **API:** Add Repo Sync [TSI-1923] ([#569](https://github.com/phrase/strings-openapi/issues/569)) ([0bd1756](https://github.com/phrase/strings-openapi/commit/0bd17562018cb045ff41cc1ff5008b9419a0ed12))
+* **API:** Add url field to uploads ([#481](https://github.com/phrase/strings-openapi/issues/481)) ([7332a84](https://github.com/phrase/strings-openapi/commit/7332a84f9958346f2fb28dee4b0353519ef466d5))
+* **API:** Document new query parameters ([#393](https://github.com/phrase/strings-openapi/issues/393)) ([770515a](https://github.com/phrase/strings-openapi/commit/770515a9628122955bb3919405babf9392684eb9))
+* **API:** Implement figma attachments endpoints ([#415](https://github.com/phrase/strings-openapi/issues/415)) ([970e612](https://github.com/phrase/strings-openapi/commit/970e612fda620ca882a221ef541036b8d200b675))
+* **API:** Introduce comment replies endpoints ([#383](https://github.com/phrase/strings-openapi/issues/383)) ([71351ac](https://github.com/phrase/strings-openapi/commit/71351ac285f4f49976092e176c77b09f3485eb65))
+* Optionally tag only affected keys on upload [TSI-2041] ([#412](https://github.com/phrase/strings-openapi/issues/412)) ([e8f958e](https://github.com/phrase/strings-openapi/commit/e8f958e91469c2542f44ab68469c933688958383))
+* **TSE-950:** Document comment_reactions endpoints ([#380](https://github.com/phrase/strings-openapi/issues/380)) ([f230244](https://github.com/phrase/strings-openapi/commit/f230244e6e9c069b18edc4c35dd5e290fd14793b))
+* **TSI-1946:** Add reviewed_at to translations ([#396](https://github.com/phrase/strings-openapi/issues/396)) ([3e663d9](https://github.com/phrase/strings-openapi/commit/3e663d971a99a816f0165dd6653a9a1e8a87c95e))
+* Update openapi-generator to v7 ([#418](https://github.com/phrase/strings-openapi/issues/418)) ([524626f](https://github.com/phrase/strings-openapi/commit/524626f5e914bfef6025d0e1c2cbc7a728d08f56))
 
 
 ### Bug Fixes
 
-* (API) Add mandatory params to linked keys endpoints ([#564](https://github.com/phrase/openapi/issues/564)) ([08d9846](https://github.com/phrase/openapi/commit/08d9846bc224d349e2ade9abf28d733afb1e8be3))
-* **API:** Adjust documentation of QPS endpoint ([#525](https://github.com/phrase/openapi/issues/525)) ([4b4f1ac](https://github.com/phrase/openapi/commit/4b4f1acf28fbd13b3d16c37162cdccfa05c38ffa))
-* **API:** allow nullable value for job's due_date ([#534](https://github.com/phrase/openapi/issues/534)) ([38b51b5](https://github.com/phrase/openapi/commit/38b51b51095394f8ce769873140038abba628514))
-* **API:** Create Custom Metadata endpoint fix [TSI-2222] ([#499](https://github.com/phrase/openapi/issues/499)) ([ce2ed94](https://github.com/phrase/openapi/commit/ce2ed9488e111fb5d9bc3810a78c47d23553c8b7))
-* Fix gitlab_sync history status type mismatch ([#363](https://github.com/phrase/openapi/issues/363)) ([ebcaa4e](https://github.com/phrase/openapi/commit/ebcaa4e5dfcb2f73559a56c78b0f2512ca798375))
-* **schemas:** Fix gitlab_sync type mismatch ([#373](https://github.com/phrase/openapi/issues/373)) ([1cb1f65](https://github.com/phrase/openapi/commit/1cb1f650598c68afee6e2cd7c3c4ede1484aba35))
+* (API) Add mandatory params to linked keys endpoints ([#564](https://github.com/phrase/strings-openapi/issues/564)) ([08d9846](https://github.com/phrase/strings-openapi/commit/08d9846bc224d349e2ade9abf28d733afb1e8be3))
+* **API:** Adjust documentation of QPS endpoint ([#525](https://github.com/phrase/strings-openapi/issues/525)) ([4b4f1ac](https://github.com/phrase/strings-openapi/commit/4b4f1acf28fbd13b3d16c37162cdccfa05c38ffa))
+* **API:** allow nullable value for job's due_date ([#534](https://github.com/phrase/strings-openapi/issues/534)) ([38b51b5](https://github.com/phrase/strings-openapi/commit/38b51b51095394f8ce769873140038abba628514))
+* **API:** Create Custom Metadata endpoint fix [TSI-2222] ([#499](https://github.com/phrase/strings-openapi/issues/499)) ([ce2ed94](https://github.com/phrase/strings-openapi/commit/ce2ed9488e111fb5d9bc3810a78c47d23553c8b7))
+* Fix gitlab_sync history status type mismatch ([#363](https://github.com/phrase/strings-openapi/issues/363)) ([ebcaa4e](https://github.com/phrase/strings-openapi/commit/ebcaa4e5dfcb2f73559a56c78b0f2512ca798375))
+* **schemas:** Fix gitlab_sync type mismatch ([#373](https://github.com/phrase/strings-openapi/issues/373)) ([1cb1f65](https://github.com/phrase/strings-openapi/commit/1cb1f650598c68afee6e2cd7c3c4ede1484aba35))
 
-## [1.21.0](https://github.com/phrase/openapi/compare/php-v1.20.0...php-v1.21.0) (2024-04-10)
+## [1.21.0](https://github.com/phrase/strings-openapi/compare/php-v1.20.0...php-v1.21.0) (2024-04-10)
 
 
 ### Features
 
-* **API:** add Linked Keys endpoints ([#555](https://github.com/phrase/openapi/issues/555)) ([4935dac](https://github.com/phrase/openapi/commit/4935dac58c787eaade2f1f65ce649f466b5e3a60))
+* **API:** add Linked Keys endpoints ([#555](https://github.com/phrase/strings-openapi/issues/555)) ([4935dac](https://github.com/phrase/strings-openapi/commit/4935dac58c787eaade2f1f65ce649f466b5e3a60))
 
 
 ### Bug Fixes
 
-* (API) Add mandatory params to linked keys endpoints ([#564](https://github.com/phrase/openapi/issues/564)) ([08d9846](https://github.com/phrase/openapi/commit/08d9846bc224d349e2ade9abf28d733afb1e8be3))
+* (API) Add mandatory params to linked keys endpoints ([#564](https://github.com/phrase/strings-openapi/issues/564)) ([08d9846](https://github.com/phrase/strings-openapi/commit/08d9846bc224d349e2ade9abf28d733afb1e8be3))
 
-## [1.20.0](https://github.com/phrase/openapi/compare/php-v1.19.2...php-v1.20.0) (2024-02-07)
+## [1.20.0](https://github.com/phrase/strings-openapi/compare/php-v1.19.2...php-v1.20.0) (2024-02-07)
 
 
 ### Features
 
-* add query param for properties ([#542](https://github.com/phrase/openapi/issues/542)) ([b4e12d0](https://github.com/phrase/openapi/commit/b4e12d04fd2916351f9201e1e6de504143ecc9aa))
+* add query param for properties ([#542](https://github.com/phrase/strings-openapi/issues/542)) ([b4e12d0](https://github.com/phrase/strings-openapi/commit/b4e12d04fd2916351f9201e1e6de504143ecc9aa))
 
-## [1.19.2](https://github.com/phrase/openapi/compare/php-v1.19.1...php-v1.19.2) (2024-02-05)
+## [1.19.2](https://github.com/phrase/strings-openapi/compare/php-v1.19.1...php-v1.19.2) (2024-02-05)
 
 
 ### Bug Fixes
 
-* **API:** allow nullable value for job's due_date ([#534](https://github.com/phrase/openapi/issues/534)) ([38b51b5](https://github.com/phrase/openapi/commit/38b51b51095394f8ce769873140038abba628514))
+* **API:** allow nullable value for job's due_date ([#534](https://github.com/phrase/strings-openapi/issues/534)) ([38b51b5](https://github.com/phrase/strings-openapi/commit/38b51b51095394f8ce769873140038abba628514))
 
-## [1.19.1](https://github.com/phrase/openapi/compare/php-v1.19.0...php-v1.19.1) (2024-02-01)
-
-
-### Bug Fixes
-
-* **API:** Adjust documentation of QPS endpoint ([#525](https://github.com/phrase/openapi/issues/525)) ([4b4f1ac](https://github.com/phrase/openapi/commit/4b4f1acf28fbd13b3d16c37162cdccfa05c38ffa))
-
-## [1.19.0](https://github.com/phrase/openapi/compare/php-v1.18.0...php-v1.19.0) (2024-01-17)
-
-
-### Features
-
-* **api:** Add QPS endpoint and documentation ([#521](https://github.com/phrase/openapi/issues/521)) ([d22c558](https://github.com/phrase/openapi/commit/d22c558adfbb7fcd13759e388c038744914e42fa))
+## [1.19.1](https://github.com/phrase/strings-openapi/compare/php-v1.19.0...php-v1.19.1) (2024-02-01)
 
 
 ### Bug Fixes
 
-* **API:** Create Custom Metadata endpoint fix [TSI-2222] ([#499](https://github.com/phrase/openapi/issues/499)) ([ce2ed94](https://github.com/phrase/openapi/commit/ce2ed9488e111fb5d9bc3810a78c47d23553c8b7))
+* **API:** Adjust documentation of QPS endpoint ([#525](https://github.com/phrase/strings-openapi/issues/525)) ([4b4f1ac](https://github.com/phrase/strings-openapi/commit/4b4f1acf28fbd13b3d16c37162cdccfa05c38ffa))
 
-## [1.18.0](https://github.com/phrase/openapi/compare/php-v1.17.0...php-v1.18.0) (2023-12-14)
-
-
-### Features
-
-* Add reports locales endpoint to API [TSS-2439] ([#465](https://github.com/phrase/openapi/issues/465)) ([e03aa9f](https://github.com/phrase/openapi/commit/e03aa9f49f031517b36db715fe70e8e0b65a438b))
-* **API:** add Custom Metadata endpoints ([#474](https://github.com/phrase/openapi/issues/474)) ([d407d8b](https://github.com/phrase/openapi/commit/d407d8be5ccddec1afde14a12804a7a616f77d7a))
-* **API:** Add custom_metadata_filters param to locale download endpoint [TSI-2174] ([#478](https://github.com/phrase/openapi/issues/478)) ([3623478](https://github.com/phrase/openapi/commit/3623478fc1518b457ab018b5630a693081637d6e))
-* **API:** Add url field to uploads ([#481](https://github.com/phrase/openapi/issues/481)) ([7332a84](https://github.com/phrase/openapi/commit/7332a84f9958346f2fb28dee4b0353519ef466d5))
-
-## [1.17.0](https://github.com/phrase/openapi/compare/php-v1.16.0...php-v1.17.0) (2023-11-03)
+## [1.19.0](https://github.com/phrase/strings-openapi/compare/php-v1.18.0...php-v1.19.0) (2024-01-17)
 
 
 ### Features
 
-* [TSI-2083] enable format_options argument for java-client   ([#426](https://github.com/phrase/openapi/issues/426)) ([faa8cb3](https://github.com/phrase/openapi/commit/faa8cb353ba9f1030b9f7cfd46b894b4d6d26e70))
-
-## [1.16.0](https://github.com/phrase/openapi/compare/php-v1.15.0...php-v1.16.0) (2023-10-30)
-
-
-### Features
-
-* Update openapi-generator to v7 ([#418](https://github.com/phrase/openapi/issues/418)) ([524626f](https://github.com/phrase/openapi/commit/524626f5e914bfef6025d0e1c2cbc7a728d08f56))
-
-## [1.15.0](https://github.com/phrase/openapi/compare/php-v1.14.0...php-v1.15.0) (2023-10-23)
-
-
-### Features
-
-* **API:** Add order param to comment list endpoints ([#441](https://github.com/phrase/openapi/issues/441)) ([441c9c4](https://github.com/phrase/openapi/commit/441c9c46169f8c5ac4e71ade09a95dab136314ef))
-
-## [1.14.0](https://github.com/phrase/openapi/compare/php-v1.13.0...php-v1.14.0) (2023-10-13)
-
-
-### Features
-
-* **API:** Implement figma attachments endpoints ([#415](https://github.com/phrase/openapi/issues/415)) ([970e612](https://github.com/phrase/openapi/commit/970e612fda620ca882a221ef541036b8d200b675))
-
-## [1.13.0](https://github.com/phrase/openapi/compare/php-v1.12.0...php-v1.13.0) (2023-09-12)
-
-
-### Features
-
-* Optionally tag only affected keys on upload [TSI-2041] ([#412](https://github.com/phrase/openapi/issues/412)) ([e8f958e](https://github.com/phrase/openapi/commit/e8f958e91469c2542f44ab68469c933688958383))
-* **TSI-1946:** Add reviewed_at to translations ([#396](https://github.com/phrase/openapi/issues/396)) ([3e663d9](https://github.com/phrase/openapi/commit/3e663d971a99a816f0165dd6653a9a1e8a87c95e))
-
-## [1.12.0](https://github.com/phrase/openapi/compare/php-v1.11.0...php-v1.12.0) (2023-08-28)
-
-
-### Features
-
-* **API:** Document new query parameters ([#393](https://github.com/phrase/openapi/issues/393)) ([770515a](https://github.com/phrase/openapi/commit/770515a9628122955bb3919405babf9392684eb9))
-
-## [1.11.0](https://github.com/phrase/openapi/compare/php-v1.10.0...php-v1.11.0) (2023-08-24)
-
-
-### Features
-
-* **API:** Introduce comment replies endpoints ([#383](https://github.com/phrase/openapi/issues/383)) ([71351ac](https://github.com/phrase/openapi/commit/71351ac285f4f49976092e176c77b09f3485eb65))
-
-## [1.10.0](https://github.com/phrase/openapi/compare/php-v1.9.1...php-v1.10.0) (2023-08-22)
-
-
-### Features
-
-* **TSE-950:** Document comment_reactions endpoints ([#380](https://github.com/phrase/openapi/issues/380)) ([f230244](https://github.com/phrase/openapi/commit/f230244e6e9c069b18edc4c35dd5e290fd14793b))
+* **api:** Add QPS endpoint and documentation ([#521](https://github.com/phrase/strings-openapi/issues/521)) ([d22c558](https://github.com/phrase/strings-openapi/commit/d22c558adfbb7fcd13759e388c038744914e42fa))
 
 
 ### Bug Fixes
 
-* **schemas:** Fix gitlab_sync type mismatch ([#373](https://github.com/phrase/openapi/issues/373)) ([1cb1f65](https://github.com/phrase/openapi/commit/1cb1f650598c68afee6e2cd7c3c4ede1484aba35))
+* **API:** Create Custom Metadata endpoint fix [TSI-2222] ([#499](https://github.com/phrase/strings-openapi/issues/499)) ([ce2ed94](https://github.com/phrase/strings-openapi/commit/ce2ed9488e111fb5d9bc3810a78c47d23553c8b7))
 
-## [1.9.1](https://github.com/phrase/openapi/compare/php-v1.9.0...php-v1.9.1) (2023-07-28)
+## [1.18.0](https://github.com/phrase/strings-openapi/compare/php-v1.17.0...php-v1.18.0) (2023-12-14)
+
+
+### Features
+
+* Add reports locales endpoint to API [TSS-2439] ([#465](https://github.com/phrase/strings-openapi/issues/465)) ([e03aa9f](https://github.com/phrase/strings-openapi/commit/e03aa9f49f031517b36db715fe70e8e0b65a438b))
+* **API:** add Custom Metadata endpoints ([#474](https://github.com/phrase/strings-openapi/issues/474)) ([d407d8b](https://github.com/phrase/strings-openapi/commit/d407d8be5ccddec1afde14a12804a7a616f77d7a))
+* **API:** Add custom_metadata_filters param to locale download endpoint [TSI-2174] ([#478](https://github.com/phrase/strings-openapi/issues/478)) ([3623478](https://github.com/phrase/strings-openapi/commit/3623478fc1518b457ab018b5630a693081637d6e))
+* **API:** Add url field to uploads ([#481](https://github.com/phrase/strings-openapi/issues/481)) ([7332a84](https://github.com/phrase/strings-openapi/commit/7332a84f9958346f2fb28dee4b0353519ef466d5))
+
+## [1.17.0](https://github.com/phrase/strings-openapi/compare/php-v1.16.0...php-v1.17.0) (2023-11-03)
+
+
+### Features
+
+* [TSI-2083] enable format_options argument for java-client   ([#426](https://github.com/phrase/strings-openapi/issues/426)) ([faa8cb3](https://github.com/phrase/strings-openapi/commit/faa8cb353ba9f1030b9f7cfd46b894b4d6d26e70))
+
+## [1.16.0](https://github.com/phrase/strings-openapi/compare/php-v1.15.0...php-v1.16.0) (2023-10-30)
+
+
+### Features
+
+* Update openapi-generator to v7 ([#418](https://github.com/phrase/strings-openapi/issues/418)) ([524626f](https://github.com/phrase/strings-openapi/commit/524626f5e914bfef6025d0e1c2cbc7a728d08f56))
+
+## [1.15.0](https://github.com/phrase/strings-openapi/compare/php-v1.14.0...php-v1.15.0) (2023-10-23)
+
+
+### Features
+
+* **API:** Add order param to comment list endpoints ([#441](https://github.com/phrase/strings-openapi/issues/441)) ([441c9c4](https://github.com/phrase/strings-openapi/commit/441c9c46169f8c5ac4e71ade09a95dab136314ef))
+
+## [1.14.0](https://github.com/phrase/strings-openapi/compare/php-v1.13.0...php-v1.14.0) (2023-10-13)
+
+
+### Features
+
+* **API:** Implement figma attachments endpoints ([#415](https://github.com/phrase/strings-openapi/issues/415)) ([970e612](https://github.com/phrase/strings-openapi/commit/970e612fda620ca882a221ef541036b8d200b675))
+
+## [1.13.0](https://github.com/phrase/strings-openapi/compare/php-v1.12.0...php-v1.13.0) (2023-09-12)
+
+
+### Features
+
+* Optionally tag only affected keys on upload [TSI-2041] ([#412](https://github.com/phrase/strings-openapi/issues/412)) ([e8f958e](https://github.com/phrase/strings-openapi/commit/e8f958e91469c2542f44ab68469c933688958383))
+* **TSI-1946:** Add reviewed_at to translations ([#396](https://github.com/phrase/strings-openapi/issues/396)) ([3e663d9](https://github.com/phrase/strings-openapi/commit/3e663d971a99a816f0165dd6653a9a1e8a87c95e))
+
+## [1.12.0](https://github.com/phrase/strings-openapi/compare/php-v1.11.0...php-v1.12.0) (2023-08-28)
+
+
+### Features
+
+* **API:** Document new query parameters ([#393](https://github.com/phrase/strings-openapi/issues/393)) ([770515a](https://github.com/phrase/strings-openapi/commit/770515a9628122955bb3919405babf9392684eb9))
+
+## [1.11.0](https://github.com/phrase/strings-openapi/compare/php-v1.10.0...php-v1.11.0) (2023-08-24)
+
+
+### Features
+
+* **API:** Introduce comment replies endpoints ([#383](https://github.com/phrase/strings-openapi/issues/383)) ([71351ac](https://github.com/phrase/strings-openapi/commit/71351ac285f4f49976092e176c77b09f3485eb65))
+
+## [1.10.0](https://github.com/phrase/strings-openapi/compare/php-v1.9.1...php-v1.10.0) (2023-08-22)
+
+
+### Features
+
+* **TSE-950:** Document comment_reactions endpoints ([#380](https://github.com/phrase/strings-openapi/issues/380)) ([f230244](https://github.com/phrase/strings-openapi/commit/f230244e6e9c069b18edc4c35dd5e290fd14793b))
 
 
 ### Bug Fixes
 
-* Fix gitlab_sync history status type mismatch ([#363](https://github.com/phrase/openapi/issues/363)) ([ebcaa4e](https://github.com/phrase/openapi/commit/ebcaa4e5dfcb2f73559a56c78b0f2512ca798375))
+* **schemas:** Fix gitlab_sync type mismatch ([#373](https://github.com/phrase/strings-openapi/issues/373)) ([1cb1f65](https://github.com/phrase/strings-openapi/commit/1cb1f650598c68afee6e2cd7c3c4ede1484aba35))
+
+## [1.9.1](https://github.com/phrase/strings-openapi/compare/php-v1.9.0...php-v1.9.1) (2023-07-28)
+
+
+### Bug Fixes
+
+* Fix gitlab_sync history status type mismatch ([#363](https://github.com/phrase/strings-openapi/issues/363)) ([ebcaa4e](https://github.com/phrase/strings-openapi/commit/ebcaa4e5dfcb2f73559a56c78b0f2512ca798375))

--- a/clients/ruby/CHANGELOG.md
+++ b/clients/ruby/CHANGELOG.md
@@ -7,399 +7,399 @@
 
 * **API:** Add linked_translation to translation type ([#1005](https://github.com/phrase/strings-openapi/issues/1005)) ([b18e64c](https://github.com/phrase/strings-openapi/commit/b18e64c948d40a9e5f996e8fdf6dee07d1812b02))
 
-## [4.16.0](https://github.com/phrase/openapi/compare/ruby-v4.15.0...ruby-v4.16.0) (2026-01-09)
+## [4.16.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.15.0...ruby-v4.16.0) (2026-01-09)
 
 
 ### Features
 
-* **API:** Add missing project flags to project details schema #SCD-141 ([#993](https://github.com/phrase/openapi/issues/993)) ([93fbdd7](https://github.com/phrase/openapi/commit/93fbdd76150ed94374ef888ac92c0c9b626de7c8))
+* **API:** Add missing project flags to project details schema #SCD-141 ([#993](https://github.com/phrase/strings-openapi/issues/993)) ([93fbdd7](https://github.com/phrase/strings-openapi/commit/93fbdd76150ed94374ef888ac92c0c9b626de7c8))
 
 
 ### Bug Fixes
 
-* **API:** drop invalid account locale params ([#992](https://github.com/phrase/openapi/issues/992)) ([87af83c](https://github.com/phrase/openapi/commit/87af83c94fd7e47340b5393847e93a31127abbe8))
+* **API:** drop invalid account locale params ([#992](https://github.com/phrase/strings-openapi/issues/992)) ([87af83c](https://github.com/phrase/strings-openapi/commit/87af83c94fd7e47340b5393847e93a31127abbe8))
 
-## [4.15.0](https://github.com/phrase/openapi/compare/ruby-v4.14.1...ruby-v4.15.0) (2025-12-11)
+## [4.15.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.14.1...ruby-v4.15.0) (2025-12-11)
 
 
 ### Features
 
-* **API:** Add create comparison endpoint for branches [SCD-549] ([#966](https://github.com/phrase/openapi/issues/966)) ([4099e32](https://github.com/phrase/openapi/commit/4099e32d42744f9d73346077ef30b0f4bd5c849e))
-* **API:** add manual triggering of automations #SCM-953 ([#968](https://github.com/phrase/openapi/issues/968)) ([ebe1c68](https://github.com/phrase/openapi/commit/ebe1c68e472d87ea6c6cd2f76bb421406c30a274))
-* **API:** add use_locale_fallback option to download #SCD-620 ([#976](https://github.com/phrase/openapi/issues/976)) ([9266c68](https://github.com/phrase/openapi/commit/9266c680d8717bb736aed83625858f0b3419da54))
+* **API:** Add create comparison endpoint for branches [SCD-549] ([#966](https://github.com/phrase/strings-openapi/issues/966)) ([4099e32](https://github.com/phrase/strings-openapi/commit/4099e32d42744f9d73346077ef30b0f4bd5c849e))
+* **API:** add manual triggering of automations #SCM-953 ([#968](https://github.com/phrase/strings-openapi/issues/968)) ([ebe1c68](https://github.com/phrase/strings-openapi/commit/ebe1c68e472d87ea6c6cd2f76bb421406c30a274))
+* **API:** add use_locale_fallback option to download #SCD-620 ([#976](https://github.com/phrase/strings-openapi/issues/976)) ([9266c68](https://github.com/phrase/strings-openapi/commit/9266c680d8717bb736aed83625858f0b3419da54))
 
-## [4.14.1](https://github.com/phrase/openapi/compare/ruby-v4.14.0...ruby-v4.14.1) (2025-11-10)
+## [4.14.1](https://github.com/phrase/strings-openapi/compare/ruby-v4.14.0...ruby-v4.14.1) (2025-11-10)
 
 
 ### Bug Fixes
 
-* **API:** Add omit_translation_keys to Jobs#show endpoint ([#957](https://github.com/phrase/openapi/issues/957)) ([23ece66](https://github.com/phrase/openapi/commit/23ece66b05fc748a4598ce876cb2954ed1a385cc))
+* **API:** Add omit_translation_keys to Jobs#show endpoint ([#957](https://github.com/phrase/strings-openapi/issues/957)) ([23ece66](https://github.com/phrase/strings-openapi/commit/23ece66b05fc748a4598ce876cb2954ed1a385cc))
 
-## [4.14.0](https://github.com/phrase/openapi/compare/ruby-v4.13.0...ruby-v4.14.0) (2025-10-27)
-
-
-### Features
-
-* **API:** Support omit_translation_keys param in Jobs#show ([#944](https://github.com/phrase/openapi/issues/944)) ([690a2ce](https://github.com/phrase/openapi/commit/690a2ce992359e7920367699145d2d4ff3a206fa))
-
-## [4.13.0](https://github.com/phrase/openapi/compare/ruby-v4.12.0...ruby-v4.13.0) (2025-10-23)
+## [4.14.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.13.0...ruby-v4.14.0) (2025-10-27)
 
 
 ### Features
 
-* **API:** Support source_locale_id param in uploads ([#935](https://github.com/phrase/openapi/issues/935)) ([304a406](https://github.com/phrase/openapi/commit/304a4061aaac8001a3a9e10c5cf985b04c31dab2))
+* **API:** Support omit_translation_keys param in Jobs#show ([#944](https://github.com/phrase/strings-openapi/issues/944)) ([690a2ce](https://github.com/phrase/strings-openapi/commit/690a2ce992359e7920367699145d2d4ff3a206fa))
 
-## [4.12.0](https://github.com/phrase/openapi/compare/ruby-v4.11.0...ruby-v4.12.0) (2025-10-16)
-
-
-### Features
-
-* List child branches ([#926](https://github.com/phrase/openapi/issues/926)) ([31d3b57](https://github.com/phrase/openapi/commit/31d3b57e0d1381149409b77c3e236b226cde22a1))
-
-## [4.11.0](https://github.com/phrase/openapi/compare/ruby-v4.10.0...ruby-v4.11.0) (2025-10-01)
+## [4.13.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.12.0...ruby-v4.13.0) (2025-10-23)
 
 
 ### Features
 
-* add branch sync endpoint ([#912](https://github.com/phrase/openapi/issues/912)) ([3293917](https://github.com/phrase/openapi/commit/329391757b3f81574448b1b87506b85bfdeb6761))
+* **API:** Support source_locale_id param in uploads ([#935](https://github.com/phrase/strings-openapi/issues/935)) ([304a406](https://github.com/phrase/strings-openapi/commit/304a4061aaac8001a3a9e10c5cf985b04c31dab2))
 
-## [4.10.0](https://github.com/phrase/openapi/compare/ruby-v4.9.0...ruby-v4.10.0) (2025-09-30)
-
-
-### Features
-
-* **API:** Add "reviewed" param for tanslations#update ([#891](https://github.com/phrase/openapi/issues/891)) ([3f77286](https://github.com/phrase/openapi/commit/3f7728669fa68d5911dfca39a9e39c24cd20c0a4))
-* **SCM-732:** expose Automation API ([#910](https://github.com/phrase/openapi/issues/910)) ([6eea53d](https://github.com/phrase/openapi/commit/6eea53d06aca8f43623ba90e2e0a8cd6761c9a13))
-
-## [4.9.0](https://github.com/phrase/openapi/compare/ruby-v4.8.0...ruby-v4.9.0) (2025-08-01)
+## [4.12.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.11.0...ruby-v4.12.0) (2025-10-16)
 
 
 ### Features
 
-* **API:** Add support for `update_custom_metadata` option on upload ([#882](https://github.com/phrase/openapi/issues/882)) ([5b486ea](https://github.com/phrase/openapi/commit/5b486eabf30c84402a8e31911a5ba6fe3b343a89))
+* List child branches ([#926](https://github.com/phrase/strings-openapi/issues/926)) ([31d3b57](https://github.com/phrase/strings-openapi/commit/31d3b57e0d1381149409b77c3e236b226cde22a1))
 
-## [4.8.0](https://github.com/phrase/openapi/compare/ruby-v4.7.0...ruby-v4.8.0) (2025-07-23)
-
-
-### Features
-
-* **API:** Job and job locale annotations #SCD-145 ([#867](https://github.com/phrase/openapi/issues/867)) ([95b6c2a](https://github.com/phrase/openapi/commit/95b6c2a2ab798d01f9bc0d53a22dbf817a5eb0ee))
-
-## [4.7.0](https://github.com/phrase/openapi/compare/ruby-v4.6.0...ruby-v4.7.0) (2025-07-18)
+## [4.11.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.10.0...ruby-v4.11.0) (2025-10-01)
 
 
 ### Features
 
-* **API:** add updated_since param for downloads ([#858](https://github.com/phrase/openapi/issues/858)) ([db4196b](https://github.com/phrase/openapi/commit/db4196bfb1a45f628577bebb99aad7da1179c241))
-* **API:** Add use_ordinal_rules attribute to request body for create/update Keys endpoints ([#868](https://github.com/phrase/openapi/issues/868)) ([29410b5](https://github.com/phrase/openapi/commit/29410b5d4edee9645f449d2d7de53fb953c1f0c2))
-* **API:** Add use_ordinal_rules boolean [STRINGS-2273] ([#846](https://github.com/phrase/openapi/issues/846)) ([450ce0c](https://github.com/phrase/openapi/commit/450ce0cce6bb2064758c44b130b39dd5539c2681))
+* add branch sync endpoint ([#912](https://github.com/phrase/strings-openapi/issues/912)) ([3293917](https://github.com/phrase/strings-openapi/commit/329391757b3f81574448b1b87506b85bfdeb6761))
 
-## [4.6.0](https://github.com/phrase/openapi/compare/ruby-v4.5.0...ruby-v4.6.0) (2025-05-23)
+## [4.10.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.9.0...ruby-v4.10.0) (2025-09-30)
 
 
 ### Features
 
-* **API:** Add omit_statistics param to tags#show ([#834](https://github.com/phrase/openapi/issues/834)) ([2058b18](https://github.com/phrase/openapi/commit/2058b18297133075885ac99770aee2e171811cd6))
+* **API:** Add "reviewed" param for tanslations#update ([#891](https://github.com/phrase/strings-openapi/issues/891)) ([3f77286](https://github.com/phrase/strings-openapi/commit/3f7728669fa68d5911dfca39a9e39c24cd20c0a4))
+* **SCM-732:** expose Automation API ([#910](https://github.com/phrase/strings-openapi/issues/910)) ([6eea53d](https://github.com/phrase/strings-openapi/commit/6eea53d06aca8f43623ba90e2e0a8cd6761c9a13))
 
-## [4.5.0](https://github.com/phrase/openapi/compare/ruby-v4.4.0...ruby-v4.5.0) (2025-05-16)
+## [4.9.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.8.0...ruby-v4.9.0) (2025-08-01)
 
 
 ### Features
 
-* **API:** Add "verify_mentioned_translations" parameter to uploads ([#830](https://github.com/phrase/openapi/issues/830)) ([f2fdf60](https://github.com/phrase/openapi/commit/f2fdf60dd97c3908293cd457a765dafde603bd9b))
-* **API:** Add processed & upload total translations on upload summary ([#824](https://github.com/phrase/openapi/issues/824)) ([081db68](https://github.com/phrase/openapi/commit/081db68d2ffcf5d66a81e07eec0a9572a1f9d633))
-* **API:** Translations unreview & batch unreview ([#831](https://github.com/phrase/openapi/issues/831)) ([6a696db](https://github.com/phrase/openapi/commit/6a696db00d80d8acaf5887a08a7a97997566eb8f))
+* **API:** Add support for `update_custom_metadata` option on upload ([#882](https://github.com/phrase/strings-openapi/issues/882)) ([5b486ea](https://github.com/phrase/strings-openapi/commit/5b486eabf30c84402a8e31911a5ba6fe3b343a89))
+
+## [4.8.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.7.0...ruby-v4.8.0) (2025-07-23)
+
+
+### Features
+
+* **API:** Job and job locale annotations #SCD-145 ([#867](https://github.com/phrase/strings-openapi/issues/867)) ([95b6c2a](https://github.com/phrase/strings-openapi/commit/95b6c2a2ab798d01f9bc0d53a22dbf817a5eb0ee))
+
+## [4.7.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.6.0...ruby-v4.7.0) (2025-07-18)
+
+
+### Features
+
+* **API:** add updated_since param for downloads ([#858](https://github.com/phrase/strings-openapi/issues/858)) ([db4196b](https://github.com/phrase/strings-openapi/commit/db4196bfb1a45f628577bebb99aad7da1179c241))
+* **API:** Add use_ordinal_rules attribute to request body for create/update Keys endpoints ([#868](https://github.com/phrase/strings-openapi/issues/868)) ([29410b5](https://github.com/phrase/strings-openapi/commit/29410b5d4edee9645f449d2d7de53fb953c1f0c2))
+* **API:** Add use_ordinal_rules boolean [STRINGS-2273] ([#846](https://github.com/phrase/strings-openapi/issues/846)) ([450ce0c](https://github.com/phrase/strings-openapi/commit/450ce0cce6bb2064758c44b130b39dd5539c2681))
+
+## [4.6.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.5.0...ruby-v4.6.0) (2025-05-23)
+
+
+### Features
+
+* **API:** Add omit_statistics param to tags#show ([#834](https://github.com/phrase/strings-openapi/issues/834)) ([2058b18](https://github.com/phrase/strings-openapi/commit/2058b18297133075885ac99770aee2e171811cd6))
+
+## [4.5.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.4.0...ruby-v4.5.0) (2025-05-16)
+
+
+### Features
+
+* **API:** Add "verify_mentioned_translations" parameter to uploads ([#830](https://github.com/phrase/strings-openapi/issues/830)) ([f2fdf60](https://github.com/phrase/strings-openapi/commit/f2fdf60dd97c3908293cd457a765dafde603bd9b))
+* **API:** Add processed & upload total translations on upload summary ([#824](https://github.com/phrase/strings-openapi/issues/824)) ([081db68](https://github.com/phrase/strings-openapi/commit/081db68d2ffcf5d66a81e07eec0a9572a1f9d633))
+* **API:** Translations unreview & batch unreview ([#831](https://github.com/phrase/strings-openapi/issues/831)) ([6a696db](https://github.com/phrase/strings-openapi/commit/6a696db00d80d8acaf5887a08a7a97997566eb8f))
 
 
 ### Bug Fixes
 
-* **API:** Remove request body from GET comments ([#817](https://github.com/phrase/openapi/issues/817)) ([2646001](https://github.com/phrase/openapi/commit/264600132e80ac03983e0ae86e99db3d6fb9080d))
+* **API:** Remove request body from GET comments ([#817](https://github.com/phrase/strings-openapi/issues/817)) ([2646001](https://github.com/phrase/strings-openapi/commit/264600132e80ac03983e0ae86e99db3d6fb9080d))
 
-## [4.4.0](https://github.com/phrase/openapi/compare/ruby-v4.3.0...ruby-v4.4.0) (2025-03-04)
-
-
-### Features
-
-* **API:** Include roles in account response ([#811](https://github.com/phrase/openapi/issues/811)) ([dc27ee5](https://github.com/phrase/openapi/commit/dc27ee5117762222b6e1e6abb639f8e00c6a9101))
-
-## [4.3.0](https://github.com/phrase/openapi/compare/ruby-v4.2.0...ruby-v4.3.0) (2025-02-21)
+## [4.4.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.3.0...ruby-v4.4.0) (2025-03-04)
 
 
 ### Features
 
-* **API:** add updated_since filter to job list #STRINGS-1555 ([#799](https://github.com/phrase/openapi/issues/799)) ([dc9b6ed](https://github.com/phrase/openapi/commit/dc9b6ed12e013231d397820449086c87fea2f8ba))
+* **API:** Include roles in account response ([#811](https://github.com/phrase/strings-openapi/issues/811)) ([dc27ee5](https://github.com/phrase/strings-openapi/commit/dc27ee5117762222b6e1e6abb639f8e00c6a9101))
 
-## [4.2.0](https://github.com/phrase/openapi/compare/ruby-v4.1.0...ruby-v4.2.0) (2025-02-17)
-
-
-### Features
-
-* **API:** document tags attribute of an upload #STRINGS-1221 ([#790](https://github.com/phrase/openapi/issues/790)) ([fff505b](https://github.com/phrase/openapi/commit/fff505bdff35a0033fee06e505c42fe794c88562))
-
-## [4.1.0](https://github.com/phrase/openapi/compare/ruby-v4.0.3...ruby-v4.1.0) (2025-02-17)
+## [4.3.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.2.0...ruby-v4.3.0) (2025-02-21)
 
 
 ### Features
 
-* **API:** Add locale_ids param to synchronous download endpoint [STRINGS-1492] ([#780](https://github.com/phrase/openapi/issues/780)) ([47186a4](https://github.com/phrase/openapi/commit/47186a44fc8c0b8e466636acf3d49413b1f29f30))
-* **API:** Add source last updated at information on job details ([#777](https://github.com/phrase/openapi/issues/777)) ([c9b8423](https://github.com/phrase/openapi/commit/c9b8423766b4138980d0553502b3e18ca524f34e))
+* **API:** add updated_since filter to job list #STRINGS-1555 ([#799](https://github.com/phrase/strings-openapi/issues/799)) ([dc9b6ed](https://github.com/phrase/strings-openapi/commit/dc9b6ed12e013231d397820449086c87fea2f8ba))
 
-## [4.0.3](https://github.com/phrase/openapi/compare/ruby-v4.0.2...ruby-v4.0.3) (2025-01-29)
+## [4.2.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.1.0...ruby-v4.2.0) (2025-02-17)
+
+
+### Features
+
+* **API:** document tags attribute of an upload #STRINGS-1221 ([#790](https://github.com/phrase/strings-openapi/issues/790)) ([fff505b](https://github.com/phrase/strings-openapi/commit/fff505bdff35a0033fee06e505c42fe794c88562))
+
+## [4.1.0](https://github.com/phrase/strings-openapi/compare/ruby-v4.0.3...ruby-v4.1.0) (2025-02-17)
+
+
+### Features
+
+* **API:** Add locale_ids param to synchronous download endpoint [STRINGS-1492] ([#780](https://github.com/phrase/strings-openapi/issues/780)) ([47186a4](https://github.com/phrase/strings-openapi/commit/47186a44fc8c0b8e466636acf3d49413b1f29f30))
+* **API:** Add source last updated at information on job details ([#777](https://github.com/phrase/strings-openapi/issues/777)) ([c9b8423](https://github.com/phrase/strings-openapi/commit/c9b8423766b4138980d0553502b3e18ca524f34e))
+
+## [4.0.3](https://github.com/phrase/strings-openapi/compare/ruby-v4.0.2...ruby-v4.0.3) (2025-01-29)
 
 
 ### Bug Fixes
 
-* **API:** pass translation_key_ids when removing keys from job ([#771](https://github.com/phrase/openapi/issues/771)) ([f670e27](https://github.com/phrase/openapi/commit/f670e2763b1112fefd1812109b3c09def42b7bd2))
+* **API:** pass translation_key_ids when removing keys from job ([#771](https://github.com/phrase/strings-openapi/issues/771)) ([f670e27](https://github.com/phrase/strings-openapi/commit/f670e2763b1112fefd1812109b3c09def42b7bd2))
 
-## [4.0.2](https://github.com/phrase/openapi/compare/ruby-v4.0.1...ruby-v4.0.2) (2025-01-06)
-
-
-### Bug Fixes
-
-* **CLI:** Adjust operationId for quality_performance_score #STRINGS-1104 ([#721](https://github.com/phrase/openapi/issues/721)) ([7aa3b9b](https://github.com/phrase/openapi/commit/7aa3b9b508d1d24a4af7f4977b1a2fead8bfda78))
-
-## [4.0.1](https://github.com/phrase/openapi/compare/ruby-v4.0.0...ruby-v4.0.1) (2024-12-20)
+## [4.0.2](https://github.com/phrase/strings-openapi/compare/ruby-v4.0.1...ruby-v4.0.2) (2025-01-06)
 
 
 ### Bug Fixes
 
-* **API:** Repo Sync Event errors field type #STRINGS-1074 ([#756](https://github.com/phrase/openapi/issues/756)) ([c7670e0](https://github.com/phrase/openapi/commit/c7670e04810f95359d72ba6346b5f626bfb77b6f))
-* **API:** Repo Sync schema fixes #STRINGS-1074 ([#748](https://github.com/phrase/openapi/issues/748)) ([033be10](https://github.com/phrase/openapi/commit/033be1003fe01b5115de1f8ba2336d32b4862bfd))
+* **CLI:** Adjust operationId for quality_performance_score #STRINGS-1104 ([#721](https://github.com/phrase/strings-openapi/issues/721)) ([7aa3b9b](https://github.com/phrase/strings-openapi/commit/7aa3b9b508d1d24a4af7f4977b1a2fead8bfda78))
 
-## [4.0.0](https://github.com/phrase/openapi/compare/ruby-v3.7.1...ruby-v4.0.0) (2024-12-18)
+## [4.0.1](https://github.com/phrase/strings-openapi/compare/ruby-v4.0.0...ruby-v4.0.1) (2024-12-20)
+
+
+### Bug Fixes
+
+* **API:** Repo Sync Event errors field type #STRINGS-1074 ([#756](https://github.com/phrase/strings-openapi/issues/756)) ([c7670e0](https://github.com/phrase/strings-openapi/commit/c7670e04810f95359d72ba6346b5f626bfb77b6f))
+* **API:** Repo Sync schema fixes #STRINGS-1074 ([#748](https://github.com/phrase/strings-openapi/issues/748)) ([033be10](https://github.com/phrase/strings-openapi/commit/033be1003fe01b5115de1f8ba2336d32b4862bfd))
+
+## [4.0.0](https://github.com/phrase/strings-openapi/compare/ruby-v3.7.1...ruby-v4.0.0) (2024-12-18)
 
 
 ### ⚠ BREAKING CHANGES
 
-* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/openapi/issues/735))
+* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/strings-openapi/issues/735))
 
 ### Features
 
-* **API:** Add 'default_encoding' documentation ([#733](https://github.com/phrase/openapi/issues/733)) ([0139c51](https://github.com/phrase/openapi/commit/0139c51da747fbe7bc9929bcf3534aad7f22f39a))
-* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/openapi/issues/735)) ([c3bd8ec](https://github.com/phrase/openapi/commit/c3bd8eccaabcfa1b1066ea4438971ac59833af46))
+* **API:** Add 'default_encoding' documentation ([#733](https://github.com/phrase/strings-openapi/issues/733)) ([0139c51](https://github.com/phrase/strings-openapi/commit/0139c51da747fbe7bc9929bcf3534aad7f22f39a))
+* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/strings-openapi/issues/735)) ([c3bd8ec](https://github.com/phrase/strings-openapi/commit/c3bd8eccaabcfa1b1066ea4438971ac59833af46))
 
-## [3.7.1](https://github.com/phrase/openapi/compare/ruby-v3.7.0...ruby-v3.7.1) (2024-12-09)
+## [3.7.1](https://github.com/phrase/strings-openapi/compare/ruby-v3.7.0...ruby-v3.7.1) (2024-12-09)
 
 
 ### Bug Fixes
 
-* **API:** Add missing branch parameter to job comment endpoints #STRINGS-988 ([#724](https://github.com/phrase/openapi/issues/724)) ([64d399c](https://github.com/phrase/openapi/commit/64d399ced0980ac2a48366f91110047287a0c590))
+* **API:** Add missing branch parameter to job comment endpoints #STRINGS-988 ([#724](https://github.com/phrase/strings-openapi/issues/724)) ([64d399c](https://github.com/phrase/strings-openapi/commit/64d399ced0980ac2a48366f91110047287a0c590))
 
-## [3.7.0](https://github.com/phrase/openapi/compare/ruby-v3.6.0...ruby-v3.7.0) (2024-12-03)
+## [3.7.0](https://github.com/phrase/strings-openapi/compare/ruby-v3.6.0...ruby-v3.7.0) (2024-12-03)
 
 
 ### Features
 
-* **API:** Add Pagination header to POST search endpoints [[#457](https://github.com/phrase/openapi/issues/457)] ([#706](https://github.com/phrase/openapi/issues/706)) ([9a79fa3](https://github.com/phrase/openapi/commit/9a79fa31bb3b9d58272fa2f4e82d72d0d44a93a0))
-* **API:** autotranslate param in key creation [STRINGS-786] ([#713](https://github.com/phrase/openapi/issues/713)) ([581d0ff](https://github.com/phrase/openapi/commit/581d0ff5f1d06757e5ddd9603b78fc8d435d68ee))
+* **API:** Add Pagination header to POST search endpoints [[#457](https://github.com/phrase/strings-openapi/issues/457)] ([#706](https://github.com/phrase/strings-openapi/issues/706)) ([9a79fa3](https://github.com/phrase/strings-openapi/commit/9a79fa31bb3b9d58272fa2f4e82d72d0d44a93a0))
+* **API:** autotranslate param in key creation [STRINGS-786] ([#713](https://github.com/phrase/strings-openapi/issues/713)) ([581d0ff](https://github.com/phrase/strings-openapi/commit/581d0ff5f1d06757e5ddd9603b78fc8d435d68ee))
 
 
 ### Bug Fixes
 
-* **API:** Comment creation schema fix #STRINGS-866 ([#718](https://github.com/phrase/openapi/issues/718)) ([e201d13](https://github.com/phrase/openapi/commit/e201d1360c89698dd8d3642cc28f89dd0e50a1fb))
+* **API:** Comment creation schema fix #STRINGS-866 ([#718](https://github.com/phrase/strings-openapi/issues/718)) ([e201d13](https://github.com/phrase/strings-openapi/commit/e201d1360c89698dd8d3642cc28f89dd0e50a1fb))
 
-## [3.6.0](https://github.com/phrase/openapi/compare/ruby-v3.5.0...ruby-v3.6.0) (2024-10-02)
+## [3.6.0](https://github.com/phrase/strings-openapi/compare/ruby-v3.5.0...ruby-v3.6.0) (2024-10-02)
 
 
 ### Features
 
-* Add translation key prefixes for upload and download ([#687](https://github.com/phrase/openapi/issues/687)) ([9c9c959](https://github.com/phrase/openapi/commit/9c9c959830631bcac8beaf1de30ab31755ac1ee5))
+* Add translation key prefixes for upload and download ([#687](https://github.com/phrase/strings-openapi/issues/687)) ([9c9c959](https://github.com/phrase/strings-openapi/commit/9c9c959830631bcac8beaf1de30ab31755ac1ee5))
 
 
 ### Bug Fixes
 
-* **API:** Format list is not paginated and authenticated #STRINGS-458 ([#690](https://github.com/phrase/openapi/issues/690)) ([25e90f4](https://github.com/phrase/openapi/commit/25e90f46513e70cf328be80c36ae785cead05851))
+* **API:** Format list is not paginated and authenticated #STRINGS-458 ([#690](https://github.com/phrase/strings-openapi/issues/690)) ([25e90f4](https://github.com/phrase/strings-openapi/commit/25e90f46513e70cf328be80c36ae785cead05851))
 
-## [3.5.0](https://github.com/phrase/openapi/compare/ruby-v3.4.0...ruby-v3.5.0) (2024-09-09)
-
-
-### Features
-
-* Add update_translations_on_source_match ([#670](https://github.com/phrase/openapi/issues/670)) ([11003ac](https://github.com/phrase/openapi/commit/11003ace7353bf99893482ca4aa32214abf3e581))
-
-## [3.4.0](https://github.com/phrase/openapi/compare/ruby-v3.3.0...ruby-v3.4.0) (2024-07-25)
+## [3.5.0](https://github.com/phrase/strings-openapi/compare/ruby-v3.4.0...ruby-v3.5.0) (2024-09-09)
 
 
 ### Features
 
-* **ruby:** Remove dependency version constraints ([#659](https://github.com/phrase/openapi/issues/659)) ([1cf052b](https://github.com/phrase/openapi/commit/1cf052b3d22642c41d0d43a35288ef4fc134ae08))
+* Add update_translations_on_source_match ([#670](https://github.com/phrase/strings-openapi/issues/670)) ([11003ac](https://github.com/phrase/strings-openapi/commit/11003ace7353bf99893482ca4aa32214abf3e581))
 
-## [3.3.0](https://github.com/phrase/openapi/compare/ruby-v3.2.1...ruby-v3.3.0) (2024-07-02)
+## [3.4.0](https://github.com/phrase/strings-openapi/compare/ruby-v3.3.0...ruby-v3.4.0) (2024-07-25)
 
 
 ### Features
 
-* add repo sync events show endpoint ([#641](https://github.com/phrase/openapi/issues/641)) ([e1d9cfb](https://github.com/phrase/openapi/commit/e1d9cfb23e079fea2d9e5475dff9a4137f1f0154))
-* **API:** Async downloads [TSI-2515] ([#642](https://github.com/phrase/openapi/issues/642)) ([6fcab5d](https://github.com/phrase/openapi/commit/6fcab5d4719f64e8e5dd49c327dc9348b384de4c))
+* **ruby:** Remove dependency version constraints ([#659](https://github.com/phrase/strings-openapi/issues/659)) ([1cf052b](https://github.com/phrase/strings-openapi/commit/1cf052b3d22642c41d0d43a35288ef4fc134ae08))
 
-## [3.2.1](https://github.com/phrase/openapi/compare/ruby-v3.2.0...ruby-v3.2.1) (2024-06-18)
+## [3.3.0](https://github.com/phrase/strings-openapi/compare/ruby-v3.2.1...ruby-v3.3.0) (2024-07-02)
+
+
+### Features
+
+* add repo sync events show endpoint ([#641](https://github.com/phrase/strings-openapi/issues/641)) ([e1d9cfb](https://github.com/phrase/strings-openapi/commit/e1d9cfb23e079fea2d9e5475dff9a4137f1f0154))
+* **API:** Async downloads [TSI-2515] ([#642](https://github.com/phrase/strings-openapi/issues/642)) ([6fcab5d](https://github.com/phrase/strings-openapi/commit/6fcab5d4719f64e8e5dd49c327dc9348b384de4c))
+
+## [3.2.1](https://github.com/phrase/strings-openapi/compare/ruby-v3.2.0...ruby-v3.2.1) (2024-06-18)
 
 
 ### Bug Fixes
 
-* add app_min_version and app_max_version param to releases ([#633](https://github.com/phrase/openapi/issues/633)) ([b384301](https://github.com/phrase/openapi/commit/b3843012460ace4c1d34c4373e5158595466adcb))
+* add app_min_version and app_max_version param to releases ([#633](https://github.com/phrase/strings-openapi/issues/633)) ([b384301](https://github.com/phrase/strings-openapi/commit/b3843012460ace4c1d34c4373e5158595466adcb))
 
-## [3.2.0](https://github.com/phrase/openapi/compare/ruby-v3.1.1...ruby-v3.2.0) (2024-06-12)
+## [3.2.0](https://github.com/phrase/strings-openapi/compare/ruby-v3.1.1...ruby-v3.2.0) (2024-06-12)
 
 
 ### Features
 
-* **API:** Add OTA Release Triggers API [TSI-2485] ([#622](https://github.com/phrase/openapi/issues/622)) ([8cb91dc](https://github.com/phrase/openapi/commit/8cb91dcce2c19ca700cf9d0713fa74f28ad59434))
+* **API:** Add OTA Release Triggers API [TSI-2485] ([#622](https://github.com/phrase/strings-openapi/issues/622)) ([8cb91dc](https://github.com/phrase/strings-openapi/commit/8cb91dcce2c19ca700cf9d0713fa74f28ad59434))
 
-## [3.1.1](https://github.com/phrase/openapi/compare/ruby-v3.1.0...ruby-v3.1.1) (2024-05-31)
+## [3.1.1](https://github.com/phrase/strings-openapi/compare/ruby-v3.1.0...ruby-v3.1.1) (2024-05-31)
 
 
 ### Bug Fixes
 
-* **CLI:** use id instead of repo_sync_id as param ([#618](https://github.com/phrase/openapi/issues/618)) ([7a1a0d9](https://github.com/phrase/openapi/commit/7a1a0d9115262dc7fa3065ee7cc76bec7a381ddb))
-* **PHP:** Fix deserializing custom metadata values in key response ([#607](https://github.com/phrase/openapi/issues/607)) ([b6eeeba](https://github.com/phrase/openapi/commit/b6eeeba223e3eabec268a8f3d372afcb6abd09dd))
+* **CLI:** use id instead of repo_sync_id as param ([#618](https://github.com/phrase/strings-openapi/issues/618)) ([7a1a0d9](https://github.com/phrase/strings-openapi/commit/7a1a0d9115262dc7fa3065ee7cc76bec7a381ddb))
+* **PHP:** Fix deserializing custom metadata values in key response ([#607](https://github.com/phrase/strings-openapi/issues/607)) ([b6eeeba](https://github.com/phrase/strings-openapi/commit/b6eeeba223e3eabec268a8f3d372afcb6abd09dd))
 
-## [3.1.0](https://github.com/phrase/openapi/compare/ruby-v3.0.0...ruby-v3.1.0) (2024-04-29)
+## [3.1.0](https://github.com/phrase/strings-openapi/compare/ruby-v3.0.0...ruby-v3.1.0) (2024-04-29)
 
 
 ### Features
 
-* **API:** Add 'update_translation_keys' for Uploads [TSI-2292] ([#578](https://github.com/phrase/openapi/issues/578)) ([4492ec0](https://github.com/phrase/openapi/commit/4492ec0a7c62f9de9ab1c1125071615bddcc26ce))
+* **API:** Add 'update_translation_keys' for Uploads [TSI-2292] ([#578](https://github.com/phrase/strings-openapi/issues/578)) ([4492ec0](https://github.com/phrase/strings-openapi/commit/4492ec0a7c62f9de9ab1c1125071615bddcc26ce))
 
-## [3.0.0](https://github.com/phrase/openapi/compare/ruby-v2.26.0...ruby-v3.0.0) (2024-04-23)
+## [3.0.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.26.0...ruby-v3.0.0) (2024-04-23)
 
 
 ### ⚠ BREAKING CHANGES
 
-* add missing required params ([#571](https://github.com/phrase/openapi/issues/571))
+* add missing required params ([#571](https://github.com/phrase/strings-openapi/issues/571))
 
 ### Code Refactoring
 
-* add missing required params ([#571](https://github.com/phrase/openapi/issues/571)) ([d810e9e](https://github.com/phrase/openapi/commit/d810e9ebc767e14ba9e56106de8c5774d9d6d178))
+* add missing required params ([#571](https://github.com/phrase/strings-openapi/issues/571)) ([d810e9e](https://github.com/phrase/strings-openapi/commit/d810e9ebc767e14ba9e56106de8c5774d9d6d178))
 
-## [2.26.0](https://github.com/phrase/openapi/compare/ruby-v2.25.0...ruby-v2.26.0) (2024-04-22)
-
-
-### Features
-
-* Add linked-parent to translation details ([#570](https://github.com/phrase/openapi/issues/570)) ([2c6f432](https://github.com/phrase/openapi/commit/2c6f43253e24b670b71ac810c85dce0759c29403))
-
-## [2.25.0](https://github.com/phrase/openapi/compare/ruby-v2.24.0...ruby-v2.25.0) (2024-04-17)
+## [2.26.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.25.0...ruby-v2.26.0) (2024-04-22)
 
 
 ### Features
 
-* **API:** Add Repo Sync [TSI-1923] ([#569](https://github.com/phrase/openapi/issues/569)) ([0bd1756](https://github.com/phrase/openapi/commit/0bd17562018cb045ff41cc1ff5008b9419a0ed12))
+* Add linked-parent to translation details ([#570](https://github.com/phrase/strings-openapi/issues/570)) ([2c6f432](https://github.com/phrase/strings-openapi/commit/2c6f43253e24b670b71ac810c85dce0759c29403))
 
-## [2.24.0](https://github.com/phrase/openapi/compare/ruby-v2.23.0...ruby-v2.24.0) (2024-04-10)
+## [2.25.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.24.0...ruby-v2.25.0) (2024-04-17)
 
 
 ### Features
 
-* **API:** add Linked Keys endpoints ([#555](https://github.com/phrase/openapi/issues/555)) ([4935dac](https://github.com/phrase/openapi/commit/4935dac58c787eaade2f1f65ce649f466b5e3a60))
+* **API:** Add Repo Sync [TSI-1923] ([#569](https://github.com/phrase/strings-openapi/issues/569)) ([0bd1756](https://github.com/phrase/strings-openapi/commit/0bd17562018cb045ff41cc1ff5008b9419a0ed12))
+
+## [2.24.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.23.0...ruby-v2.24.0) (2024-04-10)
+
+
+### Features
+
+* **API:** add Linked Keys endpoints ([#555](https://github.com/phrase/strings-openapi/issues/555)) ([4935dac](https://github.com/phrase/strings-openapi/commit/4935dac58c787eaade2f1f65ce649f466b5e3a60))
 
 
 ### Bug Fixes
 
-* (API) Add mandatory params to linked keys endpoints ([#564](https://github.com/phrase/openapi/issues/564)) ([08d9846](https://github.com/phrase/openapi/commit/08d9846bc224d349e2ade9abf28d733afb1e8be3))
+* (API) Add mandatory params to linked keys endpoints ([#564](https://github.com/phrase/strings-openapi/issues/564)) ([08d9846](https://github.com/phrase/strings-openapi/commit/08d9846bc224d349e2ade9abf28d733afb1e8be3))
 
-## [2.23.0](https://github.com/phrase/openapi/compare/ruby-v2.22.2...ruby-v2.23.0) (2024-02-07)
+## [2.23.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.22.2...ruby-v2.23.0) (2024-02-07)
 
 
 ### Features
 
-* add query param for properties ([#542](https://github.com/phrase/openapi/issues/542)) ([b4e12d0](https://github.com/phrase/openapi/commit/b4e12d04fd2916351f9201e1e6de504143ecc9aa))
+* add query param for properties ([#542](https://github.com/phrase/strings-openapi/issues/542)) ([b4e12d0](https://github.com/phrase/strings-openapi/commit/b4e12d04fd2916351f9201e1e6de504143ecc9aa))
 
-## [2.22.2](https://github.com/phrase/openapi/compare/ruby-v2.22.1...ruby-v2.22.2) (2024-02-05)
+## [2.22.2](https://github.com/phrase/strings-openapi/compare/ruby-v2.22.1...ruby-v2.22.2) (2024-02-05)
 
 
 ### Bug Fixes
 
-* **API:** allow nullable value for job's due_date ([#534](https://github.com/phrase/openapi/issues/534)) ([38b51b5](https://github.com/phrase/openapi/commit/38b51b51095394f8ce769873140038abba628514))
+* **API:** allow nullable value for job's due_date ([#534](https://github.com/phrase/strings-openapi/issues/534)) ([38b51b5](https://github.com/phrase/strings-openapi/commit/38b51b51095394f8ce769873140038abba628514))
 
-## [2.22.1](https://github.com/phrase/openapi/compare/ruby-v2.22.0...ruby-v2.22.1) (2024-02-01)
-
-
-### Bug Fixes
-
-* **API:** Adjust documentation of QPS endpoint ([#525](https://github.com/phrase/openapi/issues/525)) ([4b4f1ac](https://github.com/phrase/openapi/commit/4b4f1acf28fbd13b3d16c37162cdccfa05c38ffa))
-
-## [2.22.0](https://github.com/phrase/openapi/compare/ruby-v2.21.0...ruby-v2.22.0) (2024-01-17)
-
-
-### Features
-
-* **api:** Add QPS endpoint and documentation ([#521](https://github.com/phrase/openapi/issues/521)) ([d22c558](https://github.com/phrase/openapi/commit/d22c558adfbb7fcd13759e388c038744914e42fa))
+## [2.22.1](https://github.com/phrase/strings-openapi/compare/ruby-v2.22.0...ruby-v2.22.1) (2024-02-01)
 
 
 ### Bug Fixes
 
-* **API:** Create Custom Metadata endpoint fix [TSI-2222] ([#499](https://github.com/phrase/openapi/issues/499)) ([ce2ed94](https://github.com/phrase/openapi/commit/ce2ed9488e111fb5d9bc3810a78c47d23553c8b7))
+* **API:** Adjust documentation of QPS endpoint ([#525](https://github.com/phrase/strings-openapi/issues/525)) ([4b4f1ac](https://github.com/phrase/strings-openapi/commit/4b4f1acf28fbd13b3d16c37162cdccfa05c38ffa))
 
-## [2.21.0](https://github.com/phrase/openapi/compare/ruby-v2.20.0...ruby-v2.21.0) (2023-12-13)
-
-
-### Features
-
-* Add reports locales endpoint to API [TSS-2439] ([#465](https://github.com/phrase/openapi/issues/465)) ([e03aa9f](https://github.com/phrase/openapi/commit/e03aa9f49f031517b36db715fe70e8e0b65a438b))
-* **API:** add Custom Metadata endpoints ([#474](https://github.com/phrase/openapi/issues/474)) ([d407d8b](https://github.com/phrase/openapi/commit/d407d8be5ccddec1afde14a12804a7a616f77d7a))
-* **API:** Add custom_metadata_filters param to locale download endpoint [TSI-2174] ([#478](https://github.com/phrase/openapi/issues/478)) ([3623478](https://github.com/phrase/openapi/commit/3623478fc1518b457ab018b5630a693081637d6e))
-* **API:** Add url field to uploads ([#481](https://github.com/phrase/openapi/issues/481)) ([7332a84](https://github.com/phrase/openapi/commit/7332a84f9958346f2fb28dee4b0353519ef466d5))
-
-## [2.20.0](https://github.com/phrase/openapi/compare/ruby-v2.19.0...ruby-v2.20.0) (2023-11-03)
+## [2.22.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.21.0...ruby-v2.22.0) (2024-01-17)
 
 
 ### Features
 
-* [TSI-2083] enable format_options argument for java-client   ([#426](https://github.com/phrase/openapi/issues/426)) ([faa8cb3](https://github.com/phrase/openapi/commit/faa8cb353ba9f1030b9f7cfd46b894b4d6d26e70))
-
-## [2.19.0](https://github.com/phrase/openapi/compare/ruby-v2.18.0...ruby-v2.19.0) (2023-10-30)
-
-
-### Features
-
-* Update openapi-generator to v7 ([#418](https://github.com/phrase/openapi/issues/418)) ([524626f](https://github.com/phrase/openapi/commit/524626f5e914bfef6025d0e1c2cbc7a728d08f56))
-
-## [2.18.0](https://github.com/phrase/openapi/compare/ruby-v2.17.0...ruby-v2.18.0) (2023-10-23)
-
-
-### Features
-
-* **API:** Add order param to comment list endpoints ([#441](https://github.com/phrase/openapi/issues/441)) ([441c9c4](https://github.com/phrase/openapi/commit/441c9c46169f8c5ac4e71ade09a95dab136314ef))
-
-## [2.17.0](https://github.com/phrase/openapi/compare/ruby-v2.16.0...ruby-v2.17.0) (2023-10-13)
-
-
-### Features
-
-* **API:** Implement figma attachments endpoints ([#415](https://github.com/phrase/openapi/issues/415)) ([970e612](https://github.com/phrase/openapi/commit/970e612fda620ca882a221ef541036b8d200b675))
-
-## [2.16.0](https://github.com/phrase/openapi/compare/ruby-v2.15.0...ruby-v2.16.0) (2023-09-12)
-
-
-### Features
-
-* Optionally tag only affected keys on upload [TSI-2041] ([#412](https://github.com/phrase/openapi/issues/412)) ([e8f958e](https://github.com/phrase/openapi/commit/e8f958e91469c2542f44ab68469c933688958383))
-* **TSI-1946:** Add reviewed_at to translations ([#396](https://github.com/phrase/openapi/issues/396)) ([3e663d9](https://github.com/phrase/openapi/commit/3e663d971a99a816f0165dd6653a9a1e8a87c95e))
-
-## [2.15.0](https://github.com/phrase/openapi/compare/ruby-v2.14.0...ruby-v2.15.0) (2023-08-28)
-
-
-### Features
-
-* **API:** Document new query parameters ([#393](https://github.com/phrase/openapi/issues/393)) ([770515a](https://github.com/phrase/openapi/commit/770515a9628122955bb3919405babf9392684eb9))
-
-## [2.14.0](https://github.com/phrase/openapi/compare/ruby-v2.13.0...ruby-v2.14.0) (2023-08-24)
-
-
-### Features
-
-* **API:** Introduce comment replies endpoints ([#383](https://github.com/phrase/openapi/issues/383)) ([71351ac](https://github.com/phrase/openapi/commit/71351ac285f4f49976092e176c77b09f3485eb65))
-
-## [2.13.0](https://github.com/phrase/openapi/compare/ruby-v2.12.0...ruby-v2.13.0) (2023-08-22)
-
-
-### Features
-
-* **TSE-950:** Document comment_reactions endpoints ([#380](https://github.com/phrase/openapi/issues/380)) ([f230244](https://github.com/phrase/openapi/commit/f230244e6e9c069b18edc4c35dd5e290fd14793b))
+* **api:** Add QPS endpoint and documentation ([#521](https://github.com/phrase/strings-openapi/issues/521)) ([d22c558](https://github.com/phrase/strings-openapi/commit/d22c558adfbb7fcd13759e388c038744914e42fa))
 
 
 ### Bug Fixes
 
-* Fix gitlab_sync history status type mismatch ([#363](https://github.com/phrase/openapi/issues/363)) ([ebcaa4e](https://github.com/phrase/openapi/commit/ebcaa4e5dfcb2f73559a56c78b0f2512ca798375))
-* **schemas:** Fix gitlab_sync type mismatch ([#373](https://github.com/phrase/openapi/issues/373)) ([1cb1f65](https://github.com/phrase/openapi/commit/1cb1f650598c68afee6e2cd7c3c4ede1484aba35))
+* **API:** Create Custom Metadata endpoint fix [TSI-2222] ([#499](https://github.com/phrase/strings-openapi/issues/499)) ([ce2ed94](https://github.com/phrase/strings-openapi/commit/ce2ed9488e111fb5d9bc3810a78c47d23553c8b7))
+
+## [2.21.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.20.0...ruby-v2.21.0) (2023-12-13)
+
+
+### Features
+
+* Add reports locales endpoint to API [TSS-2439] ([#465](https://github.com/phrase/strings-openapi/issues/465)) ([e03aa9f](https://github.com/phrase/strings-openapi/commit/e03aa9f49f031517b36db715fe70e8e0b65a438b))
+* **API:** add Custom Metadata endpoints ([#474](https://github.com/phrase/strings-openapi/issues/474)) ([d407d8b](https://github.com/phrase/strings-openapi/commit/d407d8be5ccddec1afde14a12804a7a616f77d7a))
+* **API:** Add custom_metadata_filters param to locale download endpoint [TSI-2174] ([#478](https://github.com/phrase/strings-openapi/issues/478)) ([3623478](https://github.com/phrase/strings-openapi/commit/3623478fc1518b457ab018b5630a693081637d6e))
+* **API:** Add url field to uploads ([#481](https://github.com/phrase/strings-openapi/issues/481)) ([7332a84](https://github.com/phrase/strings-openapi/commit/7332a84f9958346f2fb28dee4b0353519ef466d5))
+
+## [2.20.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.19.0...ruby-v2.20.0) (2023-11-03)
+
+
+### Features
+
+* [TSI-2083] enable format_options argument for java-client   ([#426](https://github.com/phrase/strings-openapi/issues/426)) ([faa8cb3](https://github.com/phrase/strings-openapi/commit/faa8cb353ba9f1030b9f7cfd46b894b4d6d26e70))
+
+## [2.19.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.18.0...ruby-v2.19.0) (2023-10-30)
+
+
+### Features
+
+* Update openapi-generator to v7 ([#418](https://github.com/phrase/strings-openapi/issues/418)) ([524626f](https://github.com/phrase/strings-openapi/commit/524626f5e914bfef6025d0e1c2cbc7a728d08f56))
+
+## [2.18.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.17.0...ruby-v2.18.0) (2023-10-23)
+
+
+### Features
+
+* **API:** Add order param to comment list endpoints ([#441](https://github.com/phrase/strings-openapi/issues/441)) ([441c9c4](https://github.com/phrase/strings-openapi/commit/441c9c46169f8c5ac4e71ade09a95dab136314ef))
+
+## [2.17.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.16.0...ruby-v2.17.0) (2023-10-13)
+
+
+### Features
+
+* **API:** Implement figma attachments endpoints ([#415](https://github.com/phrase/strings-openapi/issues/415)) ([970e612](https://github.com/phrase/strings-openapi/commit/970e612fda620ca882a221ef541036b8d200b675))
+
+## [2.16.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.15.0...ruby-v2.16.0) (2023-09-12)
+
+
+### Features
+
+* Optionally tag only affected keys on upload [TSI-2041] ([#412](https://github.com/phrase/strings-openapi/issues/412)) ([e8f958e](https://github.com/phrase/strings-openapi/commit/e8f958e91469c2542f44ab68469c933688958383))
+* **TSI-1946:** Add reviewed_at to translations ([#396](https://github.com/phrase/strings-openapi/issues/396)) ([3e663d9](https://github.com/phrase/strings-openapi/commit/3e663d971a99a816f0165dd6653a9a1e8a87c95e))
+
+## [2.15.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.14.0...ruby-v2.15.0) (2023-08-28)
+
+
+### Features
+
+* **API:** Document new query parameters ([#393](https://github.com/phrase/strings-openapi/issues/393)) ([770515a](https://github.com/phrase/strings-openapi/commit/770515a9628122955bb3919405babf9392684eb9))
+
+## [2.14.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.13.0...ruby-v2.14.0) (2023-08-24)
+
+
+### Features
+
+* **API:** Introduce comment replies endpoints ([#383](https://github.com/phrase/strings-openapi/issues/383)) ([71351ac](https://github.com/phrase/strings-openapi/commit/71351ac285f4f49976092e176c77b09f3485eb65))
+
+## [2.13.0](https://github.com/phrase/strings-openapi/compare/ruby-v2.12.0...ruby-v2.13.0) (2023-08-22)
+
+
+### Features
+
+* **TSE-950:** Document comment_reactions endpoints ([#380](https://github.com/phrase/strings-openapi/issues/380)) ([f230244](https://github.com/phrase/strings-openapi/commit/f230244e6e9c069b18edc4c35dd5e290fd14793b))
+
+
+### Bug Fixes
+
+* Fix gitlab_sync history status type mismatch ([#363](https://github.com/phrase/strings-openapi/issues/363)) ([ebcaa4e](https://github.com/phrase/strings-openapi/commit/ebcaa4e5dfcb2f73559a56c78b0f2512ca798375))
+* **schemas:** Fix gitlab_sync type mismatch ([#373](https://github.com/phrase/strings-openapi/issues/373)) ([1cb1f65](https://github.com/phrase/strings-openapi/commit/1cb1f650598c68afee6e2cd7c3c4ede1484aba35))

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -7,412 +7,412 @@
 
 * **API:** Add linked_translation to translation type ([#1005](https://github.com/phrase/strings-openapi/issues/1005)) ([b18e64c](https://github.com/phrase/strings-openapi/commit/b18e64c948d40a9e5f996e8fdf6dee07d1812b02))
 
-## [3.15.0](https://github.com/phrase/openapi/compare/typescript-v3.14.2...typescript-v3.15.0) (2026-01-09)
+## [3.15.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.14.2...typescript-v3.15.0) (2026-01-09)
 
 
 ### Features
 
-* **API:** Add missing project flags to project details schema #SCD-141 ([#993](https://github.com/phrase/openapi/issues/993)) ([93fbdd7](https://github.com/phrase/openapi/commit/93fbdd76150ed94374ef888ac92c0c9b626de7c8))
+* **API:** Add missing project flags to project details schema #SCD-141 ([#993](https://github.com/phrase/strings-openapi/issues/993)) ([93fbdd7](https://github.com/phrase/strings-openapi/commit/93fbdd76150ed94374ef888ac92c0c9b626de7c8))
 
 
 ### Bug Fixes
 
-* **API:** drop invalid account locale params ([#992](https://github.com/phrase/openapi/issues/992)) ([87af83c](https://github.com/phrase/openapi/commit/87af83c94fd7e47340b5393847e93a31127abbe8))
+* **API:** drop invalid account locale params ([#992](https://github.com/phrase/strings-openapi/issues/992)) ([87af83c](https://github.com/phrase/strings-openapi/commit/87af83c94fd7e47340b5393847e93a31127abbe8))
 
-## [3.14.2](https://github.com/phrase/openapi/compare/typescript-v3.14.1...typescript-v3.14.2) (2025-12-17)
-
-
-### Bug Fixes
-
-* **typescript:** Fix github release creation ([#989](https://github.com/phrase/openapi/issues/989)) ([4165f9e](https://github.com/phrase/openapi/commit/4165f9e1ec8d880ca292e41b8cf321d05fb6d456))
-
-## [3.14.1](https://github.com/phrase/openapi/compare/typescript-v3.14.0...typescript-v3.14.1) (2025-12-17)
+## [3.14.2](https://github.com/phrase/strings-openapi/compare/typescript-v3.14.1...typescript-v3.14.2) (2025-12-17)
 
 
 ### Bug Fixes
 
-* **typescript:** use trusted publishing for typescript client ([#987](https://github.com/phrase/openapi/issues/987)) ([de2e477](https://github.com/phrase/openapi/commit/de2e4771e0bc1fba9949d6650834817e3016e185))
+* **typescript:** Fix github release creation ([#989](https://github.com/phrase/strings-openapi/issues/989)) ([4165f9e](https://github.com/phrase/strings-openapi/commit/4165f9e1ec8d880ca292e41b8cf321d05fb6d456))
 
-## [3.14.0](https://github.com/phrase/openapi/compare/typescript-v3.13.0...typescript-v3.14.0) (2025-12-16)
-
-
-### Features
-
-* **typescript:** Parse pagination headers in API responses #SCD-665 ([#984](https://github.com/phrase/openapi/issues/984)) ([92ad9fc](https://github.com/phrase/openapi/commit/92ad9fc573acfc4bb451c914727cc871625d91ac))
-
-## [3.13.0](https://github.com/phrase/openapi/compare/typescript-v3.12.1...typescript-v3.13.0) (2025-12-11)
-
-
-### Features
-
-* **API:** Add create comparison endpoint for branches [SCD-549] ([#966](https://github.com/phrase/openapi/issues/966)) ([4099e32](https://github.com/phrase/openapi/commit/4099e32d42744f9d73346077ef30b0f4bd5c849e))
-* **API:** add manual triggering of automations #SCM-953 ([#968](https://github.com/phrase/openapi/issues/968)) ([ebe1c68](https://github.com/phrase/openapi/commit/ebe1c68e472d87ea6c6cd2f76bb421406c30a274))
-* **API:** add use_locale_fallback option to download #SCD-620 ([#976](https://github.com/phrase/openapi/issues/976)) ([9266c68](https://github.com/phrase/openapi/commit/9266c680d8717bb736aed83625858f0b3419da54))
-
-## [3.12.1](https://github.com/phrase/openapi/compare/typescript-v3.12.0...typescript-v3.12.1) (2025-11-10)
+## [3.14.1](https://github.com/phrase/strings-openapi/compare/typescript-v3.14.0...typescript-v3.14.1) (2025-12-17)
 
 
 ### Bug Fixes
 
-* **API:** Add omit_translation_keys to Jobs#show endpoint ([#957](https://github.com/phrase/openapi/issues/957)) ([23ece66](https://github.com/phrase/openapi/commit/23ece66b05fc748a4598ce876cb2954ed1a385cc))
+* **typescript:** use trusted publishing for typescript client ([#987](https://github.com/phrase/strings-openapi/issues/987)) ([de2e477](https://github.com/phrase/strings-openapi/commit/de2e4771e0bc1fba9949d6650834817e3016e185))
 
-## [3.12.0](https://github.com/phrase/openapi/compare/typescript-v3.11.0...typescript-v3.12.0) (2025-10-27)
-
-
-### Features
-
-* **API:** Support omit_translation_keys param in Jobs#show ([#944](https://github.com/phrase/openapi/issues/944)) ([690a2ce](https://github.com/phrase/openapi/commit/690a2ce992359e7920367699145d2d4ff3a206fa))
-
-## [3.11.0](https://github.com/phrase/openapi/compare/typescript-v3.10.0...typescript-v3.11.0) (2025-10-23)
+## [3.14.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.13.0...typescript-v3.14.0) (2025-12-16)
 
 
 ### Features
 
-* **API:** Support source_locale_id param in uploads ([#935](https://github.com/phrase/openapi/issues/935)) ([304a406](https://github.com/phrase/openapi/commit/304a4061aaac8001a3a9e10c5cf985b04c31dab2))
+* **typescript:** Parse pagination headers in API responses #SCD-665 ([#984](https://github.com/phrase/strings-openapi/issues/984)) ([92ad9fc](https://github.com/phrase/strings-openapi/commit/92ad9fc573acfc4bb451c914727cc871625d91ac))
 
-## [3.10.0](https://github.com/phrase/openapi/compare/typescript-v3.9.0...typescript-v3.10.0) (2025-10-16)
-
-
-### Features
-
-* List child branches ([#926](https://github.com/phrase/openapi/issues/926)) ([31d3b57](https://github.com/phrase/openapi/commit/31d3b57e0d1381149409b77c3e236b226cde22a1))
-
-## [3.9.0](https://github.com/phrase/openapi/compare/typescript-v3.8.0...typescript-v3.9.0) (2025-10-01)
+## [3.13.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.12.1...typescript-v3.13.0) (2025-12-11)
 
 
 ### Features
 
-* add branch sync endpoint ([#912](https://github.com/phrase/openapi/issues/912)) ([3293917](https://github.com/phrase/openapi/commit/329391757b3f81574448b1b87506b85bfdeb6761))
+* **API:** Add create comparison endpoint for branches [SCD-549] ([#966](https://github.com/phrase/strings-openapi/issues/966)) ([4099e32](https://github.com/phrase/strings-openapi/commit/4099e32d42744f9d73346077ef30b0f4bd5c849e))
+* **API:** add manual triggering of automations #SCM-953 ([#968](https://github.com/phrase/strings-openapi/issues/968)) ([ebe1c68](https://github.com/phrase/strings-openapi/commit/ebe1c68e472d87ea6c6cd2f76bb421406c30a274))
+* **API:** add use_locale_fallback option to download #SCD-620 ([#976](https://github.com/phrase/strings-openapi/issues/976)) ([9266c68](https://github.com/phrase/strings-openapi/commit/9266c680d8717bb736aed83625858f0b3419da54))
 
-## [3.8.0](https://github.com/phrase/openapi/compare/typescript-v3.7.0...typescript-v3.8.0) (2025-09-30)
-
-
-### Features
-
-* **API:** Add "reviewed" param for tanslations#update ([#891](https://github.com/phrase/openapi/issues/891)) ([3f77286](https://github.com/phrase/openapi/commit/3f7728669fa68d5911dfca39a9e39c24cd20c0a4))
-* **SCM-732:** expose Automation API ([#910](https://github.com/phrase/openapi/issues/910)) ([6eea53d](https://github.com/phrase/openapi/commit/6eea53d06aca8f43623ba90e2e0a8cd6761c9a13))
-
-## [3.7.0](https://github.com/phrase/openapi/compare/typescript-v3.6.0...typescript-v3.7.0) (2025-08-01)
-
-
-### Features
-
-* **API:** Add support for `update_custom_metadata` option on upload ([#882](https://github.com/phrase/openapi/issues/882)) ([5b486ea](https://github.com/phrase/openapi/commit/5b486eabf30c84402a8e31911a5ba6fe3b343a89))
-
-## [3.6.0](https://github.com/phrase/openapi/compare/typescript-v3.5.0...typescript-v3.6.0) (2025-07-24)
-
-
-### Features
-
-* **API:** Job and job locale annotations #SCD-145 ([#867](https://github.com/phrase/openapi/issues/867)) ([95b6c2a](https://github.com/phrase/openapi/commit/95b6c2a2ab798d01f9bc0d53a22dbf817a5eb0ee))
-
-## [3.5.0](https://github.com/phrase/openapi/compare/typescript-v3.4.0...typescript-v3.5.0) (2025-07-18)
-
-
-### Features
-
-* **API:** add updated_since param for downloads ([#858](https://github.com/phrase/openapi/issues/858)) ([db4196b](https://github.com/phrase/openapi/commit/db4196bfb1a45f628577bebb99aad7da1179c241))
-* **API:** Add use_ordinal_rules attribute to request body for create/update Keys endpoints ([#868](https://github.com/phrase/openapi/issues/868)) ([29410b5](https://github.com/phrase/openapi/commit/29410b5d4edee9645f449d2d7de53fb953c1f0c2))
-* **API:** Add use_ordinal_rules boolean [STRINGS-2273] ([#846](https://github.com/phrase/openapi/issues/846)) ([450ce0c](https://github.com/phrase/openapi/commit/450ce0cce6bb2064758c44b130b39dd5539c2681))
-
-## [3.4.0](https://github.com/phrase/openapi/compare/typescript-v3.3.0...typescript-v3.4.0) (2025-05-23)
-
-
-### Features
-
-* **API:** Add omit_statistics param to tags#show ([#834](https://github.com/phrase/openapi/issues/834)) ([2058b18](https://github.com/phrase/openapi/commit/2058b18297133075885ac99770aee2e171811cd6))
-
-## [3.3.0](https://github.com/phrase/openapi/compare/typescript-v3.2.0...typescript-v3.3.0) (2025-05-16)
-
-
-### Features
-
-* **API:** Add "verify_mentioned_translations" parameter to uploads ([#830](https://github.com/phrase/openapi/issues/830)) ([f2fdf60](https://github.com/phrase/openapi/commit/f2fdf60dd97c3908293cd457a765dafde603bd9b))
-* **API:** Add processed & upload total translations on upload summary ([#824](https://github.com/phrase/openapi/issues/824)) ([081db68](https://github.com/phrase/openapi/commit/081db68d2ffcf5d66a81e07eec0a9572a1f9d633))
-* **API:** add updated_since filter to job list #STRINGS-1555 ([#799](https://github.com/phrase/openapi/issues/799)) ([dc9b6ed](https://github.com/phrase/openapi/commit/dc9b6ed12e013231d397820449086c87fea2f8ba))
-* **API:** Include roles in account response ([#811](https://github.com/phrase/openapi/issues/811)) ([dc27ee5](https://github.com/phrase/openapi/commit/dc27ee5117762222b6e1e6abb639f8e00c6a9101))
-* **API:** Translations unreview & batch unreview ([#831](https://github.com/phrase/openapi/issues/831)) ([6a696db](https://github.com/phrase/openapi/commit/6a696db00d80d8acaf5887a08a7a97997566eb8f))
+## [3.12.1](https://github.com/phrase/strings-openapi/compare/typescript-v3.12.0...typescript-v3.12.1) (2025-11-10)
 
 
 ### Bug Fixes
 
-* **API:** Remove request body from GET comments ([#817](https://github.com/phrase/openapi/issues/817)) ([2646001](https://github.com/phrase/openapi/commit/264600132e80ac03983e0ae86e99db3d6fb9080d))
+* **API:** Add omit_translation_keys to Jobs#show endpoint ([#957](https://github.com/phrase/strings-openapi/issues/957)) ([23ece66](https://github.com/phrase/strings-openapi/commit/23ece66b05fc748a4598ce876cb2954ed1a385cc))
 
-## [3.2.0](https://github.com/phrase/openapi/compare/typescript-v3.1.0...typescript-v3.2.0) (2025-02-17)
-
-
-### Features
-
-* **API:** document tags attribute of an upload #STRINGS-1221 ([#790](https://github.com/phrase/openapi/issues/790)) ([fff505b](https://github.com/phrase/openapi/commit/fff505bdff35a0033fee06e505c42fe794c88562))
-
-## [3.1.0](https://github.com/phrase/openapi/compare/typescript-v3.0.3...typescript-v3.1.0) (2025-02-17)
+## [3.12.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.11.0...typescript-v3.12.0) (2025-10-27)
 
 
 ### Features
 
-* **API:** Add locale_ids param to synchronous download endpoint [STRINGS-1492] ([#780](https://github.com/phrase/openapi/issues/780)) ([47186a4](https://github.com/phrase/openapi/commit/47186a44fc8c0b8e466636acf3d49413b1f29f30))
-* **API:** Add source last updated at information on job details ([#777](https://github.com/phrase/openapi/issues/777)) ([c9b8423](https://github.com/phrase/openapi/commit/c9b8423766b4138980d0553502b3e18ca524f34e))
+* **API:** Support omit_translation_keys param in Jobs#show ([#944](https://github.com/phrase/strings-openapi/issues/944)) ([690a2ce](https://github.com/phrase/strings-openapi/commit/690a2ce992359e7920367699145d2d4ff3a206fa))
 
-## [3.0.3](https://github.com/phrase/openapi/compare/typescript-v3.0.2...typescript-v3.0.3) (2025-01-29)
+## [3.11.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.10.0...typescript-v3.11.0) (2025-10-23)
+
+
+### Features
+
+* **API:** Support source_locale_id param in uploads ([#935](https://github.com/phrase/strings-openapi/issues/935)) ([304a406](https://github.com/phrase/strings-openapi/commit/304a4061aaac8001a3a9e10c5cf985b04c31dab2))
+
+## [3.10.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.9.0...typescript-v3.10.0) (2025-10-16)
+
+
+### Features
+
+* List child branches ([#926](https://github.com/phrase/strings-openapi/issues/926)) ([31d3b57](https://github.com/phrase/strings-openapi/commit/31d3b57e0d1381149409b77c3e236b226cde22a1))
+
+## [3.9.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.8.0...typescript-v3.9.0) (2025-10-01)
+
+
+### Features
+
+* add branch sync endpoint ([#912](https://github.com/phrase/strings-openapi/issues/912)) ([3293917](https://github.com/phrase/strings-openapi/commit/329391757b3f81574448b1b87506b85bfdeb6761))
+
+## [3.8.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.7.0...typescript-v3.8.0) (2025-09-30)
+
+
+### Features
+
+* **API:** Add "reviewed" param for tanslations#update ([#891](https://github.com/phrase/strings-openapi/issues/891)) ([3f77286](https://github.com/phrase/strings-openapi/commit/3f7728669fa68d5911dfca39a9e39c24cd20c0a4))
+* **SCM-732:** expose Automation API ([#910](https://github.com/phrase/strings-openapi/issues/910)) ([6eea53d](https://github.com/phrase/strings-openapi/commit/6eea53d06aca8f43623ba90e2e0a8cd6761c9a13))
+
+## [3.7.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.6.0...typescript-v3.7.0) (2025-08-01)
+
+
+### Features
+
+* **API:** Add support for `update_custom_metadata` option on upload ([#882](https://github.com/phrase/strings-openapi/issues/882)) ([5b486ea](https://github.com/phrase/strings-openapi/commit/5b486eabf30c84402a8e31911a5ba6fe3b343a89))
+
+## [3.6.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.5.0...typescript-v3.6.0) (2025-07-24)
+
+
+### Features
+
+* **API:** Job and job locale annotations #SCD-145 ([#867](https://github.com/phrase/strings-openapi/issues/867)) ([95b6c2a](https://github.com/phrase/strings-openapi/commit/95b6c2a2ab798d01f9bc0d53a22dbf817a5eb0ee))
+
+## [3.5.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.4.0...typescript-v3.5.0) (2025-07-18)
+
+
+### Features
+
+* **API:** add updated_since param for downloads ([#858](https://github.com/phrase/strings-openapi/issues/858)) ([db4196b](https://github.com/phrase/strings-openapi/commit/db4196bfb1a45f628577bebb99aad7da1179c241))
+* **API:** Add use_ordinal_rules attribute to request body for create/update Keys endpoints ([#868](https://github.com/phrase/strings-openapi/issues/868)) ([29410b5](https://github.com/phrase/strings-openapi/commit/29410b5d4edee9645f449d2d7de53fb953c1f0c2))
+* **API:** Add use_ordinal_rules boolean [STRINGS-2273] ([#846](https://github.com/phrase/strings-openapi/issues/846)) ([450ce0c](https://github.com/phrase/strings-openapi/commit/450ce0cce6bb2064758c44b130b39dd5539c2681))
+
+## [3.4.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.3.0...typescript-v3.4.0) (2025-05-23)
+
+
+### Features
+
+* **API:** Add omit_statistics param to tags#show ([#834](https://github.com/phrase/strings-openapi/issues/834)) ([2058b18](https://github.com/phrase/strings-openapi/commit/2058b18297133075885ac99770aee2e171811cd6))
+
+## [3.3.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.2.0...typescript-v3.3.0) (2025-05-16)
+
+
+### Features
+
+* **API:** Add "verify_mentioned_translations" parameter to uploads ([#830](https://github.com/phrase/strings-openapi/issues/830)) ([f2fdf60](https://github.com/phrase/strings-openapi/commit/f2fdf60dd97c3908293cd457a765dafde603bd9b))
+* **API:** Add processed & upload total translations on upload summary ([#824](https://github.com/phrase/strings-openapi/issues/824)) ([081db68](https://github.com/phrase/strings-openapi/commit/081db68d2ffcf5d66a81e07eec0a9572a1f9d633))
+* **API:** add updated_since filter to job list #STRINGS-1555 ([#799](https://github.com/phrase/strings-openapi/issues/799)) ([dc9b6ed](https://github.com/phrase/strings-openapi/commit/dc9b6ed12e013231d397820449086c87fea2f8ba))
+* **API:** Include roles in account response ([#811](https://github.com/phrase/strings-openapi/issues/811)) ([dc27ee5](https://github.com/phrase/strings-openapi/commit/dc27ee5117762222b6e1e6abb639f8e00c6a9101))
+* **API:** Translations unreview & batch unreview ([#831](https://github.com/phrase/strings-openapi/issues/831)) ([6a696db](https://github.com/phrase/strings-openapi/commit/6a696db00d80d8acaf5887a08a7a97997566eb8f))
 
 
 ### Bug Fixes
 
-* **API:** pass translation_key_ids when removing keys from job ([#771](https://github.com/phrase/openapi/issues/771)) ([f670e27](https://github.com/phrase/openapi/commit/f670e2763b1112fefd1812109b3c09def42b7bd2))
+* **API:** Remove request body from GET comments ([#817](https://github.com/phrase/strings-openapi/issues/817)) ([2646001](https://github.com/phrase/strings-openapi/commit/264600132e80ac03983e0ae86e99db3d6fb9080d))
 
-## [3.0.2](https://github.com/phrase/openapi/compare/typescript-v3.0.1...typescript-v3.0.2) (2025-01-06)
+## [3.2.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.1.0...typescript-v3.2.0) (2025-02-17)
+
+
+### Features
+
+* **API:** document tags attribute of an upload #STRINGS-1221 ([#790](https://github.com/phrase/strings-openapi/issues/790)) ([fff505b](https://github.com/phrase/strings-openapi/commit/fff505bdff35a0033fee06e505c42fe794c88562))
+
+## [3.1.0](https://github.com/phrase/strings-openapi/compare/typescript-v3.0.3...typescript-v3.1.0) (2025-02-17)
+
+
+### Features
+
+* **API:** Add locale_ids param to synchronous download endpoint [STRINGS-1492] ([#780](https://github.com/phrase/strings-openapi/issues/780)) ([47186a4](https://github.com/phrase/strings-openapi/commit/47186a44fc8c0b8e466636acf3d49413b1f29f30))
+* **API:** Add source last updated at information on job details ([#777](https://github.com/phrase/strings-openapi/issues/777)) ([c9b8423](https://github.com/phrase/strings-openapi/commit/c9b8423766b4138980d0553502b3e18ca524f34e))
+
+## [3.0.3](https://github.com/phrase/strings-openapi/compare/typescript-v3.0.2...typescript-v3.0.3) (2025-01-29)
 
 
 ### Bug Fixes
 
-* **CLI:** Adjust operationId for quality_performance_score #STRINGS-1104 ([#721](https://github.com/phrase/openapi/issues/721)) ([7aa3b9b](https://github.com/phrase/openapi/commit/7aa3b9b508d1d24a4af7f4977b1a2fead8bfda78))
+* **API:** pass translation_key_ids when removing keys from job ([#771](https://github.com/phrase/strings-openapi/issues/771)) ([f670e27](https://github.com/phrase/strings-openapi/commit/f670e2763b1112fefd1812109b3c09def42b7bd2))
 
-## [3.0.1](https://github.com/phrase/openapi/compare/typescript-v3.0.0...typescript-v3.0.1) (2024-12-20)
+## [3.0.2](https://github.com/phrase/strings-openapi/compare/typescript-v3.0.1...typescript-v3.0.2) (2025-01-06)
 
 
 ### Bug Fixes
 
-* **API:** Repo Sync Event errors field type #STRINGS-1074 ([#756](https://github.com/phrase/openapi/issues/756)) ([c7670e0](https://github.com/phrase/openapi/commit/c7670e04810f95359d72ba6346b5f626bfb77b6f))
-* **API:** Repo Sync schema fixes #STRINGS-1074 ([#748](https://github.com/phrase/openapi/issues/748)) ([033be10](https://github.com/phrase/openapi/commit/033be1003fe01b5115de1f8ba2336d32b4862bfd))
+* **CLI:** Adjust operationId for quality_performance_score #STRINGS-1104 ([#721](https://github.com/phrase/strings-openapi/issues/721)) ([7aa3b9b](https://github.com/phrase/strings-openapi/commit/7aa3b9b508d1d24a4af7f4977b1a2fead8bfda78))
 
-## [3.0.0](https://github.com/phrase/openapi/compare/typescript-v2.6.0...typescript-v3.0.0) (2024-12-18)
+## [3.0.1](https://github.com/phrase/strings-openapi/compare/typescript-v3.0.0...typescript-v3.0.1) (2024-12-20)
+
+
+### Bug Fixes
+
+* **API:** Repo Sync Event errors field type #STRINGS-1074 ([#756](https://github.com/phrase/strings-openapi/issues/756)) ([c7670e0](https://github.com/phrase/strings-openapi/commit/c7670e04810f95359d72ba6346b5f626bfb77b6f))
+* **API:** Repo Sync schema fixes #STRINGS-1074 ([#748](https://github.com/phrase/strings-openapi/issues/748)) ([033be10](https://github.com/phrase/strings-openapi/commit/033be1003fe01b5115de1f8ba2336d32b4862bfd))
+
+## [3.0.0](https://github.com/phrase/strings-openapi/compare/typescript-v2.6.0...typescript-v3.0.0) (2024-12-18)
 
 
 ### ⚠ BREAKING CHANGES
 
-* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/openapi/issues/735))
+* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/strings-openapi/issues/735))
 
 ### Features
 
-* **API:** Add 'default_encoding' documentation ([#733](https://github.com/phrase/openapi/issues/733)) ([0139c51](https://github.com/phrase/openapi/commit/0139c51da747fbe7bc9929bcf3534aad7f22f39a))
-* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/openapi/issues/735)) ([c3bd8ec](https://github.com/phrase/openapi/commit/c3bd8eccaabcfa1b1066ea4438971ac59833af46))
+* **API:** Add 'default_encoding' documentation ([#733](https://github.com/phrase/strings-openapi/issues/733)) ([0139c51](https://github.com/phrase/strings-openapi/commit/0139c51da747fbe7bc9929bcf3534aad7f22f39a))
+* Remove old Git sync endpoints. Replaced with new repo sync ([#735](https://github.com/phrase/strings-openapi/issues/735)) ([c3bd8ec](https://github.com/phrase/strings-openapi/commit/c3bd8eccaabcfa1b1066ea4438971ac59833af46))
 
 
 ### Bug Fixes
 
-* **API:** Add missing branch parameter to job comment endpoints #STRINGS-988 ([#724](https://github.com/phrase/openapi/issues/724)) ([64d399c](https://github.com/phrase/openapi/commit/64d399ced0980ac2a48366f91110047287a0c590))
+* **API:** Add missing branch parameter to job comment endpoints #STRINGS-988 ([#724](https://github.com/phrase/strings-openapi/issues/724)) ([64d399c](https://github.com/phrase/strings-openapi/commit/64d399ced0980ac2a48366f91110047287a0c590))
 
-## [2.6.0](https://github.com/phrase/openapi/compare/typescript-v2.5.0...typescript-v2.6.0) (2024-12-03)
+## [2.6.0](https://github.com/phrase/strings-openapi/compare/typescript-v2.5.0...typescript-v2.6.0) (2024-12-03)
 
 
 ### Features
 
-* **API:** Add Pagination header to POST search endpoints [[#457](https://github.com/phrase/openapi/issues/457)] ([#706](https://github.com/phrase/openapi/issues/706)) ([9a79fa3](https://github.com/phrase/openapi/commit/9a79fa31bb3b9d58272fa2f4e82d72d0d44a93a0))
-* **API:** autotranslate param in key creation [STRINGS-786] ([#713](https://github.com/phrase/openapi/issues/713)) ([581d0ff](https://github.com/phrase/openapi/commit/581d0ff5f1d06757e5ddd9603b78fc8d435d68ee))
+* **API:** Add Pagination header to POST search endpoints [[#457](https://github.com/phrase/strings-openapi/issues/457)] ([#706](https://github.com/phrase/strings-openapi/issues/706)) ([9a79fa3](https://github.com/phrase/strings-openapi/commit/9a79fa31bb3b9d58272fa2f4e82d72d0d44a93a0))
+* **API:** autotranslate param in key creation [STRINGS-786] ([#713](https://github.com/phrase/strings-openapi/issues/713)) ([581d0ff](https://github.com/phrase/strings-openapi/commit/581d0ff5f1d06757e5ddd9603b78fc8d435d68ee))
 
 
 ### Bug Fixes
 
-* **API:** Comment creation schema fix #STRINGS-866 ([#718](https://github.com/phrase/openapi/issues/718)) ([e201d13](https://github.com/phrase/openapi/commit/e201d1360c89698dd8d3642cc28f89dd0e50a1fb))
+* **API:** Comment creation schema fix #STRINGS-866 ([#718](https://github.com/phrase/strings-openapi/issues/718)) ([e201d13](https://github.com/phrase/strings-openapi/commit/e201d1360c89698dd8d3642cc28f89dd0e50a1fb))
 
-## [2.5.0](https://github.com/phrase/openapi/compare/typescript-v2.4.0...typescript-v2.5.0) (2024-10-02)
+## [2.5.0](https://github.com/phrase/strings-openapi/compare/typescript-v2.4.0...typescript-v2.5.0) (2024-10-02)
 
 
 ### Features
 
-* Add translation key prefixes for upload and download ([#687](https://github.com/phrase/openapi/issues/687)) ([9c9c959](https://github.com/phrase/openapi/commit/9c9c959830631bcac8beaf1de30ab31755ac1ee5))
+* Add translation key prefixes for upload and download ([#687](https://github.com/phrase/strings-openapi/issues/687)) ([9c9c959](https://github.com/phrase/strings-openapi/commit/9c9c959830631bcac8beaf1de30ab31755ac1ee5))
 
 
 ### Bug Fixes
 
-* **API:** Format list is not paginated and authenticated #STRINGS-458 ([#690](https://github.com/phrase/openapi/issues/690)) ([25e90f4](https://github.com/phrase/openapi/commit/25e90f46513e70cf328be80c36ae785cead05851))
+* **API:** Format list is not paginated and authenticated #STRINGS-458 ([#690](https://github.com/phrase/strings-openapi/issues/690)) ([25e90f4](https://github.com/phrase/strings-openapi/commit/25e90f46513e70cf328be80c36ae785cead05851))
 
-## [2.4.0](https://github.com/phrase/openapi/compare/typescript-v2.3.0...typescript-v2.4.0) (2024-09-09)
-
-
-### Features
-
-* Add update_translations_on_source_match ([#670](https://github.com/phrase/openapi/issues/670)) ([11003ac](https://github.com/phrase/openapi/commit/11003ace7353bf99893482ca4aa32214abf3e581))
-
-## [2.3.0](https://github.com/phrase/openapi/compare/typescript-v2.2.1...typescript-v2.3.0) (2024-07-02)
+## [2.4.0](https://github.com/phrase/strings-openapi/compare/typescript-v2.3.0...typescript-v2.4.0) (2024-09-09)
 
 
 ### Features
 
-* add repo sync events show endpoint ([#641](https://github.com/phrase/openapi/issues/641)) ([e1d9cfb](https://github.com/phrase/openapi/commit/e1d9cfb23e079fea2d9e5475dff9a4137f1f0154))
-* **API:** Async downloads [TSI-2515] ([#642](https://github.com/phrase/openapi/issues/642)) ([6fcab5d](https://github.com/phrase/openapi/commit/6fcab5d4719f64e8e5dd49c327dc9348b384de4c))
+* Add update_translations_on_source_match ([#670](https://github.com/phrase/strings-openapi/issues/670)) ([11003ac](https://github.com/phrase/strings-openapi/commit/11003ace7353bf99893482ca4aa32214abf3e581))
 
-## [2.2.1](https://github.com/phrase/openapi/compare/typescript-v2.2.0...typescript-v2.2.1) (2024-06-18)
+## [2.3.0](https://github.com/phrase/strings-openapi/compare/typescript-v2.2.1...typescript-v2.3.0) (2024-07-02)
+
+
+### Features
+
+* add repo sync events show endpoint ([#641](https://github.com/phrase/strings-openapi/issues/641)) ([e1d9cfb](https://github.com/phrase/strings-openapi/commit/e1d9cfb23e079fea2d9e5475dff9a4137f1f0154))
+* **API:** Async downloads [TSI-2515] ([#642](https://github.com/phrase/strings-openapi/issues/642)) ([6fcab5d](https://github.com/phrase/strings-openapi/commit/6fcab5d4719f64e8e5dd49c327dc9348b384de4c))
+
+## [2.2.1](https://github.com/phrase/strings-openapi/compare/typescript-v2.2.0...typescript-v2.2.1) (2024-06-18)
 
 
 ### Bug Fixes
 
-* add app_min_version and app_max_version param to releases ([#633](https://github.com/phrase/openapi/issues/633)) ([b384301](https://github.com/phrase/openapi/commit/b3843012460ace4c1d34c4373e5158595466adcb))
+* add app_min_version and app_max_version param to releases ([#633](https://github.com/phrase/strings-openapi/issues/633)) ([b384301](https://github.com/phrase/strings-openapi/commit/b3843012460ace4c1d34c4373e5158595466adcb))
 
-## [2.2.0](https://github.com/phrase/openapi/compare/typescript-v2.1.1...typescript-v2.2.0) (2024-06-12)
+## [2.2.0](https://github.com/phrase/strings-openapi/compare/typescript-v2.1.1...typescript-v2.2.0) (2024-06-12)
 
 
 ### Features
 
-* **API:** Add OTA Release Triggers API [TSI-2485] ([#622](https://github.com/phrase/openapi/issues/622)) ([8cb91dc](https://github.com/phrase/openapi/commit/8cb91dcce2c19ca700cf9d0713fa74f28ad59434))
+* **API:** Add OTA Release Triggers API [TSI-2485] ([#622](https://github.com/phrase/strings-openapi/issues/622)) ([8cb91dc](https://github.com/phrase/strings-openapi/commit/8cb91dcce2c19ca700cf9d0713fa74f28ad59434))
 
-## [2.1.1](https://github.com/phrase/openapi/compare/typescript-v2.1.0...typescript-v2.1.1) (2024-05-31)
+## [2.1.1](https://github.com/phrase/strings-openapi/compare/typescript-v2.1.0...typescript-v2.1.1) (2024-05-31)
 
 
 ### Bug Fixes
 
-* **CLI:** use id instead of repo_sync_id as param ([#618](https://github.com/phrase/openapi/issues/618)) ([7a1a0d9](https://github.com/phrase/openapi/commit/7a1a0d9115262dc7fa3065ee7cc76bec7a381ddb))
-* **PHP:** Fix deserializing custom metadata values in key response ([#607](https://github.com/phrase/openapi/issues/607)) ([b6eeeba](https://github.com/phrase/openapi/commit/b6eeeba223e3eabec268a8f3d372afcb6abd09dd))
+* **CLI:** use id instead of repo_sync_id as param ([#618](https://github.com/phrase/strings-openapi/issues/618)) ([7a1a0d9](https://github.com/phrase/strings-openapi/commit/7a1a0d9115262dc7fa3065ee7cc76bec7a381ddb))
+* **PHP:** Fix deserializing custom metadata values in key response ([#607](https://github.com/phrase/strings-openapi/issues/607)) ([b6eeeba](https://github.com/phrase/strings-openapi/commit/b6eeeba223e3eabec268a8f3d372afcb6abd09dd))
 
-## [2.1.0](https://github.com/phrase/openapi/compare/typescript-v2.0.0...typescript-v2.1.0) (2024-04-29)
+## [2.1.0](https://github.com/phrase/strings-openapi/compare/typescript-v2.0.0...typescript-v2.1.0) (2024-04-29)
 
 
 ### Features
 
-* **API:** Add 'update_translation_keys' for Uploads [TSI-2292] ([#578](https://github.com/phrase/openapi/issues/578)) ([4492ec0](https://github.com/phrase/openapi/commit/4492ec0a7c62f9de9ab1c1125071615bddcc26ce))
+* **API:** Add 'update_translation_keys' for Uploads [TSI-2292] ([#578](https://github.com/phrase/strings-openapi/issues/578)) ([4492ec0](https://github.com/phrase/strings-openapi/commit/4492ec0a7c62f9de9ab1c1125071615bddcc26ce))
 
-## [2.0.0](https://github.com/phrase/openapi/compare/typescript-v1.23.0...typescript-v2.0.0) (2024-04-23)
+## [2.0.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.23.0...typescript-v2.0.0) (2024-04-23)
 
 
 ### ⚠ BREAKING CHANGES
 
-* add missing required params ([#571](https://github.com/phrase/openapi/issues/571))
+* add missing required params ([#571](https://github.com/phrase/strings-openapi/issues/571))
 
 ### Code Refactoring
 
-* add missing required params ([#571](https://github.com/phrase/openapi/issues/571)) ([d810e9e](https://github.com/phrase/openapi/commit/d810e9ebc767e14ba9e56106de8c5774d9d6d178))
+* add missing required params ([#571](https://github.com/phrase/strings-openapi/issues/571)) ([d810e9e](https://github.com/phrase/strings-openapi/commit/d810e9ebc767e14ba9e56106de8c5774d9d6d178))
 
-## [1.23.0](https://github.com/phrase/openapi/compare/typescript-v1.22.0...typescript-v1.23.0) (2024-04-22)
-
-
-### Features
-
-* Add linked-parent to translation details ([#570](https://github.com/phrase/openapi/issues/570)) ([2c6f432](https://github.com/phrase/openapi/commit/2c6f43253e24b670b71ac810c85dce0759c29403))
-
-## [1.22.0](https://github.com/phrase/openapi/compare/typescript-v1.21.0...typescript-v1.22.0) (2024-04-17)
+## [1.23.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.22.0...typescript-v1.23.0) (2024-04-22)
 
 
 ### Features
 
-* **API:** Add Repo Sync [TSI-1923] ([#569](https://github.com/phrase/openapi/issues/569)) ([0bd1756](https://github.com/phrase/openapi/commit/0bd17562018cb045ff41cc1ff5008b9419a0ed12))
+* Add linked-parent to translation details ([#570](https://github.com/phrase/strings-openapi/issues/570)) ([2c6f432](https://github.com/phrase/strings-openapi/commit/2c6f43253e24b670b71ac810c85dce0759c29403))
 
-## [1.21.0](https://github.com/phrase/openapi/compare/typescript-v1.20.0...typescript-v1.21.0) (2024-04-10)
+## [1.22.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.21.0...typescript-v1.22.0) (2024-04-17)
 
 
 ### Features
 
-* **API:** add Linked Keys endpoints ([#555](https://github.com/phrase/openapi/issues/555)) ([4935dac](https://github.com/phrase/openapi/commit/4935dac58c787eaade2f1f65ce649f466b5e3a60))
+* **API:** Add Repo Sync [TSI-1923] ([#569](https://github.com/phrase/strings-openapi/issues/569)) ([0bd1756](https://github.com/phrase/strings-openapi/commit/0bd17562018cb045ff41cc1ff5008b9419a0ed12))
+
+## [1.21.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.20.0...typescript-v1.21.0) (2024-04-10)
+
+
+### Features
+
+* **API:** add Linked Keys endpoints ([#555](https://github.com/phrase/strings-openapi/issues/555)) ([4935dac](https://github.com/phrase/strings-openapi/commit/4935dac58c787eaade2f1f65ce649f466b5e3a60))
 
 
 ### Bug Fixes
 
-* (API) Add mandatory params to linked keys endpoints ([#564](https://github.com/phrase/openapi/issues/564)) ([08d9846](https://github.com/phrase/openapi/commit/08d9846bc224d349e2ade9abf28d733afb1e8be3))
+* (API) Add mandatory params to linked keys endpoints ([#564](https://github.com/phrase/strings-openapi/issues/564)) ([08d9846](https://github.com/phrase/strings-openapi/commit/08d9846bc224d349e2ade9abf28d733afb1e8be3))
 
-## [1.20.0](https://github.com/phrase/openapi/compare/typescript-v1.19.2...typescript-v1.20.0) (2024-02-07)
+## [1.20.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.19.2...typescript-v1.20.0) (2024-02-07)
 
 
 ### Features
 
-* add query param for properties ([#542](https://github.com/phrase/openapi/issues/542)) ([b4e12d0](https://github.com/phrase/openapi/commit/b4e12d04fd2916351f9201e1e6de504143ecc9aa))
+* add query param for properties ([#542](https://github.com/phrase/strings-openapi/issues/542)) ([b4e12d0](https://github.com/phrase/strings-openapi/commit/b4e12d04fd2916351f9201e1e6de504143ecc9aa))
 
-## [1.19.2](https://github.com/phrase/openapi/compare/typescript-v1.19.1...typescript-v1.19.2) (2024-02-05)
+## [1.19.2](https://github.com/phrase/strings-openapi/compare/typescript-v1.19.1...typescript-v1.19.2) (2024-02-05)
 
 
 ### Bug Fixes
 
-* **API:** allow nullable value for job's due_date ([#534](https://github.com/phrase/openapi/issues/534)) ([38b51b5](https://github.com/phrase/openapi/commit/38b51b51095394f8ce769873140038abba628514))
+* **API:** allow nullable value for job's due_date ([#534](https://github.com/phrase/strings-openapi/issues/534)) ([38b51b5](https://github.com/phrase/strings-openapi/commit/38b51b51095394f8ce769873140038abba628514))
 
-## [1.19.1](https://github.com/phrase/openapi/compare/typescript-v1.19.0...typescript-v1.19.1) (2024-02-01)
-
-
-### Bug Fixes
-
-* **API:** Adjust documentation of QPS endpoint ([#525](https://github.com/phrase/openapi/issues/525)) ([4b4f1ac](https://github.com/phrase/openapi/commit/4b4f1acf28fbd13b3d16c37162cdccfa05c38ffa))
-
-## [1.19.0](https://github.com/phrase/openapi/compare/typescript-v1.18.0...typescript-v1.19.0) (2024-01-17)
-
-
-### Features
-
-* **api:** Add QPS endpoint and documentation ([#521](https://github.com/phrase/openapi/issues/521)) ([d22c558](https://github.com/phrase/openapi/commit/d22c558adfbb7fcd13759e388c038744914e42fa))
+## [1.19.1](https://github.com/phrase/strings-openapi/compare/typescript-v1.19.0...typescript-v1.19.1) (2024-02-01)
 
 
 ### Bug Fixes
 
-* **API:** Create Custom Metadata endpoint fix [TSI-2222] ([#499](https://github.com/phrase/openapi/issues/499)) ([ce2ed94](https://github.com/phrase/openapi/commit/ce2ed9488e111fb5d9bc3810a78c47d23553c8b7))
+* **API:** Adjust documentation of QPS endpoint ([#525](https://github.com/phrase/strings-openapi/issues/525)) ([4b4f1ac](https://github.com/phrase/strings-openapi/commit/4b4f1acf28fbd13b3d16c37162cdccfa05c38ffa))
 
-## [1.18.0](https://github.com/phrase/openapi/compare/typescript-v1.17.0...typescript-v1.18.0) (2023-12-13)
-
-
-### Features
-
-* Add reports locales endpoint to API [TSS-2439] ([#465](https://github.com/phrase/openapi/issues/465)) ([e03aa9f](https://github.com/phrase/openapi/commit/e03aa9f49f031517b36db715fe70e8e0b65a438b))
-* **API:** add Custom Metadata endpoints ([#474](https://github.com/phrase/openapi/issues/474)) ([d407d8b](https://github.com/phrase/openapi/commit/d407d8be5ccddec1afde14a12804a7a616f77d7a))
-* **API:** Add custom_metadata_filters param to locale download endpoint [TSI-2174] ([#478](https://github.com/phrase/openapi/issues/478)) ([3623478](https://github.com/phrase/openapi/commit/3623478fc1518b457ab018b5630a693081637d6e))
-* **API:** Add url field to uploads ([#481](https://github.com/phrase/openapi/issues/481)) ([7332a84](https://github.com/phrase/openapi/commit/7332a84f9958346f2fb28dee4b0353519ef466d5))
-
-## [1.17.0](https://github.com/phrase/openapi/compare/typescript-v1.16.0...typescript-v1.17.0) (2023-11-03)
+## [1.19.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.18.0...typescript-v1.19.0) (2024-01-17)
 
 
 ### Features
 
-* [TSI-2083] enable format_options argument for java-client   ([#426](https://github.com/phrase/openapi/issues/426)) ([faa8cb3](https://github.com/phrase/openapi/commit/faa8cb353ba9f1030b9f7cfd46b894b4d6d26e70))
-
-## [1.16.0](https://github.com/phrase/openapi/compare/typescript-v1.15.0...typescript-v1.16.0) (2023-10-30)
-
-
-### Features
-
-* Update openapi-generator to v7 ([#418](https://github.com/phrase/openapi/issues/418)) ([524626f](https://github.com/phrase/openapi/commit/524626f5e914bfef6025d0e1c2cbc7a728d08f56))
-
-## [1.15.0](https://github.com/phrase/openapi/compare/typescript-v1.14.0...typescript-v1.15.0) (2023-10-23)
-
-
-### Features
-
-* **API:** Add order param to comment list endpoints ([#441](https://github.com/phrase/openapi/issues/441)) ([441c9c4](https://github.com/phrase/openapi/commit/441c9c46169f8c5ac4e71ade09a95dab136314ef))
-
-## [1.14.0](https://github.com/phrase/openapi/compare/typescript-v1.13.0...typescript-v1.14.0) (2023-10-13)
-
-
-### Features
-
-* **API:** Implement figma attachments endpoints ([#415](https://github.com/phrase/openapi/issues/415)) ([970e612](https://github.com/phrase/openapi/commit/970e612fda620ca882a221ef541036b8d200b675))
-
-## [1.13.0](https://github.com/phrase/openapi/compare/typescript-v1.12.0...typescript-v1.13.0) (2023-09-12)
-
-
-### Features
-
-* Optionally tag only affected keys on upload [TSI-2041] ([#412](https://github.com/phrase/openapi/issues/412)) ([e8f958e](https://github.com/phrase/openapi/commit/e8f958e91469c2542f44ab68469c933688958383))
-* **TSI-1946:** Add reviewed_at to translations ([#396](https://github.com/phrase/openapi/issues/396)) ([3e663d9](https://github.com/phrase/openapi/commit/3e663d971a99a816f0165dd6653a9a1e8a87c95e))
-
-## [1.12.0](https://github.com/phrase/openapi/compare/typescript-v1.11.0...typescript-v1.12.0) (2023-08-28)
-
-
-### Features
-
-* **API:** Document new query parameters ([#393](https://github.com/phrase/openapi/issues/393)) ([770515a](https://github.com/phrase/openapi/commit/770515a9628122955bb3919405babf9392684eb9))
-
-## [1.11.0](https://github.com/phrase/openapi/compare/typescript-v1.10.0...typescript-v1.11.0) (2023-08-24)
-
-
-### Features
-
-* **API:** Introduce comment replies endpoints ([#383](https://github.com/phrase/openapi/issues/383)) ([71351ac](https://github.com/phrase/openapi/commit/71351ac285f4f49976092e176c77b09f3485eb65))
-
-## [1.10.0](https://github.com/phrase/openapi/compare/typescript-v1.9.2...typescript-v1.10.0) (2023-08-22)
-
-
-### Features
-
-* **TSE-950:** Document comment_reactions endpoints ([#380](https://github.com/phrase/openapi/issues/380)) ([f230244](https://github.com/phrase/openapi/commit/f230244e6e9c069b18edc4c35dd5e290fd14793b))
+* **api:** Add QPS endpoint and documentation ([#521](https://github.com/phrase/strings-openapi/issues/521)) ([d22c558](https://github.com/phrase/strings-openapi/commit/d22c558adfbb7fcd13759e388c038744914e42fa))
 
 
 ### Bug Fixes
 
-* **schemas:** Fix gitlab_sync type mismatch ([#373](https://github.com/phrase/openapi/issues/373)) ([1cb1f65](https://github.com/phrase/openapi/commit/1cb1f650598c68afee6e2cd7c3c4ede1484aba35))
+* **API:** Create Custom Metadata endpoint fix [TSI-2222] ([#499](https://github.com/phrase/strings-openapi/issues/499)) ([ce2ed94](https://github.com/phrase/strings-openapi/commit/ce2ed9488e111fb5d9bc3810a78c47d23553c8b7))
 
-## [1.9.2](https://github.com/phrase/openapi/compare/typescript-v1.9.1...typescript-v1.9.2) (2023-07-28)
+## [1.18.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.17.0...typescript-v1.18.0) (2023-12-13)
+
+
+### Features
+
+* Add reports locales endpoint to API [TSS-2439] ([#465](https://github.com/phrase/strings-openapi/issues/465)) ([e03aa9f](https://github.com/phrase/strings-openapi/commit/e03aa9f49f031517b36db715fe70e8e0b65a438b))
+* **API:** add Custom Metadata endpoints ([#474](https://github.com/phrase/strings-openapi/issues/474)) ([d407d8b](https://github.com/phrase/strings-openapi/commit/d407d8be5ccddec1afde14a12804a7a616f77d7a))
+* **API:** Add custom_metadata_filters param to locale download endpoint [TSI-2174] ([#478](https://github.com/phrase/strings-openapi/issues/478)) ([3623478](https://github.com/phrase/strings-openapi/commit/3623478fc1518b457ab018b5630a693081637d6e))
+* **API:** Add url field to uploads ([#481](https://github.com/phrase/strings-openapi/issues/481)) ([7332a84](https://github.com/phrase/strings-openapi/commit/7332a84f9958346f2fb28dee4b0353519ef466d5))
+
+## [1.17.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.16.0...typescript-v1.17.0) (2023-11-03)
+
+
+### Features
+
+* [TSI-2083] enable format_options argument for java-client   ([#426](https://github.com/phrase/strings-openapi/issues/426)) ([faa8cb3](https://github.com/phrase/strings-openapi/commit/faa8cb353ba9f1030b9f7cfd46b894b4d6d26e70))
+
+## [1.16.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.15.0...typescript-v1.16.0) (2023-10-30)
+
+
+### Features
+
+* Update openapi-generator to v7 ([#418](https://github.com/phrase/strings-openapi/issues/418)) ([524626f](https://github.com/phrase/strings-openapi/commit/524626f5e914bfef6025d0e1c2cbc7a728d08f56))
+
+## [1.15.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.14.0...typescript-v1.15.0) (2023-10-23)
+
+
+### Features
+
+* **API:** Add order param to comment list endpoints ([#441](https://github.com/phrase/strings-openapi/issues/441)) ([441c9c4](https://github.com/phrase/strings-openapi/commit/441c9c46169f8c5ac4e71ade09a95dab136314ef))
+
+## [1.14.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.13.0...typescript-v1.14.0) (2023-10-13)
+
+
+### Features
+
+* **API:** Implement figma attachments endpoints ([#415](https://github.com/phrase/strings-openapi/issues/415)) ([970e612](https://github.com/phrase/strings-openapi/commit/970e612fda620ca882a221ef541036b8d200b675))
+
+## [1.13.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.12.0...typescript-v1.13.0) (2023-09-12)
+
+
+### Features
+
+* Optionally tag only affected keys on upload [TSI-2041] ([#412](https://github.com/phrase/strings-openapi/issues/412)) ([e8f958e](https://github.com/phrase/strings-openapi/commit/e8f958e91469c2542f44ab68469c933688958383))
+* **TSI-1946:** Add reviewed_at to translations ([#396](https://github.com/phrase/strings-openapi/issues/396)) ([3e663d9](https://github.com/phrase/strings-openapi/commit/3e663d971a99a816f0165dd6653a9a1e8a87c95e))
+
+## [1.12.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.11.0...typescript-v1.12.0) (2023-08-28)
+
+
+### Features
+
+* **API:** Document new query parameters ([#393](https://github.com/phrase/strings-openapi/issues/393)) ([770515a](https://github.com/phrase/strings-openapi/commit/770515a9628122955bb3919405babf9392684eb9))
+
+## [1.11.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.10.0...typescript-v1.11.0) (2023-08-24)
+
+
+### Features
+
+* **API:** Introduce comment replies endpoints ([#383](https://github.com/phrase/strings-openapi/issues/383)) ([71351ac](https://github.com/phrase/strings-openapi/commit/71351ac285f4f49976092e176c77b09f3485eb65))
+
+## [1.10.0](https://github.com/phrase/strings-openapi/compare/typescript-v1.9.2...typescript-v1.10.0) (2023-08-22)
+
+
+### Features
+
+* **TSE-950:** Document comment_reactions endpoints ([#380](https://github.com/phrase/strings-openapi/issues/380)) ([f230244](https://github.com/phrase/strings-openapi/commit/f230244e6e9c069b18edc4c35dd5e290fd14793b))
 
 
 ### Bug Fixes
 
-* Fix gitlab_sync history status type mismatch ([#363](https://github.com/phrase/openapi/issues/363)) ([ebcaa4e](https://github.com/phrase/openapi/commit/ebcaa4e5dfcb2f73559a56c78b0f2512ca798375))
+* **schemas:** Fix gitlab_sync type mismatch ([#373](https://github.com/phrase/strings-openapi/issues/373)) ([1cb1f65](https://github.com/phrase/strings-openapi/commit/1cb1f650598c68afee6e2cd7c3c4ede1484aba35))
 
-## [1.9.1](https://github.com/phrase/openapi/compare/typescript-v1.9.0...typescript-v1.9.1) (2023-06-23)
+## [1.9.2](https://github.com/phrase/strings-openapi/compare/typescript-v1.9.1...typescript-v1.9.2) (2023-07-28)
 
 
 ### Bug Fixes
 
-* **typescript:** Serialize deep FormData parameters [TSI-1895] ([#355](https://github.com/phrase/openapi/issues/355)) ([c64da4f](https://github.com/phrase/openapi/commit/c64da4fedbef84e7da0eaaef96cedd7c5315b327))
+* Fix gitlab_sync history status type mismatch ([#363](https://github.com/phrase/strings-openapi/issues/363)) ([ebcaa4e](https://github.com/phrase/strings-openapi/commit/ebcaa4e5dfcb2f73559a56c78b0f2512ca798375))
+
+## [1.9.1](https://github.com/phrase/strings-openapi/compare/typescript-v1.9.0...typescript-v1.9.1) (2023-06-23)
+
+
+### Bug Fixes
+
+* **typescript:** Serialize deep FormData parameters [TSI-1895] ([#355](https://github.com/phrase/strings-openapi/issues/355)) ([c64da4f](https://github.com/phrase/strings-openapi/commit/c64da4fedbef84e7da0eaaef96cedd7c5315b327))

--- a/openapi-generator/java_lang.yaml
+++ b/openapi-generator/java_lang.yaml
@@ -17,7 +17,7 @@ licenseUrl: https://choosealicense.com/licenses/mit/
 modelPackage: com.phrase.client.model
 scmConnection: scm:git:git@github.com:phrase/openapi.git
 scmDeveloperConnection: scm:git:git@github.com:phrase/openapi.git
-scmUrl: https://github.com/phrase/openapi
+scmUrl: https://github.com/phrase/strings-openapi
 java8: true
 dateLibrary: java8
 templateDir: openapi-generator/templates/java

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/phrase/openapi.git"
+    "url": "git+https://github.com/phrase/strings-openapi.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/phrase/openapi/issues"
+    "url": "https://github.com/phrase/strings-openapi/issues"
   },
   "homepage": "https://developers.phrase.com/",
   "devDependencies": {


### PR DESCRIPTION
Rename repo to clarify this is the strings product API documentation