### PR TITLE
feat(SCM-1430): Add q search param to tags list endpoint

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -20472,6 +20472,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Specify a query to filter tags by name.",
+            "example": "feature",
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/paths/tags/index.yaml
+++ b/paths/tags/index.yaml
@@ -20,6 +20,12 @@ parameters:
     in: query
     schema:
       type: string
+  - description: Specify a query to filter tags by name.
+    example: feature
+    name: q
+    in: query
+    schema:
+      type: string
 responses:
   '200':
     description: OK


### PR DESCRIPTION
## Summary
  - Adds optional `q` query parameter to the `GET /api/v2/projects/:project_id/tags` (List Tags) endpoint
  - Enables case-insensitive prefix filtering of tags by name (e.g. `?q=release` returns all tags starting with "release")
  - Parameter type: `string`, optional — existing callers are unaffected

  ## Motivation
  Projects with large numbers of tags (e.g. 1,300+) caused performance issues in the Figma plugin, which had to paginate through all tags client-side. This allows filtering to happen server-side.

  ## Changes
  - `paths/tags/index.yaml` — added `q` parameter definition
  - `doc/compiled.json` — regenerated bundle reflecting the above

  ## Related
  - Backend implementation: Phrase-Engineering/strings-app#17476
  - Jira: [SCM-1430](https://phrase.atlassian.net/browse/SCM-1430)

[SCM-1430]: https://phrase.atlassian.net/browse/SCM-1430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="629" height="133" alt="Screenshot 2026-04-29 at 14 17 00" src="https://github.com/user-attachments/assets/c496d102-c631-45e9-ba5d-39ba62780ec8" />
