### PR TITLE
fix(ruby): pin link-header-parser to >=7.0 and fix its new keyword arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ clients/ruby/git_push.sh
 clients/ruby/openapitools.json
 clients/ruby/*.gemspec
 clients/ruby/spec/*.rb
+!clients/ruby/spec/response_spec.rb
 clients/ruby/spec/api/*
 clients/ruby/spec/models/
 clients/ruby/docs

--- a/clients/ruby/lib/phrase/response.rb
+++ b/clients/ruby/lib/phrase/response.rb
@@ -10,8 +10,8 @@ module Phrase
       link_headers = headers["link"]
       if link_headers
         @paginated = true
-        parsed_links = LinkHeaderParser.parse(link_headers, base_uri: 'https://api.phrase.com').group_by_relation_type.transform_keys(&:to_sym)
-        next_page_link = parsed_links[:next]&.first
+        parsed_links = LinkHeaderParser.parse(link_headers, base_uri: 'https://api.phrase.com').group_by_relation_type
+        next_page_link = parsed_links["next"]&.first
         if next_page_link
           @next_page = CGI.parse(URI.parse(next_page_link.target_uri).query)["page"]&.first&.to_i
         end

--- a/clients/ruby/lib/phrase/response.rb
+++ b/clients/ruby/lib/phrase/response.rb
@@ -10,7 +10,7 @@ module Phrase
       link_headers = headers["link"]
       if link_headers
         @paginated = true
-        parsed_links = LinkHeaderParser.parse(link_headers, base: 'https://api.phrase.com').group_by_relation_type
+        parsed_links = LinkHeaderParser.parse(link_headers, base_uri: 'https://api.phrase.com').group_by_relation_type.transform_keys(&:to_sym)
         next_page_link = parsed_links[:next]&.first
         if next_page_link
           @next_page = CGI.parse(URI.parse(next_page_link.target_uri).query)["page"]&.first&.to_i

--- a/clients/ruby/spec/response_spec.rb
+++ b/clients/ruby/spec/response_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe Phrase::Response do
+  context 'without a link header' do
+    it 'is not paginated' do
+      response = Phrase::Response.new({ 'foo' => 'bar' }, {})
+
+      expect(response.paginated?).to eq(false)
+      expect(response.next_page?).to eq(false)
+      expect(response.next_page).to be_nil
+    end
+  end
+
+  context 'with a link header that has a next page' do
+    let(:headers) do
+      {
+        'link' => '<https://api.phrase.com/v2/projects/project_id/keys?page=2>; rel="next", ' \
+                  '<https://api.phrase.com/v2/projects/project_id/keys?page=5>; rel="last"'
+      }
+    end
+
+    it 'parses the next page number without raising' do
+      response = Phrase::Response.new({ 'foo' => 'bar' }, headers)
+
+      expect(response.paginated?).to eq(true)
+      expect(response.next_page?).to eq(true)
+      expect(response.next_page).to eq(2)
+    end
+  end
+
+  context 'with a link header that has no next page' do
+    let(:headers) do
+      {
+        'link' => '<https://api.phrase.com/v2/projects/project_id/keys?page=1>; rel="first", ' \
+                  '<https://api.phrase.com/v2/projects/project_id/keys?page=1>; rel="last"'
+      }
+    end
+
+    it 'is paginated but has no next page' do
+      response = Phrase::Response.new({ 'foo' => 'bar' }, headers)
+
+      expect(response.paginated?).to eq(true)
+      expect(response.next_page?).to eq(false)
+      expect(response.next_page).to be_nil
+    end
+  end
+
+  it 'delegates missing methods to the underlying data' do
+    response = Phrase::Response.new({ 'foo' => 'bar' }, {})
+
+    expect(response['foo']).to eq('bar')
+  end
+end

--- a/openapi-generator/templates/ruby-client/gemspec.mustache
+++ b/openapi-generator/templates/ruby-client/gemspec.mustache
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'typhoeus', '>= 1.0.1'
   {{/isFaraday}}
   s.add_runtime_dependency 'json', '>= 2.1.0'
-  s.add_runtime_dependency 'link-header-parser'
+  s.add_runtime_dependency 'link-header-parser', '>= 7.0'
 
   s.add_development_dependency 'rspec', '>= 3.6.0'
 


### PR DESCRIPTION
## Summary
- `link-header-parser` 7.0 renamed the `base:` keyword argument to `base_uri:` and changed `group_by_relation_type` to return string keys instead of symbols. Since the ruby client's gemspec had no version constraint, anyone installing/updating today gets 7.0.1, and any paginated API response crashes with `ArgumentError: missing keyword: :base_uri` in `Phrase::Response#initialize`.
- Updates `clients/ruby/lib/phrase/response.rb` to call `LinkHeaderParser.parse` with `base_uri:` and normalize `group_by_relation_type`'s keys back to symbols.
- Constrains the `link-header-parser` runtime dependency to `>= 7.0` in `openapi-generator/templates/ruby-client/gemspec.mustache` (the template that generates `clients/ruby/phrase.gemspec`).
- Adds `clients/ruby/spec/response_spec.rb`, a regression spec covering `Phrase::Response` with and without pagination `Link` headers — there was previously no test coverage for this file at all, which is why the existing suite passed despite the crash. Added a `.gitignore` exception for it, following the same pattern used for the existing hand-maintained `locales_api_spec.rb`/`uploads_api_spec.rb`.

Fixes phrase/phrase-ruby#11

## Test plan
- [x] `bundle exec rspec spec/response_spec.rb` — new spec passes with the fix, and reproduces the reported `ArgumentError` when the fix is reverted
- [x] `bundle exec rspec` — full suite (1845 examples) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)