### PR TITLE
feat(API): add fallback_for_unverified_translations param to locale d…

### DIFF
--- a/clients/java/src/test/java/com/phrase/client/api/LocalesApiTest.java
+++ b/clients/java/src/test/java/com/phrase/client/api/LocalesApiTest.java
@@ -168,6 +168,7 @@ public class LocalesApiTest {
         Boolean useLastReviewedVersion = null;
         String fallbackLocaleId = null;
         Boolean useLocaleFallback = null;
+        Boolean fallbackForUnverifiedTranslations = null;
         String sourceLocaleId = null;
         Object customMetadataFilters = null;
         String translationKeyPrefix = null;
@@ -178,8 +179,8 @@ public class LocalesApiTest {
             branch, fileFormat, tags, tag, includeEmptyTranslations, excludeEmptyZeroForms,
             includeTranslatedKeys, keepNotranslateTags, convertEmoji, formatOptions, encoding,
             skipUnverifiedTranslations, includeUnverifiedTranslations, useLastReviewedVersion,
-            fallbackLocaleId, useLocaleFallback, sourceLocaleId, translationKeyPrefix, filterByPrefix,
-            customMetadataFilters, localeIds, updatedSince);
+            fallbackLocaleId, useLocaleFallback, fallbackForUnverifiedTranslations, sourceLocaleId,
+            translationKeyPrefix, filterByPrefix, customMetadataFilters, localeIds, updatedSince);
 
         String fileContents = new String(java.nio.file.Files.readAllBytes(response.toPath()));
         Assert.assertEquals("Correct file contents", fileContents, body);

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -9360,7 +9360,7 @@
           },
           {
             "name": "fallback_locale_id",
-            "description": "If a key has no translation in the locale being downloaded, the translation in the fallback locale will be used.\nProvide the ID of the locale that should be used as the fallback.\nRequires `include_empty_translations` to be set to `true`. Mutually exclusive with `use_locale_fallback`.\n",
+            "description": "If a key has no translation in the locale being downloaded, the translation in the fallback locale will be used.\nProvide the ID of the locale that should be used as the fallback.\nRequires `include_empty_translations` to be set to `true` unless `fallback_for_unverified_translations` is also set to `true`. Mutually exclusive with `use_locale_fallback`.\n",
             "in": "query",
             "schema": {
               "type": "string"
@@ -9369,12 +9369,23 @@
           },
           {
             "name": "use_locale_fallback",
-            "description": "If a key has no translation in the locale being downloaded, the translation in the fallback locale will be used.\nFallback locale is defined in [locale's settings](/en/api/strings/locales/update-a-locale#body-fallback-locale-id).\nRequires `include_empty_translations` to be set to `true`. Mutually exclusive with `fallback_locale_id`.\n",
+            "description": "If a key has no translation in the locale being downloaded, the translation in the fallback locale will be used.\nFallback locale is defined in [locale's settings](/en/api/strings/locales/update-a-locale#body-fallback-locale-id).\nRequires `include_empty_translations` to be set to `true` unless `fallback_for_unverified_translations` is also set to `true`. Mutually exclusive with `fallback_locale_id`.\n",
             "in": "query",
             "schema": {
               "type": "boolean"
             },
             "example": true
+          },
+          {
+            "name": "fallback_for_unverified_translations",
+            "description": "If set to `true`, translations in a non-final state are replaced by the fallback locale's translation at export time.\nIn the simple workflow, \"non-final\" means `unverified`. In the review workflow, it additionally includes `translated` (awaiting review).\nNo stored translations are modified. Requires `fallback_locale_id` or `use_locale_fallback` to be set; a `422` validation error is returned otherwise.\n",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "example": null
           },
           {
             "description": "Provides the source language of a corresponding job as the source language of the generated locale file. This parameter will be ignored unless used in combination with a `tag` parameter indicating a specific job.",
@@ -9593,13 +9604,19 @@
                     ]
                   },
                   "fallback_locale_id": {
-                    "description": "If a key has no translation in the locale being downloaded, the translation in the fallback locale will be used.\nProvide the ID of the locale that should be used as the fallback.\nRequires `include_empty_translations` to be set to `true`. Mutually exclusive with `use_locale_fallback`.\n",
+                    "description": "If a key has no translation in the locale being downloaded, the translation in the fallback locale will be used.\nProvide the ID of the locale that should be used as the fallback.\nRequires `include_empty_translations` to be set to `true` unless `fallback_for_unverified_translations` is also set to `true`. Mutually exclusive with `use_locale_fallback`.\n",
                     "type": "string",
                     "example": "abcd1234abcd1234abcd1234abcd1234"
                   },
                   "use_locale_fallback": {
-                    "description": "If a key has no translation in the locale being downloaded, the translation in the fallback locale will be used.\nFallback locale is defined in [locale's settings](/en/api/strings/locales/update-a-locale#body-fallback-locale-id).\nRequires `include_empty_translations` to be set to `true`. Mutually exclusive with `fallback_locale_id`.\n",
+                    "description": "If a key has no translation in the locale being downloaded, the translation in the fallback locale will be used.\nFallback locale is defined in [locale's settings](/en/api/strings/locales/update-a-locale#body-fallback-locale-id).\nRequires `include_empty_translations` to be set to `true` unless `fallback_for_unverified_translations` is also set to `true`. Mutually exclusive with `fallback_locale_id`.\n",
                     "type": "boolean",
+                    "example": false
+                  },
+                  "fallback_for_unverified_translations": {
+                    "description": "If set to `true`, translations in a non-final state are replaced by the fallback locale's translation at export time.\nIn the simple workflow, \"non-final\" means `unverified`. In the review workflow, it additionally includes `translated` (awaiting review).\nNo stored translations are modified. Requires `fallback_locale_id` or `use_locale_fallback` to be set; a `422` validation error is returned otherwise.\n",
+                    "type": "boolean",
+                    "default": false,
                     "example": false
                   },
                   "source_locale_id": {

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -9382,8 +9382,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "boolean",
-              "default": false
+              "type": "boolean"
             },
             "example": null
           },
