### PR TITLE
docs(API): gate multi-project automation on advanced_job_automation plan feature #SCM-1408

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -31445,7 +31445,7 @@
                     ]
                   },
                   "project_ids": {
-                    "description": "List of project IDs to associate with the automation.\nCurrently, only the first ID in the array is used.\nThe array format leaves room for future support of multiple projects.\n",
+                    "description": "List of project IDs to associate with the automation.\nProviding more than one project ID requires the `advanced_job_automation`\nplan feature; accounts without this feature receive a 422 response with\nerror field `project_ids`.\n",
                     "type": "array",
                     "items": {
                       "type": "string"
@@ -31674,7 +31674,7 @@
                     ]
                   },
                   "project_ids": {
-                    "description": "List of project IDs to associate with the automation.\nCurrently, only the first ID in the array is used.\nThe array format leaves room for future support of multiple projects.\n",
+                    "description": "List of project IDs to associate with the automation.\nProviding more than one project ID requires the `advanced_job_automation`\nplan feature; accounts without this feature receive a 422 response with\nerror field `project_ids`.\n",
                     "type": "array",
                     "items": {
                       "type": "string"

--- a/paths/automations/create.yaml
+++ b/paths/automations/create.yaml
@@ -33,8 +33,9 @@ requestBody:
           project_ids:
             description: |
               List of project IDs to associate with the automation.
-              Currently, only the first ID in the array is used.
-              The array format leaves room for future support of multiple projects.
+              Providing more than one project ID requires the `advanced_job_automation`
+              plan feature; accounts without this feature receive a 422 response with
+              error field `project_ids`.
             type: array
             items:
               type: string

--- a/paths/automations/update.yaml
+++ b/paths/automations/update.yaml
@@ -34,8 +34,9 @@ requestBody:
           project_ids:
             description: |
               List of project IDs to associate with the automation.
-              Currently, only the first ID in the array is used.
-              The array format leaves room for future support of multiple projects.
+              Providing more than one project ID requires the `advanced_job_automation`
+              plan feature; accounts without this feature receive a 422 response with
+              error field `project_ids`.
             type: array
             items:
               type: string


### PR DESCRIPTION
## What changed

Update the `project_ids` field description in the automation **create** and **update** operations to reflect the current API contract:

- Multi-project support (more than one entry in `project_ids`) is now gated on the `advanced_job_automation` plan feature.
- Accounts without this feature receive a `422 Unprocessable Entity` response with error field `project_ids`.
- The previous description ("currently only the first ID in the array is used / leaves room for future support") was stale and no longer accurate.

## Affected operations

- `POST /api/v2/accounts/{account_id}/automations`
- `PATCH /api/v2/accounts/{account_id}/automations/{id}`

## Related

strings-app PR: https://github.com/Phrase-Engineering/strings-app/pull/17939 (SCM-1408)