### PR TITLE
fix(cli): detect file upload params by type, and run CLI build on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,12 @@ jobs:
           GOPRIVATE: github.com/phrase/phrase-go
         run: |
           npm install
+          npm run generate.go
           npm run generate.cli
+          # Verify the generated CLI compiles before publishing it. Build against
+          # the freshly generated go client so this does not depend on a released
+          # phrase-go version that may lag behind the spec.
+          (cd ./clients/cli && go mod edit -replace github.com/phrase/phrase-go/v4=../go && go build . && go mod edit -dropreplace github.com/phrase/phrase-go/v4)
           git clone https://$API_TOKEN_GITHUB@github.com/phrase/phrase-cli.git clones/cli &> /dev/null
           rsync -avI --delete --exclude='.git/' clients/cli/ clones/cli
           cd clones/cli

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -5,7 +5,9 @@ on:
   pull_request:
     paths:
       - 'paths/**'
+      - 'paths.yaml'
       - 'schemas/**'
+      - 'schemas.yaml'
       - 'parameters.yaml'
       - 'responses.yaml'
       - 'headers.yaml'

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -2,11 +2,18 @@
 # Once we add tests, we should add a step here to run them
 name: Run CLI Tests
 on:
-  push:
+  pull_request:
     paths:
-      - .github/workflows/test-cli.yml
+      - 'paths/**'
+      - 'schemas/**'
+      - 'parameters.yaml'
+      - 'responses.yaml'
+      - 'headers.yaml'
+      - 'main.yaml'
+      - 'openapi-generator/templates/cli/**'
       - openapi-generator/cli_lang.yaml
       - 'clients/cli/**'
+      - .github/workflows/test-cli.yml
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/openapi-generator/templates/cli/api.handlebars
+++ b/openapi-generator/templates/cli/api.handlebars
@@ -55,7 +55,7 @@ func init{{{nickname}}}() {
 				{{#required~}}
 					{{#isPrimitiveType~}}
 						{{#isFile~}}
-							{{paramName}}, err := os.Open(params.GetString(helpers.ToSnakeCase("{{paramName}}")))
+							{{paramName}}, err := os.Open(params.GetString(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}")))
 							if err != nil {
 							HandleError(err)
 							}
@@ -73,8 +73,8 @@ func init{{{nickname}}}() {
 					{{/isPrimitiveType~}}
 				{{else~}}
 					{{#isFile~}}
-						if params.IsSet(helpers.ToSnakeCase("{{paramName}}")) {
-							file, err := os.Open(params.GetString(helpers.ToSnakeCase("{{paramName}}")))
+						if params.IsSet(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}")) {
+							file, err := os.Open(params.GetString(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}")))
 							localVarOptionals.{{{vendorExtensions.x-export-param-name}}} = optional.NewInterface(file)
 							if err != nil {
 								HandleError(err)

--- a/openapi-generator/templates/cli/api.handlebars
+++ b/openapi-generator/templates/cli/api.handlebars
@@ -54,14 +54,14 @@ func init{{{nickname}}}() {
 			{{#allParams~}}
 				{{#required~}}
 					{{#isPrimitiveType~}}
-						{{#if (eq paramName "file")~}}
+						{{#isFile~}}
 							{{paramName}}, err := os.Open(params.GetString(helpers.ToSnakeCase("{{paramName}}")))
 							if err != nil {
 							HandleError(err)
 							}
 						{{else~}}
 							{{paramName}} := params.Get{{{capitalizeFirst dataType}}}(helpers.ToSnakeCase("{{{vendorExtensions.x-export-param-name}}}"))
-						{{/if}}
+						{{/isFile}}
 					{{else~}}
 						var {{paramName}} api.{{{dataType}}}
 						if err := json.Unmarshal([]byte(params.GetString("data")), &{{paramName}}); err != nil {
@@ -72,7 +72,7 @@ func init{{{nickname}}}() {
 						}
 					{{/isPrimitiveType~}}
 				{{else~}}
-					{{#if (or (eq paramName "file") (eq paramName "filename"))~}}
+					{{#isFile~}}
 						if params.IsSet(helpers.ToSnakeCase("{{paramName}}")) {
 							file, err := os.Open(params.GetString(helpers.ToSnakeCase("{{paramName}}")))
 							localVarOptionals.{{{vendorExtensions.x-export-param-name}}} = optional.NewInterface(file)
@@ -111,7 +111,7 @@ func init{{{nickname}}}() {
 								localVarOptionals.{{{vendorExtensions.x-export-param-name}}} = {{#if (eq dataType "[]string")}}{{paramName}}{{else}}optional.NewInterface({{paramName}}){{/if}}
 							}
 						{{/isModel}}{{/isPrimitiveType}}
-					{{/if}}
+					{{/isFile}}
 				{{/required~}}
 			{{/allParams~}}
 


### PR DESCRIPTION
## What

Two related fixes prompted by the `screenshot/create` endpoint breaking the CLI build (`go build` in `clients/cli` failed with `params.Get*os.File` and a `too many arguments` call).

### 1. Detect binary upload params by type, not by name

The CLI handlebars template detected file-upload params by matching the literal param name (`file`/`filename`). A **required** binary field with any other name fell through to the primitive handler and generated invalid Go:

```go
filename := params.Get * os.File(helpers.ToSnakeCase("Filename"))
```

`screenshot/create`'s binary field is named `filename` and is required, hitting exactly this case.

Both branches now use `{{#isFile}}` — the flag the generator derives from `format: binary`, and the same one the go/python/typescript/php templates in this repo already use. Future binary fields (`image`, `attachment`, …) work automatically.

### 2. Make CI actually compile the CLI on PRs

This break reached `main` because **no CI job compiled the CLI on the PR**:

- **`test-cli.yml`** is the only job that runs `go build` on the CLI, but its `paths:` filter excluded the spec (`paths/**`, `schemas/**`, shared `*.yaml`) and the CLI templates the CLI is generated from — so a spec-only change skipped it. Switched to `on: pull_request` and expanded the path filter. (`pull_request` also covers fork PRs and associates the run with the PR as a gate.)
- **`build.yml`**'s `build-cli` job published the generated CLI to `phrase-cli` **without ever compiling it**. Added a `go build` (against the freshly generated go client, so it doesn't depend on a possibly-lagging released `phrase-go`) before the publish step.

## Verification

- Regenerated the CLI: `screenshot/create` (required `filename`) and `upload/create` (required `file`) both emit correct `os.Open(...)`; no malformed output anywhere.
- Built `clients/cli` against the freshly generated `clients/go` — clean build.

## Note

The follow-on `too many arguments` error is a separate matter: the CLI's committed `go.mod` pins a released `phrase-go` that predates this endpoint. It resolves once a new `phrase-go` is released from the updated spec and the CLI bumps its dependency — unaffected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)