### PR TITLE
feat(API): improve DELETE /projects/{project_id}/screenshots/{id} documentation

### DIFF
--- a/paths/screenshots/destroy.yaml
+++ b/paths/screenshots/destroy.yaml
@@ -1,31 +1,52 @@
 ---
 summary: Delete a screenshot
-description: Delete an existing screenshot.
-operationId: screenshot/delete
+description: |
+  Permanently deletes a screenshot from the project. All translation key markers
+  attached to the screenshot are also removed as part of the deletion. Use this
+  operation when a screenshot is no longer needed or has been replaced by an
+  updated image.
+
+  Requires the `write` OAuth scope. The requesting user must have Manage
+  permission on the Screenshot resource in the project. This endpoint is only
+  available to accounts with the Attachable Screenshots feature enabled; requests
+  from accounts without this feature return 403.
+
+  The `id` path parameter is the screenshot's string code (e.g.
+  `d2e056aa9e70b01121f41693e344f5ee`), not a numeric identifier.
+
+  Deletion dispatches a `screenshots:delete` event that may trigger configured
+  webhook subscriptions.
+operationId: screenshots/destroy
 tags:
 - Screenshots
 parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/project_id"
 - "$ref": "../../parameters.yaml#/id"
-- description: specify the branch to use
-  example: my-feature-branch
-  name: branch
-  in: query
-  schema:
-    type: string
+- "$ref": "../../parameters.yaml#/branch"
 responses:
   '204':
-    "$ref": "../../responses.yaml#/204"
+    description: The screenshot was deleted successfully. No response body is returned.
+    headers:
+      X-Rate-Limit-Limit:
+        "$ref": "../../headers.yaml#/X-Rate-Limit-Limit"
+      X-Rate-Limit-Remaining:
+        "$ref": "../../headers.yaml#/X-Rate-Limit-Remaining"
+      X-Rate-Limit-Reset:
+        "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
   '400':
     "$ref": "../../responses.yaml#/400"
-  '404':
-    "$ref": "../../responses.yaml#/404"
   '401':
     "$ref": "../../responses.yaml#/401"
   '403':
     "$ref": "../../responses.yaml#/403"
-    description: Forbidden. Returned when the access token lacks the `write` scope, when the requesting user is not allowed to delete this screenshot, or when the account does not have the Attachable Screenshots feature.
+    description: >-
+      Forbidden. Returned when the access token lacks the `write` scope,
+      when the requesting user does not have Manage permission on the
+      Screenshot resource, or when the account does not have the
+      Attachable Screenshots feature enabled.
+  '404':
+    "$ref": "../../responses.yaml#/404"
   '422':
     "$ref": "../../responses.yaml#/422"
   '429':
@@ -33,16 +54,14 @@ responses:
 x-code-samples:
 - lang: Curl
   source: |-
-    curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:id" \
+    curl "https://api.phrase.com/v2/projects/your_project_id/screenshots/d2e056aa9e70b01121f41693e344f5ee?branch=my-feature-branch" \
       -u USERNAME_OR_ACCESS_TOKEN \
-      -X DELETE \
-      -d '{"branch":"my-feature-branch"}' \
-      -H 'Content-Type: application/json'
+      -X DELETE
 - lang: CLI v2
   source: |-
     phrase screenshots delete \
-    --project_id <project_id> \
-    --id <id> \
+    --project_id your_project_id \
+    --id d2e056aa9e70b01121f41693e344f5ee \
     --branch my-feature-branch \
     --access_token <token>
 x-cli-version: '2.5'

--- a/paths/screenshots/show.yaml
+++ b/paths/screenshots/show.yaml
@@ -1,19 +1,32 @@
 ---
 summary: Get a single screenshot
-description: Get details on a single screenshot for a given project.
-operationId: screenshot/show
+description: |
+  Returns the details of a single screenshot within a project. Screenshots are image
+  files uploaded to a project to provide visual context for translators; each screenshot
+  may be linked to one or more translation keys via markers.
+
+  Use this endpoint to retrieve a screenshot's metadata — including its name, description,
+  hosted image URL, and the count of translation-key markers attached to it — by its
+  unique identifier.
+
+  The `id` field in the response is the screenshot's string code, not a numeric primary
+  key. Pass this value to other screenshot endpoints.
+
+  **Access control:** The requesting token must carry the `read` OAuth scope, and the
+  authenticated user must have at least read permission on the project. Access is also
+  gated on the Attachable Screenshots feature being enabled for the account; a 403 is
+  returned when the feature is unavailable.
+
+  **Branches:** When working with branch-isolated projects, pass the `branch` parameter
+  to read from a specific branch's screenshot context. Omit it to read from the main branch.
+operationId: screenshots/show
 tags:
 - Screenshots
 parameters:
 - "$ref": "../../parameters.yaml#/X-PhraseApp-OTP"
 - "$ref": "../../parameters.yaml#/project_id"
 - "$ref": "../../parameters.yaml#/id"
-- description: specify the branch to use
-  example: my-feature-branch
-  name: branch
-  in: query
-  schema:
-    type: string
+- "$ref": "../../parameters.yaml#/branch"
 responses:
   '200':
     description: OK
@@ -21,6 +34,14 @@ responses:
       application/json:
         schema:
           "$ref": "../../schemas/screenshot.yaml#/screenshot"