@@ -9616,7 +9615,6 @@
                   "fallback_for_unverified_translations": {
                     "description": "If set to `true`, translations in a non-final state are replaced by the fallback locale's translation at export time.\nIn the simple workflow, \"non-final\" means `unverified`. In the review workflow, it additionally includes `translated` (awaiting review).\nNo stored translations are modified. Requires `fallback_locale_id` or `use_locale_fallback` to be set; a `422` validation error is returned otherwise.\n",
                     "type": "boolean",
-                    "default": false,
                     "example": false
                   },
                   "source_locale_id": {

--- a/paths/locale_downloads/create.yaml
+++ b/paths/locale_downloads/create.yaml
@@ -97,7 +97,6 @@ requestBody:
               In the simple workflow, "non-final" means `unverified`. In the review workflow, it additionally includes `translated` (awaiting review).
               No stored translations are modified. Requires `fallback_locale_id` or `use_locale_fallback` to be set; a `422` validation error is returned otherwise.
             type: boolean
-            default: false
             example: false
           source_locale_id:
             description: Provides the source language of a corresponding job as the source language of the generated locale file. This parameter will be ignored unless used in combination with a `tag` parameter indicating a specific job.

--- a/paths/locale_downloads/create.yaml
+++ b/paths/locale_downloads/create.yaml
@@ -81,15 +81,23 @@ requestBody:
             description: |
               If a key has no translation in the locale being downloaded, the translation in the fallback locale will be used.
               Provide the ID of the locale that should be used as the fallback.
-              Requires `include_empty_translations` to be set to `true`. Mutually exclusive with `use_locale_fallback`.
+              Requires `include_empty_translations` to be set to `true` unless `fallback_for_unverified_translations` is also set to `true`. Mutually exclusive with `use_locale_fallback`.
             type: string
             example: abcd1234abcd1234abcd1234abcd1234
           use_locale_fallback:
             description: |
               If a key has no translation in the locale being downloaded, the translation in the fallback locale will be used.
               Fallback locale is defined in [locale's settings](/en/api/strings/locales/update-a-locale#body-fallback-locale-id).
-              Requires `include_empty_translations` to be set to `true`. Mutually exclusive with `fallback_locale_id`.
+              Requires `include_empty_translations` to be set to `true` unless `fallback_for_unverified_translations` is also set to `true`. Mutually exclusive with `fallback_locale_id`.
             type: boolean
+            example: false
+          fallback_for_unverified_translations:
+            description: |
+              If set to `true`, translations in a non-final state are replaced by the fallback locale's translation at export time.
+              In the simple workflow, "non-final" means `unverified`. In the review workflow, it additionally includes `translated` (awaiting review).
+              No stored translations are modified. Requires `fallback_locale_id` or `use_locale_fallback` to be set; a `422` validation error is returned otherwise.
+            type: boolean
+            default: false
             example: false
           source_locale_id:
             description: Provides the source language of a corresponding job as the source language of the generated locale file. This parameter will be ignored unless used in combination with a `tag` parameter indicating a specific job.

--- a/paths/locales/download.yaml
+++ b/paths/locales/download.yaml
@@ -127,7 +127,6 @@ parameters:
     required: false
     schema:
       type: boolean
-      default: false
     example:
   - description: Provides the source language of a corresponding job as the source language of the generated locale file. This parameter will be ignored unless used in combination with a `tag` parameter indicating a specific job.
     example:

--- a/paths/locales/download.yaml
+++ b/paths/locales/download.yaml
@@ -104,7 +104,7 @@ parameters:
     description: |
       If a key has no translation in the locale being downloaded, the translation in the fallback locale will be used.
       Provide the ID of the locale that should be used as the fallback.
-      Requires `include_empty_translations` to be set to `true`. Mutually exclusive with `use_locale_fallback`.
+      Requires `include_empty_translations` to be set to `true` unless `fallback_for_unverified_translations` is also set to `true`. Mutually exclusive with `use_locale_fallback`.
     in: query
     schema:
       type: string
@@ -113,11 +113,22 @@ parameters:
     description: |
       If a key has no translation in the locale being downloaded, the translation in the fallback locale will be used.
       Fallback locale is defined in [locale's settings](/en/api/strings/locales/update-a-locale#body-fallback-locale-id).
-      Requires `include_empty_translations` to be set to `true`. Mutually exclusive with `fallback_locale_id`.
+      Requires `include_empty_translations` to be set to `true` unless `fallback_for_unverified_translations` is also set to `true`. Mutually exclusive with `fallback_locale_id`.
     in: query
     schema:
       type: boolean
     example: true
+  - name: fallback_for_unverified_translations
+    description: |
+      If set to `true`, translations in a non-final state are replaced by the fallback locale's translation at export time.
+      In the simple workflow, "non-final" means `unverified`. In the review workflow, it additionally includes `translated` (awaiting review).
+      No stored translations are modified. Requires `fallback_locale_id` or `use_locale_fallback` to be set; a `422` validation error is returned otherwise.
+    in: query
+    required: false
+    schema:
+      type: boolean
+      default: false
+    example:
   - description: Provides the source language of a corresponding job as the source language of the generated locale file. This parameter will be ignored unless used in combination with a `tag` parameter indicating a specific job.
     example:
     name: source_locale_id


### PR DESCRIPTION
…ownload endpoints

Adds the new boolean parameter `fallback_for_unverified_translations` (default `false`) to:
- GET /api/v2/projects/{project_id}/locales/{id}/download
- POST /api/v2/projects/{project_id}/locales/{locale_id}/downloads

Also updates the `fallback_locale_id` and `use_locale_fallback` descriptions on both operations to reflect the relaxed constraint: `include_empty_translations=true` is no longer required when `fallback_for_unverified_translations=true` is set.

Corresponds to strings-app PR #17730 (SCD-950).