### PR TITLE
feat(API): Add q search param to locales list endpoint

### DIFF
--- a/clients/java/src/test/java/com/phrase/client/api/LocalesApiTest.java
+++ b/clients/java/src/test/java/com/phrase/client/api/LocalesApiTest.java
@@ -251,7 +251,8 @@ public class LocalesApiTest {
         Integer perPage = null;
         String sortBy = null;
         String branch = "MY_BRANCH";
-        List<Locale> response = api.localesList(projectId, xPhraseAppOTP, page, perPage, sortBy, branch);
+        String q = null;
+        List<Locale> response = api.localesList(projectId, xPhraseAppOTP, page, perPage, sortBy, branch, q);
 
         Assert.assertEquals("Correct number of elements", response.size(), 3);
         Assert.assertEquals("Correct locale name", response.get(0).getName(), "de-DE");

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -8355,6 +8355,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Specify a query to filter locales by name.",
+            "example": "name:en",
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -8357,7 +8357,7 @@
             }
           },
           {
-            "description": "Specify a query to filter locales by name.",
+            "description": "Specify a query to filter locales. Currently supports `name` argument, filtering only locales with names starting with the given string.",
             "example": "name:en",
             "name": "q",
             "in": "query",

--- a/paths/locales/index.yaml
+++ b/paths/locales/index.yaml
@@ -21,6 +21,12 @@ parameters:
   in: query
   schema:
     type: string
+- description: Specify a query to filter locales by name.
+  example: name:en
+  name: q
+  in: query
+  schema:
+    type: string
 responses:
   '200':
     description: OK

--- a/paths/locales/index.yaml
+++ b/paths/locales/index.yaml
@@ -21,7 +21,7 @@ parameters:
   in: query
   schema:
     type: string
-- description: Specify a query to filter locales by name.
+- description: Specify a query to filter locales. Currently supports `name` argument, filtering only locales with names starting with the given string.
   example: name:en
   name: q
   in: query


### PR DESCRIPTION
## Summary

Adds optional q query parameter to the (List Locales) endpoint
Enables case-insensitive prefix filtering of tags by name (e.g. ?q=name:en)
Parameter type: string, optional — existing callers are unaffected
