### PR TITLE
docs(API): fix missing line continuations in curl examples

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -7445,7 +7445,7 @@
         "x-code-samples": [
           {
             "lang": "Curl",
-            "source": "curl \"https://api.phrase.com/v2/accounts/:account_id/custom_metadata/properties/:id\" \\\n  -u USERNAME_OR_ACCESS_TOKEN\n  -X DELETE\n  -H 'Content-Type: application/json'"
+            "source": "curl \"https://api.phrase.com/v2/accounts/:account_id/custom_metadata/properties/:id\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X DELETE \\\n  -H 'Content-Type: application/json'"
           },
           {
             "lang": "CLI v2",
@@ -8562,7 +8562,7 @@
         "x-code-samples": [
           {
             "lang": "Curl",
-            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/screenshots/:screenshot_id/markers\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X DELETE\n  -d '{\"branch\":\"my-feature-branch\"}' \\\n  -H 'Content-Type: application/json'"
+            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/screenshots/:screenshot_id/markers\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X DELETE \\\n  -d '{\"branch\":\"my-feature-branch\"}' \\\n  -H 'Content-Type: application/json'"
           },
           {
             "lang": "CLI v2",
@@ -21438,7 +21438,7 @@
         "x-code-samples": [
           {
             "lang": "Curl",
-            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/screenshots/:id\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X DELETE\n  -d '{\"branch\":\"my-feature-branch\"}' \\\n  -H 'Content-Type: application/json'"
+            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/screenshots/:id\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X DELETE \\\n  -d '{\"branch\":\"my-feature-branch\"}' \\\n  -H 'Content-Type: application/json'"
           },
           {
             "lang": "CLI v2",
@@ -22825,7 +22825,7 @@
         "x-code-samples": [
           {
             "lang": "Curl",
-            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/keys\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X POST \\\n  -F branch=my-feature-branch \\\n  -F name=home.index.headline \\\n  -F description=Some%20description%20worth%20knowing... \\\n  -F name_plural=home.index.headlines \\\n  -F data_type=number \\\n  -F tags=awesome-feature,needs-proofreading \\\n  -F max_characters_allowed=140 \\\n  -F screenshot=@/path/to/my/screenshot.png\n  -F custom_metadata[property]=value"
+            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/keys\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X POST \\\n  -F branch=my-feature-branch \\\n  -F name=home.index.headline \\\n  -F description=Some%20description%20worth%20knowing... \\\n  -F name_plural=home.index.headlines \\\n  -F data_type=number \\\n  -F tags=awesome-feature,needs-proofreading \\\n  -F max_characters_allowed=140 \\\n  -F screenshot=@/path/to/my/screenshot.png \\\n  -F custom_metadata[property]=value"
           },
           {
             "lang": "CLI v2",
@@ -23315,7 +23315,7 @@
         "x-code-samples": [
           {
             "lang": "Curl",
-            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/keys/:id\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X PATCH \\\n  -F branch=my-feature-branch \\\n  -F name=home.index.headline \\\n  -F description=Some%20description%20worth%20knowing... \\\n  -F name_plural=home.index.headlines \\\n  -F data_type=number \\\n  -F tags=awesome-feature,needs-proofreading \\\n  -F max_characters_allowed=140 \\\n  -F screenshot=@/path/to/my/screenshot.png\n  -F custom_metadata[property]=value"
+            "source": "curl \"https://api.phrase.com/v2/projects/:project_id/keys/:id\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X PATCH \\\n  -F branch=my-feature-branch \\\n  -F name=home.index.headline \\\n  -F description=Some%20description%20worth%20knowing... \\\n  -F name_plural=home.index.headlines \\\n  -F data_type=number \\\n  -F tags=awesome-feature,needs-proofreading \\\n  -F max_characters_allowed=140 \\\n  -F screenshot=@/path/to/my/screenshot.png \\\n  -F custom_metadata[property]=value"
           },
           {
             "lang": "CLI v2",
@@ -31544,7 +31544,7 @@
         "x-code-samples": [
           {
             "lang": "Curl",
-            "source": "curl \"https://api.phrase.com/v2/accounts/:account_id/automations/:id\" \\\n  -u USERNAME_OR_ACCESS_TOKEN\n  -X DELETE\n  -H 'Content-Type: application/json'"
+            "source": "curl \"https://api.phrase.com/v2/accounts/:account_id/automations/:id\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X DELETE \\\n  -H 'Content-Type: application/json'"
           },
           {
             "lang": "CLI v2",
@@ -31617,7 +31617,7 @@
         "x-code-samples": [
           {
             "lang": "Curl",
-            "source": "curl \"https://api.phrase.com/v2/accounts/:account_id/automations/:id/activate\" \\\n  -u USERNAME_OR_ACCESS_TOKEN\n  -X POST\n  -H 'Content-Type: application/json'"
+            "source": "curl \"https://api.phrase.com/v2/accounts/:account_id/automations/:id/activate\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X POST \\\n  -H 'Content-Type: application/json'"
           },
           {
             "lang": "CLI v2",
@@ -31690,7 +31690,7 @@
         "x-code-samples": [
           {
             "lang": "Curl",
-            "source": "curl \"https://api.phrase.com/v2/accounts/:account_id/automations/:id/deactivate\" \\\n  -u USERNAME_OR_ACCESS_TOKEN\n  -X POST\n  -H 'Content-Type: application/json'"
+            "source": "curl \"https://api.phrase.com/v2/accounts/:account_id/automations/:id/deactivate\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X POST \\\n  -H 'Content-Type: application/json'"
           },
           {
             "lang": "CLI v2",
@@ -31745,7 +31745,7 @@
         "x-code-samples": [
           {
             "lang": "Curl",
-            "source": "curl \"https://api.phrase.com/v2/accounts/:account_id/automations/:id/trigger\" \\\n  -u USERNAME_OR_ACCESS_TOKEN\n  -X POST\n  -H 'Content-Type: application/json'"
+            "source": "curl \"https://api.phrase.com/v2/accounts/:account_id/automations/:id/trigger\" \\\n  -u USERNAME_OR_ACCESS_TOKEN \\\n  -X POST \\\n  -H 'Content-Type: application/json'"
           },
           {
             "lang": "CLI v2",

--- a/paths/automations/activate.yaml
+++ b/paths/automations/activate.yaml
@@ -42,8 +42,8 @@ x-code-samples:
 - lang: Curl
   source: |-
     curl "https://api.phrase.com/v2/accounts/:account_id/automations/:id/activate" \
-      -u USERNAME_OR_ACCESS_TOKEN
-      -X POST
+      -u USERNAME_OR_ACCESS_TOKEN \
+      -X POST \
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-

--- a/paths/automations/deactivate.yaml
+++ b/paths/automations/deactivate.yaml
@@ -42,8 +42,8 @@ x-code-samples:
 - lang: Curl
   source: |-
     curl "https://api.phrase.com/v2/accounts/:account_id/automations/:id/deactivate" \
-      -u USERNAME_OR_ACCESS_TOKEN
-      -X POST
+      -u USERNAME_OR_ACCESS_TOKEN \
+      -X POST \
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-

--- a/paths/automations/destroy.yaml
+++ b/paths/automations/destroy.yaml
@@ -29,8 +29,8 @@ x-code-samples:
 - lang: Curl
   source: |-
     curl "https://api.phrase.com/v2/accounts/:account_id/automations/:id" \
-      -u USERNAME_OR_ACCESS_TOKEN
-      -X DELETE
+      -u USERNAME_OR_ACCESS_TOKEN \
+      -X DELETE \
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-

--- a/paths/automations/trigger.yaml
+++ b/paths/automations/trigger.yaml
@@ -29,8 +29,8 @@ x-code-samples:
 - lang: Curl
   source: |-
     curl "https://api.phrase.com/v2/accounts/:account_id/automations/:id/trigger" \
-      -u USERNAME_OR_ACCESS_TOKEN
-      -X POST
+      -u USERNAME_OR_ACCESS_TOKEN \
+      -X POST \
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-

--- a/paths/custom_metadata_properties/destroy.yaml
+++ b/paths/custom_metadata_properties/destroy.yaml
@@ -24,8 +24,8 @@ x-code-samples:
 - lang: Curl
   source: |-
     curl "https://api.phrase.com/v2/accounts/:account_id/custom_metadata/properties/:id" \
-      -u USERNAME_OR_ACCESS_TOKEN
-      -X DELETE
+      -u USERNAME_OR_ACCESS_TOKEN \
+      -X DELETE \
       -H 'Content-Type: application/json'
 - lang: CLI v2
   source: |-

--- a/paths/keys/create.yaml
+++ b/paths/keys/create.yaml
@@ -47,7 +47,7 @@ x-code-samples:
       -F data_type=number \
       -F tags=awesome-feature,needs-proofreading \
       -F max_characters_allowed=140 \
-      -F screenshot=@/path/to/my/screenshot.png
+      -F screenshot=@/path/to/my/screenshot.png \
       -F custom_metadata[property]=value
 - lang: CLI v2
   source: |-

--- a/paths/keys/update.yaml
+++ b/paths/keys/update.yaml
@@ -48,7 +48,7 @@ x-code-samples:
       -F data_type=number \
       -F tags=awesome-feature,needs-proofreading \
       -F max_characters_allowed=140 \
-      -F screenshot=@/path/to/my/screenshot.png
+      -F screenshot=@/path/to/my/screenshot.png \
       -F custom_metadata[property]=value
 - lang: CLI v2
   source: |-

--- a/paths/screenshot_markers/destroy.yaml
+++ b/paths/screenshot_markers/destroy.yaml
@@ -35,7 +35,7 @@ x-code-samples:
   source: |-
     curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:screenshot_id/markers" \
       -u USERNAME_OR_ACCESS_TOKEN \
-      -X DELETE
+      -X DELETE \
       -d '{"branch":"my-feature-branch"}' \
       -H 'Content-Type: application/json'
 - lang: CLI v2

--- a/paths/screenshots/destroy.yaml
+++ b/paths/screenshots/destroy.yaml
@@ -35,7 +35,7 @@ x-code-samples:
   source: |-
     curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:id" \
       -u USERNAME_OR_ACCESS_TOKEN \
-      -X DELETE
+      -X DELETE \
       -d '{"branch":"my-feature-branch"}' \
       -H 'Content-Type: application/json'
 - lang: CLI v2


### PR DESCRIPTION
Several curl x-code-samples were missing trailing backslashes, which broke the multi-line shell invocations when copy-pasted.