### PR TITLE
chore: Add merged_by to client-payload

### DIFF
--- a/.github/workflows/developer-hub.yml
+++ b/.github/workflows/developer-hub.yml
@@ -21,5 +21,6 @@ jobs:
               "source": "phrase/openapi",
               "type": "update",
               "pr_author": "${{ github.event.pull_request.user.login }}",
-              "pr_url": "${{ github.event.pull_request.html_url }}"
+              "pr_url": "${{ github.event.pull_request.html_url }}",
+              "pr_merged_by": "${{ github.event.pull_request.merged_by.login }}"
             }


### PR DESCRIPTION
Passed information to the client-payload about the person who merges the pull request so we can properly assign pull requests in the Developer Hub project.