### PR TITLE
docs(API): raise translation_keys_unmentioned threshold to 100k (SCD-971)

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -1841,7 +1841,7 @@
                 "type": "integer"
               },
               "translation_keys_unmentioned": {
-                "description": "The number of translation keys in the project that were not mentioned in the upload.\n\nNote: this field is not calculated (and shows 0) if the upload contains more than 10,000 keys.\n",
+                "description": "The number of translation keys in the project that were not mentioned in the upload.\n\nNote: this field is not calculated (and shows 0) if the upload contains more than 100,000 keys.\n",
                 "type": "integer"
               },
               "translations_created": {

--- a/schemas/upload.yaml
+++ b/schemas/upload.yaml
@@ -41,7 +41,7 @@ upload:
           description: |
             The number of translation keys in the project that were not mentioned in the upload.
 
-            Note: this field is not calculated (and shows 0) if the upload contains more than 10,000 keys.
+            Note: this field is not calculated (and shows 0) if the upload contains more than 100,000 keys.
           type: integer
         translations_created:
           type: integer


### PR DESCRIPTION
## Purpose

The upload safety limit `MAX_KEYS_IN_PROJECT_BEFORE_UNMENTIONED_ISNT_CALCULATED` was raised from `10_000` to `100_000` in strings-app ([Phrase-Engineering/strings-app#17853](https://github.com/Phrase-Engineering/strings-app/pull/17853)), re-enabling `delete_unmentioned_keys` for large projects.

This updates the public API docs to match: the `translation_keys_unmentioned` field on the `upload` schema previously stated the value is not calculated for uploads with more than 10,000 keys. That threshold is now 100,000 keys.

## Ticket

https://phrase.atlassian.net/browse/SCD-971

## Changes

- `schemas/upload.yaml` — updated the `translation_keys_unmentioned` description (10,000 → 100,000 keys)
- `doc/compiled.json` — regenerated via `make lint bundle`

This is a documentation-only change (field description), so no client library version bump is required. The per-client `clients/*/api/openapi.yaml` bundles are git-ignored generated artifacts and are regenerated by the push/generation workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)