### PR TITLE
feat(API): Add translation_key_prefix and filter_by_prefix to async locale download

### DIFF
--- a/doc/compiled.json
+++ b/doc/compiled.json
@@ -9663,7 +9663,7 @@
             }
           },
           {
-            "description": "Only download translation keys containing the specified prefix, and remove the prefix from the generated file.",
+            "description": "Only download translation keys containing the prefix specified by `translation_key_prefix`, and remove that prefix from the generated file. Requires `translation_key_prefix` to be set.",
             "example": null,
             "name": "filter_by_prefix",
             "in": "query",
@@ -9884,6 +9884,15 @@
                     "description": "Custom metadata filters. Provide the name of the metadata field and the value to filter by. Only keys with matching metadata will be included in the download.\n",
                     "type": "object",
                     "properties": {}
+                  },
+                  "translation_key_prefix": {
+                    "description": "Download all translation keys, and remove the specified prefix where possible. Warning: this may create duplicate key names if other keys share the same name after the prefix is removed.",
+                    "example": "prefix_",
+                    "type": "string"
+                  },
+                  "filter_by_prefix": {
+                    "description": "Only download translation keys containing the prefix specified by `translation_key_prefix`, and remove that prefix from the generated file. Requires `translation_key_prefix` to be set.",
+                    "type": "boolean"
                   },
                   "updated_since": {
                     "description": "Only include translations and keys that have been updated since the given date. The date must be in ISO 8601 format (e.g., `2023-01-01T00:00:00Z`).\n",

--- a/paths/locale_downloads/create.yaml
+++ b/paths/locale_downloads/create.yaml
@@ -107,6 +107,13 @@ requestBody:
               Custom metadata filters. Provide the name of the metadata field and the value to filter by. Only keys with matching metadata will be included in the download.
             type: object
             properties: {}
+          translation_key_prefix:
+            description: 'Download all translation keys, and remove the specified prefix where possible. Warning: this may create duplicate key names if other keys share the same name after the prefix is removed.'
+            example: "prefix_"
+            type: string
+          filter_by_prefix:
+            description: Only download translation keys containing the prefix specified by `translation_key_prefix`, and remove that prefix from the generated file. Requires `translation_key_prefix` to be set.
+            type: boolean
           updated_since:
             description: |
               Only include translations and keys that have been updated since the given date. The date must be in ISO 8601 format (e.g., `2023-01-01T00:00:00Z`).

--- a/paths/locales/download.yaml
+++ b/paths/locales/download.yaml
@@ -140,7 +140,7 @@ parameters:
     in: query
     schema:
       type: string
-  - description: Only download translation keys containing the specified prefix, and remove the prefix from the generated file.
+  - description: Only download translation keys containing the prefix specified by `translation_key_prefix`, and remove that prefix from the generated file. Requires `translation_key_prefix` to be set.
     example:
     name: filter_by_prefix
     in: query


### PR DESCRIPTION
## Changes

- Add `translation_key_prefix` and `filter_by_prefix` params to `locale_downloads/create` for parity with the sync locale download endpoint
- Clarify `filter_by_prefix` description on both endpoints: it requires `translation_key_prefix` to be set