### PR TITLE
feat(API): Add language_ai_profile to locales

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -1675,6 +1675,9 @@
           "fallback_locale": {
             "$ref": "#/components/schemas/locale_preview"
           },
+          "language_ai_profile": {
+            "type": "string"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time"
@@ -1682,9 +1685,6 @@
           "updated_at": {
             "type": "string",
             "format": "date-time"
-          },
-          "language_ai_profile": {
-            "type": "string"
           }
         },
         "example": {
@@ -1713,6 +1713,7 @@
             "name": "en",
             "code": "en-GB"
           },
+          "language_ai_profile": "abcd1234abcd1234abcd1234abcd1234",
           "created_at": "2015-01-28T09:52:53Z",
           "updated_at": "2015-01-28T09:52:53Z"
         }

--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -1682,6 +1682,9 @@
           "updated_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "language_ai_profile": {
+            "type": "string"
           }
         },
         "example": {
@@ -9168,6 +9171,11 @@
                     "description": "If set, translations for this locale will be fetched automatically, right after creation.",
                     "type": "boolean",
                     "example": null
+                  },
+                  "language_ai_profile": {
+                    "description": "Identifier of the Language AI profile to use for this locale.",
+                    "type": "string",
+                    "example": "abcd1234abcd1234abcd1234abcd1234"
                   }
                 }
               }
@@ -9388,6 +9396,11 @@
                     "description": "If set, translations for this locale will be fetched automatically, right after creation.",
                     "type": "boolean",
                     "example": null
+                  },
+                  "language_ai_profile": {
+                    "description": "Identifier of the Language AI profile to use for this locale.",
+                    "type": "string",
+                    "example": "abcd1234abcd1234abcd1234abcd1234"
                   }
                 }
               }

--- a/paths/locales/create.yaml
+++ b/paths/locales/create.yaml
@@ -103,4 +103,8 @@ requestBody:
             description: If set, translations for this locale will be fetched automatically, right after creation.
             type: boolean
             example:
+          language_ai_profile:
+            description: Identifier of the Language AI profile to use for this locale.
+            type: string
+            example: abcd1234abcd1234abcd1234abcd1234
 x-cli-version: '2.5'

--- a/paths/locales/update.yaml
+++ b/paths/locales/update.yaml
@@ -102,4 +102,8 @@ requestBody:
             description: If set, translations for this locale will be fetched automatically, right after creation.
             type: boolean
             example:
+          language_ai_profile:
+            description: Identifier of the Language AI profile to use for this locale.
+            type: string
+            example: abcd1234abcd1234abcd1234abcd1234
 x-cli-version: '2.5'

--- a/schemas/locale.yaml
+++ b/schemas/locale.yaml
@@ -33,6 +33,8 @@ locale:
     updated_at:
       type: string
       format: date-time
+    language_ai_profile:
+      type: string
   example:
     id: abcd1234cdef1234abcd1234cdef1234
     name: de

--- a/schemas/locale.yaml
+++ b/schemas/locale.yaml
@@ -27,14 +27,14 @@ locale:
       "$ref": "./locale_preview.yaml#/locale_preview"
     fallback_locale:
       "$ref": "./locale_preview.yaml#/locale_preview"
+    language_ai_profile:
+      type: string
     created_at:
       type: string
       format: date-time
     updated_at:
       type: string
       format: date-time
-    language_ai_profile:
-      type: string
   example:
     id: abcd1234cdef1234abcd1234cdef1234
     name: de
@@ -57,5 +57,6 @@ locale:
       id: abcd1234cdef1234abcd1234cdef1234
       name: en
       code: en-GB
+    language_ai_profile: abcd1234abcd1234abcd1234abcd1234
     created_at: '2015-01-28T09:52:53Z'
     updated_at: '2015-01-28T09:52:53Z'


### PR DESCRIPTION
Add language_ai_profile parameter to the locale create and update request bodies, and to the locale serializer schema.