+        example:
+          id: d2e056aa9e70b01121f41693e344f5ee
+          name: Onboarding step 1
+          description: First step of the user onboarding flow showing the project selection screen
+          screenshot_url: https://assets.phrase.com/screenshots/d2e056aa9e70b01121f41693e344f5ee.png
+          created_at: '2024-03-15T10:22:31Z'
+          updated_at: '2024-03-18T14:05:12Z'
+          markers_count: 3
     headers:
       X-Rate-Limit-Limit:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Limit"
@@ -30,25 +51,29 @@ responses:
         "$ref": "../../headers.yaml#/X-Rate-Limit-Reset"
   '400':
     "$ref": "../../responses.yaml#/400"
-  '404':
-    "$ref": "../../responses.yaml#/404"
   '401':
     "$ref": "../../responses.yaml#/401"
   '403':
     "$ref": "../../responses.yaml#/403"
-    description: Forbidden. Returned when the access token lacks the `read` scope, when the requesting user is not allowed to read this screenshot, or when the account does not have the Attachable Screenshots feature.
+    description: |
+      Forbidden. Returned when:
+      - The access token lacks the `read` OAuth scope.
+      - The authenticated user does not have read permission on this project or screenshot.
+      - The account does not have the Attachable Screenshots feature enabled on its plan.
+  '404':
+    "$ref": "../../responses.yaml#/404"
   '429':
     "$ref": "../../responses.yaml#/429"
 x-code-samples:
 - lang: Curl
   source: |-
-    curl "https://api.phrase.com/v2/projects/:project_id/screenshots/:id?branch=my-feature-branch" \
+    curl "https://api.phrase.com/v2/projects/3d7ce831a3e9e1b843dc16d36ee5b9f4/screenshots/d2e056aa9e70b01121f41693e344f5ee?branch=main" \
       -u USERNAME_OR_ACCESS_TOKEN
 - lang: CLI v2
   source: |-
     phrase screenshots show \
-    --project_id <project_id> \
-    --id <id> \
-    --branch my-feature-branch \
+    --project_id 3d7ce831a3e9e1b843dc16d36ee5b9f4 \
+    --id d2e056aa9e70b01121f41693e344f5ee \
+    --branch main \
     --access_token <token>
 x-cli-version: '2.5'

--- a/schemas/screenshot.yaml
+++ b/schemas/screenshot.yaml
@@ -5,25 +5,39 @@ screenshot:
   properties:
     id:
       type: string
+      description: The unique string code identifying this screenshot. Use this value when referencing the screenshot in other API calls.
+      example: d2e056aa9e70b01121f41693e344f5ee
     name:
       type: string
+      description: A human-readable name for the screenshot.
+      example: Onboarding step 1
     description:
       type: string
+      description: An optional longer description of what the screenshot shows, providing additional context for translators.
+      example: First step of the user onboarding flow showing the project selection screen
     screenshot_url:
       type: string
+      description: The full URL of the hosted screenshot image file.
+      example: https://assets.phrase.com/screenshots/d2e056aa9e70b01121f41693e344f5ee.png
     created_at:
       type: string
       format: date-time
+      description: The date and time when the screenshot was first uploaded, in ISO 8601 format.
+      example: '2024-03-15T10:22:31Z'
     updated_at:
       type: string
       format: date-time
+      description: The date and time when the screenshot was last modified, in ISO 8601 format.
+      example: '2024-03-18T14:05:12Z'
     markers_count:
       type: integer
+      description: The number of translation-key markers currently attached to this screenshot.
+      example: 3
   example:
     id: d2e056aa9e70b01121f41693e344f5ee
-    name: A screenshot name
-    description: A screenshot description
-    screenshot_url: http://assets.example.com/screenshot.png
-    created_at: '2015-01-28T09:52:53Z'
-    updated_at: '2015-01-28T09:52:53Z'
-    markers_count: 0
+    name: Onboarding step 1
+    description: First step of the user onboarding flow showing the project selection screen
+    screenshot_url: https://assets.phrase.com/screenshots/d2e056aa9e70b01121f41693e344f5ee.png
+    created_at: '2024-03-15T10:22:31Z'
+    updated_at: '2024-03-18T14:05:12Z'
+    markers_count: 3


### PR DESCRIPTION
Fixes rubric dimensions: conceptual_clarity, error_documentation, example_quality, frontmatter_metadata, reference_completeness, schema_completeness, self_contained_examples, stable_identifiers, vocabulary_consistency

Part of DEVEX-60

Source-grounded via Phrase-Engineering/strings-app.

## Changes

- operationId corrected from screenshot/delete to screenshots/destroy (resource/action convention)
- description expanded from a single vague sentence to a full description covering what the operation does, why you would use it, the string-code id shape, the cascade (markers removed), the feature gate (Attachable Screenshots), and the webhook side effect
- branch parameter replaced inline definition with shared param ref
- 204 response replaced bare ref with inline response including rate-limit headers
- 403 description reworded to accurately reflect Manage permission requirement
- curl example fixed branch from JSON body to query parameter; replaced placeholders with realistic example values; removed incorrect flags for a DELETE with no body
- CLI example replaced angle-bracket placeholders with realistic example values